### PR TITLE
[Button] [Link] Do not blur document.body

### DIFF
--- a/components/Button/Button.js
+++ b/components/Button/Button.js
@@ -169,7 +169,7 @@ class Button extends React.Component {
 
     return (
       <span className={styles.wrap} style={wrapStyle}>
-        <button {...rootProps}>
+        <button {...rootProps} ref={ref => this.buttonRef = ref}>
           {loading}
           <div className={styles.caption}>
             {icon}
@@ -181,8 +181,9 @@ class Button extends React.Component {
     );
   }
 
-  _handleMouseDown(e) {
-    if (browser.hasFocusOnButtonClick && document.activeElement) {
+  _handleMouseDown = e => {
+    if (browser.hasFocusOnButtonClick &&
+      document.activeElement === this.buttonRef) {
       document.activeElement.blur();
       e.preventDefault();
     }

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -75,7 +75,7 @@ class Link extends React.Component {
     }
 
     return (
-      <a {...rest} {...props}>
+      <a {...rest} {...props} ref={ref => this.linkRef = ref}>
         {icon}
         {this.props.children}
         {arrow}
@@ -83,8 +83,9 @@ class Link extends React.Component {
     );
   }
 
-  _handleMouseDown(e) {
-    if (browser.hasFocusOnLinkClick && document.activeElement) {
+  _handleMouseDown = e => {
+    if (browser.hasFocusOnLinkClick &&
+      document.activeElement === this.linkRef) {
       document.activeElement.blur();
       e.preventDefault();
     }


### PR DESCRIPTION
Иногда в document.activeElement оказывается не сама кнопка, а какой-нибудь другой элемент, например document.body. А в IE<=10 document.body.blur() убирает окно браузера за предыдущее открытое окно.
Поэтому получалось, что иногда браузер "сворачивается" при клике на ссылку или кнопку.