### PR TITLE
fix ie8 hover on checked button

### DIFF
--- a/components/Button/Button.less
+++ b/components/Button/Button.less
@@ -463,6 +463,10 @@
         2px -2px 0 0 @border-color-warning;
     }
 
+    &:hover {
+      background: #737373;
+    }
+
     &.focus {
       box-shadow:
         inset 0 0 0 1px #fff,

--- a/components/Button/Button.less
+++ b/components/Button/Button.less
@@ -440,14 +440,14 @@
   // End Use
 
   .root.checked {
-    background: #737373;
+    background: @btn-checked-bg;
     box-shadow:
       0 0 0 1px rgba(0, 0, 0, 0.6),
       inset 0 1px 2px 0 rgba(0, 0, 0, 0.3);
     color: #fff;
 
     .arrow {
-      background: #737373;
+      background: @btn-checked-bg;
       box-shadow: @btn-shadow-checked-arrow;
     }
 
@@ -464,7 +464,7 @@
     }
 
     &:hover {
-      background: #737373;
+      background: @btn-checked-bg;
     }
 
     &.focus {

--- a/components/variables.less
+++ b/components/variables.less
@@ -34,6 +34,9 @@
 
 // Button
 
+//checked button
+@btn-checked-bg: #737373;
+
 // use default
 @btn-default-bg: #f9f9f9;
 @btn-default-bg-start: #fff;


### PR DESCRIPTION
У кнопки в состоянии checked в IE8 срабатывает ховер и убирает выделение.
https://monosnap.com/file/hIKHPPJJKz9vF9oYkS5KKYb8cwnMZa
https://monosnap.com/file/ZIlN6FLuSxYJK2Ra0I6ikfLEPnangx
Пофиксил, добавив кнопке в состоянии checked свой ховер.
