### PR TITLE
[Textarea] [IE8] Fix разноцветного border при фокусе

### DIFF
--- a/components/Textarea/Textarea.less
+++ b/components/Textarea/Textarea.less
@@ -36,6 +36,11 @@
     .textarea:focus {
       outline: 1px solid @border-color-focus;
     }
+    
+    .error,
+    .error:focus {
+      outline: 1px solid @border-color-error;
+    }
   }
 
   .textarea[disabled] {


### PR DESCRIPTION
пример бага:
![d28ff7f1-4265-4212-9932-95ac823933a7 01 01 11 - internet explorer-84g0u](https://cloud.githubusercontent.com/assets/2862206/25217863/fa96c718-25c1-11e7-8650-6939d0d4aefa.png)
