### PR TITLE
Явная привязка контекста для getComputedStyle

### DIFF
--- a/lib/dom/getComputedStyle.js
+++ b/lib/dom/getComputedStyle.js
@@ -3,7 +3,7 @@
 
 export default (function() {
   if (document.defaultView && document.defaultView.getComputedStyle) {
-    return document.defaultView.getComputedStyle;
+    return document.defaultView.getComputedStyle.bind(document.defaultView);
   }
 
   function getComputedStylePixel(element, property, fontSize) {


### PR DESCRIPTION
Из-за особенности бандлера, нативная функция getComputedStyle, которая является частью экспортируемого по дефолту модуля, может вызываться в контексте кастомного объекта, что может приводить вот к такой ошибке:

![image](https://user-images.githubusercontent.com/20541685/31231955-d29afc4c-aa01-11e7-80f1-5bfb1dc61447.png)

Добавили явную привязку контекста.