### PR TITLE
Правки для календаря

### DIFF
--- a/components/DatePicker/DateInput.js
+++ b/components/DatePicker/DateInput.js
@@ -27,7 +27,8 @@ type Props = {
   value: string,
   placeholder?: string,
   size: 'small' | 'medium' | 'large',
-  getRef?: (ref: any) => void,
+  getIconRef?: (ref: any) => void,
+  getInputRef?: (ref: any) => void,
   onFocus?: () => void,
   onBlur?: () => void,
   onIconClick: Function,
@@ -37,7 +38,8 @@ type Props = {
 
 export default class DateInput extends Component {
   static propTypes = {
-    getRef: PropTypes.func,
+    getIconRef: PropTypes.func,
+    getInputRef: PropTypes.func,
     opened: PropTypes.bool.isRequired,
     placeholder: PropTypes.string,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
@@ -78,7 +80,11 @@ export default class DateInput extends Component {
           ref={this.getInputRef}
           rightIcon={
             (
-              <span className={openClassName} onClick={this.props.onIconClick}>
+              <span
+                className={openClassName}
+                onClick={this.props.onIconClick}
+                ref={this.getIconRef}
+              >
                 <Icon name="calendar" size={iconSize} />
               </span>
             )
@@ -89,8 +95,11 @@ export default class DateInput extends Component {
   }
 
   componentDidMount() {
-    if (this.props.getRef && this._input) {
-      this.props.getRef(this._input);
+    if (this.props.getInputRef && this._input) {
+      this.props.getInputRef(this._input);
+    }
+    if (this.props.getIconRef && this._icon) {
+      this.props.getIconRef(this._icon);
     }
   }
 
@@ -228,6 +237,10 @@ export default class DateInput extends Component {
 
   getInputRef = (ref: any) => {
     this._input = ref;
+  };
+
+  getIconRef = (ref: any) => {
+    this._icon = ref;
   };
 }
 

--- a/components/DatePicker/DateInput.less
+++ b/components/DatePicker/DateInput.less
@@ -4,12 +4,10 @@
   .openButton {
     color: #333;
     cursor: pointer;
-    line-height: 32px;
-    position: absolute;
-    right: 1px;
-    top: 1px;
     z-index: 2;
     font-size: 14px;
+    padding: 4px 6px 7px 6px;
+    margin-right: -10px;
   }
 
   .openButtonDisabled {

--- a/components/DatePicker/DatePicker.js
+++ b/components/DatePicker/DatePicker.js
@@ -43,8 +43,6 @@ type Props = {
   placeholder?: string,
   size?: 'small' | 'medium' | 'large',
   value?: ?Date,
-  validationMsg?: string,
-  validationType?: 'text' | 'baloon',
   width?: number | string,
   onBlur?: () => void,
   onChange?: (e: {target: {value: ?Date}}, v: ?Date) => void,
@@ -56,6 +54,7 @@ type Props = {
   onMouseEnter?: (e: SyntheticMouseEvent) => void,
   onMouseLeave?: (e: SyntheticMouseEvent) => void,
   onMouseOver?: (e: SyntheticMouseEvent) => void,
+  onUnexpectedInput?: (value: string) => string | null,
 };
 
 type State = {
@@ -79,11 +78,7 @@ export default class DatePicker extends React.Component {
      */
     minYear: PropTypes.number,
 
-    validationMsg: PropTypes.string,
-
-    validationType: PropTypes.oneOf(['text', 'balloon']),
-
-    value: PropTypes.instanceOf(Date),
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
 
     warning: PropTypes.bool,
 
@@ -112,28 +107,33 @@ export default class DatePicker extends React.Component {
 
     onMouseLeave: PropTypes.func,
 
-    onMouseOver: PropTypes.func
+    onMouseOver: PropTypes.func,
+
+    /**
+     * Если не получилось распарсить дату,
+     * можно получить содержимое инпута
+     * (например, для валидации снаружи)
+     */
+    onUnexpectedInput: PropTypes.func
   };
 
   static defaultProps = {
     minYear: 1900,
     maxYear: 2100,
     width: 120,
-    withMask: false
+    withMask: false,
+    onUnexpectedInput: () => null
   };
 
   props: Props;
   state: State;
 
-  _focused = false;
-  _cursorPosition = 0;
   input: Input;
 
   constructor(props: Props, context: mixed) {
     super(props, context);
 
     this.state = {
-      textValue: formatDate(props.value),
       opened: false
     };
   }
@@ -149,13 +149,14 @@ export default class DatePicker extends React.Component {
           getParent={() => findDOMNode(this)}
           offsetY={1}
         >
-           <Picker
-             value={value}
-             minYear={this.props.minYear}
-             maxYear={this.props.maxYear}
-             onPick={this.handlePick}
-             onClose={this.handlePickerClose}
-           />
+          <Picker
+            value={value}
+            minYear={this.props.minYear}
+            maxYear={this.props.maxYear}
+            onPick={this.handlePick}
+            onClose={this.handlePickerClose}
+            iconRef={this.icon}
+          />
         </DropdownContainer>
       );
     }
@@ -168,35 +169,37 @@ export default class DatePicker extends React.Component {
       <span className={className} style={{ width: this.props.width }}>
         <DateInput
           {...filterProps(this.props, INPUT_PASS_PROPS)}
-          getRef={this.getInputRef}
+          getIconRef={this.getIconRef}
+          getInputRef={this.getInputRef}
           opened={opened}
-          value={this.state.textValue}
+          value={this.getValue()}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
           onChange={this.handleChange}
-          onIconClick={this.open}
+          onIconClick={this.toggleCalendar}
         />
         {picker}
       </span>
     );
   }
 
-  componentWillReceiveProps(newProps: Props) {
-    const newTextValue = formatDate(newProps.value);
-    if (
-      !this._focused &&
-      !newProps.error &&
-      this.state.textValue !== newTextValue
-    ) {
-      this.setState({ textValue: newTextValue });
+  getValue = () => {
+    const value = this.props.value
+    if (value instanceof Date) {
+      return formatDate(value);
     }
-  }
+    if (typeof value === 'string') {
+      return value;
+    }
+    return '';
+  };
 
-  handleChange = (newDate: Date | string) => {
-    if (newDate === undefined) { return; }
-    this.setState({
-      textValue: newDate instanceof Date ? formatDate(newDate) : newDate
-    });
+  handleChange = (value: Date | string) => {
+    if (value === undefined) { return; }
+    const { onChange, onUnexpectedInput } = this.props;
+    if (!onChange) { return; }
+    const newDate = getDateValue(value, onUnexpectedInput);
+    onChange({ target: { value: newDate } }, newDate);
   };
 
   handleFocus = () => {
@@ -206,24 +209,16 @@ export default class DatePicker extends React.Component {
   };
 
   handleBlur = () => {
-    this._focused = false;
-    this._cursorPosition = 0;
+    const value = this.props.value;
+    const date = parseDate(value);
 
-    const { textValue } =  this.state;
-    const date = parseDate(textValue);
-
-    if (this.props.onChange && textValue !== formatDate(this.props.value)) {
-      this.props.onChange({ target: { value: date } }, date);
+    if (this.props.onChange) {
+      const newDate = date === null ? getDateValue(value, this.props.onUnexpectedInput) : date;
+      this.props.onChange({ target: { value: newDate } }, newDate);
     }
 
     if (this.props.onBlur) {
       this.props.onBlur();
-    }
-  };
-
-  handlePickerKey = (event: SyntheticKeyboardEvent) => {
-    if (event.key === 'Escape') {
-      this.close(true);
     }
   };
 
@@ -238,28 +233,49 @@ export default class DatePicker extends React.Component {
     this.close(false);
   };
 
-  open = () => {
-    if (!this.props.disabled) {
+  toggleCalendar = e => {
+    if (this.props.disabled) {
+      return;
+    }
+    if (this.state.opened) {
+      e.preventDefault()
+      this.close(false);
+    } else {
       this.setState({ opened: true });
     }
   };
 
   close(focus: bool) {
-    this.setState({ opened: false });
-    if (focus) {
-      setTimeout(() => this.input.focus(), 0);
-    }
-  }
-
-  focus() {
-    this._focused = true;
-    this.input.focus();
+    this.setState({ opened: false }, () => {
+      if (focus) {
+        this.input.focus();
+      }
+    });
   }
 
   getInputRef = (ref: Input) => {
     this.input = ref;
   };
+
+  getIconRef = (ref: Span) => {
+    this.icon = ref;
+  };
 }
+
+const getDateValue = (value, onUnexpectedInput) => {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const newDate = parseDate(value, false);
+    if (newDate) {
+      return newDate;
+    } else {
+      return onUnexpectedInput(value);
+    }
+  }
+  return null;
+};
 
 function checkDate(date) {
   if (date instanceof Date && !isNaN(date.getTime())) {
@@ -278,8 +294,8 @@ function formatDate(date) {
   return `${day}.${month}.${date.getUTCFullYear()}`;
 }
 
-function parseDate(str) {
-  const date = dateParser(str);
+function parseDate(str, withCorrection) {
+  const date = dateParser(str, withCorrection);
   if (!date) {
     return null;
   }

--- a/components/DatePicker/Picker.js
+++ b/components/DatePicker/Picker.js
@@ -102,6 +102,10 @@ export default class Picker extends React.Component {
     }
     const target: Element = (event.target: any) || event.srcElement;
     if (!ReactDOM.findDOMNode(this).contains(target) && !isDetached(target)) {
+      const icon = this.props.iconRef;
+      if (icon && ReactDOM.findDOMNode(icon).contains(target)) {
+        return;
+      }
       this.props.onClose();
     }
   };

--- a/components/DatePicker/dateParser.js
+++ b/components/DatePicker/dateParser.js
@@ -1,5 +1,7 @@
 // @flow
-export default function(str: string): ?Date {
+export default function(str: string, withCorrection: bool = true): ?Date {
+  if (str === null) return str;
+  if (str instanceof Date) return str;
   const datePartsRegExp = /^(\d{1,2})\.?(\d{1,2})?\.?(\d{1,4})?$/;
   const parts = str.replace(/_/g, '').match(datePartsRegExp);
 
@@ -10,19 +12,21 @@ export default function(str: string): ?Date {
     month = parseInt(month, 10) - 1;
     date = parseInt(date, 10);
 
-    const now = new Date();
-    if (isNaN(month)) {
-      month = now.getUTCMonth();
-    }
-    if (isNaN(year)) {
-      year = now.getUTCFullYear();
-    }
+    if (withCorrection) {
+      const now = new Date();
+      if (isNaN(month)) {
+        month = now.getUTCMonth();
+      }
+      if (isNaN(year)) {
+        year = now.getUTCFullYear();
+      }
 
-    // Handle short year version
-    if (year < 50) { // 20xx
-      year += 2000;
-    } else if (year < 100) { // 19xx
-      year += 1900;
+      // Handle short year version
+      if (year < 50) { // 20xx
+        year += 2000;
+      } else if (year < 100) { // 19xx
+        year += 1900;
+      }
     }
 
     // IE8 does't support `Date('yyyy-mm-dd')` constructor.

--- a/docs/src/snippets/DatePicker-snip.js
+++ b/docs/src/snippets/DatePicker-snip.js
@@ -11,6 +11,7 @@ class Comp extends React.Component {
       <DatePicker
         value={this.state.date}
         onChange={(_, date) => this.setState({ date })}
+        onUnexpectedInput={x => x.length ? x : null}
       />
     );
   }


### PR DESCRIPTION
Стилевые: 
- увеличила область кликабельности кнопки открытия календаря
- поправила позиционирование календаря относительно инпута

Логика:
- Компонент может получать на вход не только дату, но и строку
- Возвращает по-прежнему дату или null, но есть возможность получить строку, если не удалось распарсить дату
- Больше не хранит значение инпута в state, зависит только от пропсов

+ поправила сниппет с учетом новых возможностей