### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "peerDependencies": {
     "@types/react": "^0.14.9 || ^15.0.25",
     "react": "^0.14.9 || ^15.5.0",
-    "react-addons-css-transition-group": "^0.14.9 || ^15.5.0",
+    "react-addons-css-transition-group": "^0.14.8 || ^15.5.0",
     "react-dom": "^0.14.9 || ^15.5.0"
   },
   "jest": {


### PR DESCRIPTION
У  react-addons-css-transition-group нет версии 0.14.9.
Вот вывод `npm show react-addons-css-transition-group versions`
```
[ '0.14.0-beta1',
  '0.14.0-beta2',
  '0.14.0-beta3',
  '0.14.0-rc1',
  '0.14.0',
  '0.14.1',
  '0.14.2',
  '0.14.3',
  '0.14.4',
  '0.14.5',
  '0.14.6',
  '0.14.7',
  '0.14.8',
  '0.15.0-alpha.1',
  '15.0.0-rc.1',
  '15.0.0-rc.2',
  '15.0.0',...
```