### PR TITLE
[Modal] Fallback for close cross's color

### DIFF
--- a/components/Modal/Modal.less
+++ b/components/Modal/Modal.less
@@ -40,6 +40,7 @@
   }
 
   .close {
+    color: #757575;
     color: rgba(0, 0, 0, 0.54);
     float: right;
     font-family: arial;


### PR DESCRIPTION
IE8 не умеет в rgba, поэтому цвет крестика был синий.