### PR TITLE
[Spinner] React 15.x начал корректно работать с svg аттрибутами 

### DIFF
--- a/components/Spinner/Spinner.js
+++ b/components/Spinner/Spinner.js
@@ -90,8 +90,6 @@ class Spinner extends React.Component {
           cx="8"
           cy="8"
           r="6"
-          strokeMiterlimit="10"
-          strokeDashoffset="0"
           className={styles.path}
           strokeWidth={params.strokeWidth}
         />


### PR DESCRIPTION
и перезаписывает их инлайном и тем самым ломает контрол. все вполне замечательно работает через класс. strokeWidth на всякий случай оставил - вдруг будет кружок побольше.

Откуда тут эти аттрибуты, если честн обыло лень раскапывать :)