### PR TITLE
[Checkbox] Fix color in ie8

### DIFF
--- a/components/Checkbox/Checkbox.less
+++ b/components/Checkbox/Checkbox.less
@@ -33,6 +33,7 @@
     width: 0;
     height: 0;
     position: absolute;
+    z-index: -1;
   }
 
   .box {
@@ -64,7 +65,12 @@
   :global(.rt-ie8) {
     .box {
       background-color: #fdfdfd;
-      border: 1px solid #ededed;
+      border: 1px solid #b9b9b9;
+    }
+
+    .root:hover .box {
+      background-color: #f1f1f1;
+      border: 1px solid #aeaeae;
     }
 
     .focus .box {
@@ -83,6 +89,10 @@
   :global(.rt-ie9) {
     .box {
       background-color: #fdfdfd;
+    }
+
+    .root:hover .box {
+      background-color: #f1f1f1;
     }
   }
 


### PR DESCRIPTION
В ие8 чекбокс очень плохо видно, поменял цвет границы и фона. (Возможно стоит взять другие, брал пипеткой из гайдов)
Для hover ie8-9 заменил градиент на обычный цвет.
В ie8 при клике появлялась область фокусировки.

![checkboxie8](https://cloud.githubusercontent.com/assets/14935625/25610407/81eb8752-2f3c-11e7-939d-88a77797955b.png)
