### PR TITLE
Ошибка в ReactTesting

### DIFF
--- a/testing/ReactTesting.js
+++ b/testing/ReactTesting.js
@@ -25,7 +25,7 @@ function ref(tid, existingRef) {
         node.setAttribute('react-testing-id', id);
       }
       map[id] = { el, node, tid };
-    } else {
+    } else if (map[id]) {
       const node = map[id].node;
       if (node) {
         node.removeAttribute('tid');


### PR DESCRIPTION
Когда map[id] undefined, и мы пытаемся получить map[id].node, начинают происходить страшные вещи