### PR TITLE
fix clipping a dropdown label in ie8

### DIFF
--- a/components/Select/Select.less
+++ b/components/Select/Select.less
@@ -11,6 +11,7 @@
     display: inline-block;
     padding: 0 34px 0 9px;
     max-width: 100%;
+    width: 100%;
 
     &.labelWithLeftIcon {
       padding-left: 0;
@@ -36,7 +37,7 @@
     right: 13px;
     top: 0;
 
-    &::before {
+    &:before {
       content: '';
       display: inline-block;
       height: 100%;


### PR DESCRIPTION
В ие8 некорректно обрезается label дропдауна, из-за того, что не указана ширина явно. 