### PR TITLE
добавлена возможноть увеличивать специфичность селекторов контролов

### DIFF
--- a/components/MenuItem/MenuItem.less
+++ b/components/MenuItem/MenuItem.less
@@ -1,59 +1,63 @@
 @import '../variables.less';
 
-:local {
-  .root {
-    position: relative;
-    color: inherit;
-    cursor: pointer;
-    display: block;
-    line-height: 18px;
-    outline: none;
-    padding: 6px 18px 7px 8px;
-    text-decoration: none;
-    white-space: nowrap;
-  }
+.rules() {
+  :local {
+    .root {
+      position: relative;
+      color: inherit;
+      cursor: pointer;
+      display: block;
+      line-height: 18px;
+      outline: none;
+      padding: 6px 18px 7px 8px;
+      text-decoration: none;
+      white-space: nowrap;
+    }
 
-  .hover {
-    background: @dropdown-menu-hover-bg;
-    color: @text-color-invert !important; // To override `a:hover`.
-  }
+    .hover {
+      background: @dropdown-menu-hover-bg;
+      color: @text-color-invert !important; // To override `a:hover`.
+    }
 
-  .loose {
-    padding-left: 15px;
-  }
+    .loose {
+      padding-left: 15px;
+    }
 
-  .selected {
-    background: @dropdown-menu-selected-bg;
-  }
+    .selected {
+      background: @dropdown-menu-selected-bg;
+    }
 
-  .disabled {
-    background: transparent;
-    color: @text-color-disabled;
-    cursor: default;
-  }
+    .disabled {
+      background: transparent;
+      color: @text-color-disabled;
+      cursor: default;
+    }
 
-  .link {
-    color: @link-color;
-  }
+    .link {
+      color: @link-color;
+    }
 
-  .withIcon {
-    padding-left: @menu-item-padding-for-icon;
-  }
+    .withIcon {
+      padding-left: @menu-item-padding-for-icon;
+    }
 
-  .comment {
-    color: #a0a0a0;
-    white-space: normal;
-  }
+    .comment {
+      color: #a0a0a0;
+      white-space: normal;
+    }
 
-  .commentHover {
-    color: #fff;
-    opacity: .6;
-  }
+    .commentHover {
+      color: #fff;
+      opacity: .6;
+    }
 
-  .icon {
-    display: inline-block;
-    position: absolute;
-    left: 15px;
-    top: 5px;
+    .icon {
+      display: inline-block;
+      position: absolute;
+      left: 15px;
+      top: 5px;
+    }
   }
 }
+
+.with-specificity({.rules();});

--- a/components/RenderContainer/RenderContainer.js
+++ b/components/RenderContainer/RenderContainer.js
@@ -23,6 +23,7 @@ export default class RenderContainer extends React.Component {
       'data-rendered-container-id',
       this._testID.toString()
     );
+    this._domContainer.className = 'react-ui';
 
     if (global.ReactTesting) {
       global.ReactTesting.addRenderContainer(this._testID, this);

--- a/components/variables.less
+++ b/components/variables.less
@@ -152,4 +152,20 @@
   drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 @popup-box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 3px 10px 0 rgba(0, 0, 0, 0.2);
 
+// specificity
+@specificity-level: 0;
+
+.add-specificity (@rules, @times) when (@times > 0) {
+  &.react-ui {
+    .add-specificity(@rules, @times - 1);
+  }
+}
+.add-specificity (@rules, @times) when (default()) {
+  @rules();
+}
+
+.with-specificity(@rules) {
+  .add-specificity(@rules, @specificity-level);
+}
+
 @import (optional) '~react-ui-theme';


### PR DESCRIPTION
специфичность увеличивается за счет добавления к селекторам класса `react-ui` с несколькими повторениями - повторения и увеличивают специфичность
количество повторений класса `retail-ui` в селекторе задается переопределением переменной `@specificity-level` с умолчательного значения `0` на любое другое разумное неотрицательно число

класс `react-ui` всегда добавляется к контейнеру `Portal` - так как пользователь библиотеки не может оказывать на него никакого влияния
к остальным контейнерам, в которых рендерятся контролы retail-ui необходимо явно добавить класс `react-ui`.

если все будет ок, то аналогичный миксин нужно будет добавить во все остальные less файлы