### PR TITLE
fixed markup in Checkbox

### DIFF
--- a/components/Checkbox/Checkbox.js
+++ b/components/Checkbox/Checkbox.js
@@ -91,11 +91,13 @@ class Checkbox extends React.Component {
         onMouseOver={this.props.onMouseOver}
       >
         <input {...inputProps} />
-        <span className={styles.box}>
-          {this.props.checked &&
-            <div className={styles.ok}>
-              <Icon name="ok" />
-            </div>}
+        <span className={styles.boxWrapper}>
+          <span className={styles.box}>
+            {this.props.checked &&
+              <div className={styles.ok}>
+                <Icon name="ok" />
+              </div>}
+          </span>
         </span>
         <span className={styles.caption}>{this.props.children}</span>
       </label>

--- a/components/Checkbox/Checkbox.less
+++ b/components/Checkbox/Checkbox.less
@@ -20,6 +20,15 @@
         0 0 0 1px rgba(0, 0, 0, 0.2),
         inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);
     }
+
+    &:before, &:after {
+      content: '';
+      display: table;
+    }
+
+    &:after {
+      clear: both;
+    }
   }
 
   .disabled {
@@ -33,6 +42,10 @@
     width: 0;
     height: 0;
     position: absolute;
+  }
+
+  .boxWrapper {
+    float: left;
   }
 
   .box {


### PR DESCRIPTION
Изменила немного разметку и стили у Checkbox.
Сейчас, если у описания Checkbox много текста, текст попадает под чекбокс, что не очень красиво. 

<img width="740" alt="2017-05-09 16 52 33" src="https://cloud.githubusercontent.com/assets/11808557/25845457/26957704-34d8-11e7-87a3-ef3e152e8832.png">
В контур.гайдах тоже описание не попадает под сам чекбокс
https://guides.kontur.ru/controls/checkbox/