### PR TITLE
Убрал использование 'composes' в стилях

### DIFF
--- a/components/Loader/Loader.less
+++ b/components/Loader/Loader.less
@@ -32,7 +32,7 @@
   }
 
   .spinnerContainerCenter {
-    composes: spinnerContainer;
+    .spinnerContainer;
     .fillContainerPosition;
 
     &:before {

--- a/components/Spinner/Spinner.less
+++ b/components/Spinner/Spinner.less
@@ -17,12 +17,14 @@
   }
 
   .captionRight {
-    composes: caption;
+    .caption;
+
     margin-left: 5px;
   }
 
   .captionBottom {
-    composes: caption;
+    .caption;
+
     display: block;
   }
 


### PR DESCRIPTION
Для ускорения билда я использую css-loader@0.14.5, в котором composes не работает. Разбираться не стал, ибо в библиотеке чаще используют less миксины, а composes всего в двух местах. Предлагаю заменить composes на использование миксина.