### PR TITLE
Add focusin event listener only after document load

### DIFF
--- a/lib/listenFocusOutside.js
+++ b/lib/listenFocusOutside.js
@@ -5,7 +5,15 @@ import ReactDOM from 'react-dom';
 
 const handlers = [];
 
-events.addEventListener(document.body, 'focusin', handleNativeFocus);
+function addHandleEvent() {
+  events.addEventListener(document.body, 'focusin', handleNativeFocus);
+}
+
+if (document.readyState === 'complete') {
+  addHandleEvent();
+} else {
+  events.addEventListener(window, 'load', addHandleEvent);
+}
 
 function handleNativeFocus(event: UIEvent) {
   const target: HTMLElement = (event.target || event.srcElement: any);


### PR DESCRIPTION
Во время выполнения скрипта document.body еще может не быть, что обрушит бандл.