### PR TITLE
[Select] новый пропс "areValuesEqual" с shallow-сравнением значений по умолчанию

### DIFF
--- a/components/Select/Select.js
+++ b/components/Select/Select.js
@@ -63,7 +63,7 @@ type Props = {
   placeholder?: React$Element<*> | string,
   renderItem: (value: mixed, item: mixed) => React$Element<*> | string,
   renderValue: (value: mixed, item: mixed) => React$Element<*> | string,
-  compareValues: (value1: mixed, value2: mixed) => boolean,
+  areValuesEqual: (value1: mixed, value2: mixed) => boolean,
   search?: boolean,
   value?: mixed,
   width?: number | string
@@ -131,10 +131,11 @@ class Select extends React.Component {
     renderValue: PropTypes.func,
 
     /**
-     * Функция для сравнения двух values друг между другом.
+     * Функция для сравнения двух значений
      * Нужна в случае, если они не являются простыми типами
+     * По умолчанию проверяет с помощью shallowEqual
      */
-    compareValues: PropTypes.func,
+    areValuesEqual: PropTypes.func,
 
     /**
      * Показывать строку поиска в списке.
@@ -158,7 +159,7 @@ class Select extends React.Component {
     placeholder: 'ничего не выбрано',
     renderValue,
     renderItem,
-    compareValues,
+    areValuesEqual,
     filterItem
   };
 
@@ -190,7 +191,7 @@ class Select extends React.Component {
     if (value != null) {
       label = this.props.renderValue(
         value,
-        getItemByValue(this.props.items, value, this.props.compareValues)
+        this._getItemByValue(this.props.items, value)
       );
     } else {
       label = (
@@ -334,7 +335,7 @@ class Select extends React.Component {
               return (
                 <MenuItem
                   key={i}
-                  state={this.props.compareValues(iValue, value) ? 'selected' : null}
+                  state={this.props.areValuesEqual(iValue, value) ? 'selected' : null}
                   onClick={this._select.bind(this, iValue)}
                   comment={comment}
                 >
@@ -510,6 +511,19 @@ class Select extends React.Component {
 
     return ret;
   }
+
+  _getItemByValue(items, value) {
+    if (!items) {
+      return null;
+    }
+    for (let entry of items) {
+      entry = normalizeEntry(entry);
+      if (this.props.areValuesEqual(entry[0], value)) {
+        return entry[1];
+      }
+    }
+    return null;
+  }
 }
 
 function renderValue(value, item) {
@@ -519,21 +533,9 @@ function renderValue(value, item) {
 function renderItem(value, item) {
   return item;
 }
-function compareValues(value1, value2) {
-  return shallow(value1, value2);
-}
 
-function getItemByValue(items, value, compareValuesFn) {
-  if (!items) {
-    return null;
-  }
-  for (let entry of items) {
-    entry = normalizeEntry(entry);
-    if (compareValuesFn(entry[0], value)) {
-      return entry[1];
-    }
-  }
-  return null;
+function areValuesEqual(value1, value2) {
+  return shallow(value1, value2);
 }
 
 function normalizeEntry(entry) {

--- a/components/Select/__tests__/Select-test.js
+++ b/components/Select/__tests__/Select-test.js
@@ -19,7 +19,7 @@ describe('Select', () => {
        items={objectItems}
        renderItem={x => x.name}
        renderValue={x => x.name}
-       compareValues={(x1, x2) => x1.id === x2.id}
+       areValuesEqual={(x1, x2) => x1.id === x2.id}
     />);
 
     wrapper.setState({ opened: true });
@@ -36,22 +36,3 @@ describe('Select', () => {
     expect(selectedMenuItem.text()).toBe(defaultValueText);
   });
 });
-
-
-
-  // testAdapter('getValue with complex syntax', mount => {
-  //   const objectItems = [
-  //     { value: 1, label: 'One' },
-  //     { value: 2, label: 'Two' },
-  //     { value: 3, label: 'Three' }
-  //   ];
-
-  //   const adapter = mount(<Select
-  //     value={{value: 2, label: 'Two'}}
-  //     items={objectItems}
-  //     renderItem={x => x.label}
-  //     renderValue={x => x.label}
-  //     compareValues={(x1, x2) => x1.value === x2.value}
-  //   />);
-  //   expect(adapter.getValue()).toEqual(objectItems[1]);
-  // });

--- a/components/Select/__tests__/Select-test.js
+++ b/components/Select/__tests__/Select-test.js
@@ -1,0 +1,57 @@
+// @flow
+
+import { mount } from 'enzyme';
+import React from 'react';
+
+import Select from '../Select';
+
+describe('Select', () => {
+  it('puts default value to menu', () => {
+    const currentValue = { id: 1, name: 'John', group: { id: 1, name: "Red group" } };
+    const objectItems = [
+       { id: 1, name: 'John', group: { id: 1, name: "Red group" } },
+       { id: 2, name: 'Bill', group: { id: 2, name: "Blue group" } },
+       { id: 3, name: 'Sam', group: { id: 1, name: "Red group" } }
+    ];
+
+    const wrapper = mount(<Select
+       value={currentValue}
+       items={objectItems}
+       renderItem={x => x.name}
+       renderValue={x => x.name}
+       compareValues={(x1, x2) => x1.id === x2.id}
+    />);
+
+    wrapper.setState({ opened: true });
+
+    const dropdownContainer = wrapper.find("DropdownContainer");
+
+    const defaultValueText = wrapper.prop("renderItem")(currentValue, currentValue);
+
+    const menu = mount(dropdownContainer.get(0).props.children).find('Menu');
+    var selectedMenuItem = menu.findWhere(
+      node => node.is("MenuItem") && node.prop("state") === "selected"
+    );
+    expect(selectedMenuItem.length).toBe(1);
+    expect(selectedMenuItem.text()).toBe(defaultValueText);
+  });
+});
+
+
+
+  // testAdapter('getValue with complex syntax', mount => {
+  //   const objectItems = [
+  //     { value: 1, label: 'One' },
+  //     { value: 2, label: 'Two' },
+  //     { value: 3, label: 'Three' }
+  //   ];
+
+  //   const adapter = mount(<Select
+  //     value={{value: 2, label: 'Two'}}
+  //     items={objectItems}
+  //     renderItem={x => x.label}
+  //     renderValue={x => x.label}
+  //     compareValues={(x1, x2) => x1.value === x2.value}
+  //   />);
+  //   expect(adapter.getValue()).toEqual(objectItems[1]);
+  // });

--- a/components/Select/__tests__/Select.stories.js
+++ b/components/Select/__tests__/Select.stories.js
@@ -3,6 +3,24 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Select from '../Select';
 
+class SelectWrapper extends React.Component {
+  state = {
+    value: {label: 'One', value: 1}
+  }
+  render() {
+    return (
+      <div>
+        <Select
+          items={[ {label: 'One', value: 1}, {label: 'Two', value: 2}, {label: 'Three', value: 3} ]}
+          value={this.state.value}
+          onChange={(_, value) => this.setState({ value })}
+          renderItem={x => x.label}
+          renderValue={x => x.label}
+        />
+      </div>);
+  }
+}
+
 storiesOf('Select', module)
   .addDecorator(story =>
     <div
@@ -12,4 +30,5 @@ storiesOf('Select', module)
       {story()}
     </div>
   )
-  .add('Simple', () => <Select items={['one', 'two', 'three']} />);
+  .add('Simple', () => <Select items={['one', 'two', 'three']} />)
+  .add('Complex values', () => <SelectWrapper/> );


### PR DESCRIPTION
Фикс issue #263. Shallow-сравнение значений фиксит этот баг в 90% случаев, а для остальных 10%, когда "неглубокого" сравнения недостаточно, введен новый пропс "compareValues".