### PR TITLE
Fixed gap between textarea and her wrapper

### DIFF
--- a/components/Textarea/Textarea.less
+++ b/components/Textarea/Textarea.less
@@ -17,6 +17,7 @@
     line-height: 16px;
     outline: none;
     padding: 8px;
+    vertical-align: middle;
     width: 100%;
     -webkit-appearance: none;
     transition: all 0.2s ease-out;


### PR DESCRIPTION
**Повторный пулл реквест из-за реорганизации форка. [Первый](https://github.com/skbkontur/retail-ui/pull/305)**

Если верить интернету, это пробел под `inline` и `inline-block` элементами - это задел для букв с нижними выносными элементами (descender), например _у_ или _р_. Он влияет на вертикальный ритм и отлично заметен, когда среди нескольких `<Input />` вставлена `<Textarea />`.

В разных браузерах он разный:

- 2 пикселя в Фаерфоксе на Виндоуз 10
- 4 пикселя в Фаерфоксе на Линуксе
- 5 пикселей в Хроме и ему подобных браузерах на Виндоуз 10
- в IE9 на удивление десцендера нет :-)

[Живое демо](https://sashasushko.github.io/retail-ui-form/), измерьте в инспекторе высоту обёртки и самой текстарии.

Убирается этот отступ указанием `vertical-align` для строчного или блочно-строчного элемента.