### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ module: {
         {
           loader: 'babel-loader',
           options: {
-            presets: ['env', 'stage-0', 'react']
+            presets: [
+              'env',
+              'babel-plugin-transform-object-rest-spread',
+              'babel-plugin-transform-class-properties',
+              'react'
+            ]
           }
         }
       ],

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ const MyApp = () => (
 то необходимо подключить `regenerator-runtime` или `babel-polyfill`,
 например в `index.html`
 
+Квик-старт подойдёт, если вебпак настроен на сборку. Например, вы используете `create-react-app`. В противном случае добавьте в конфиг Вебпака `style-`, `css-` и `file-loader`.
 
 ### Слоу-старт
 Необходимо в [конфиг webpack](https://webpack.js.org/configuration/) добавить следующие лоадеры:

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ module: {
           options: {
             presets: [
               'env',
-              'babel-plugin-transform-object-rest-spread',
-              'babel-plugin-transform-class-properties',
               'react'
+            ],
+            plugins: [
+              'transform-object-rest-spread',
+              'transform-class-properties'
             ]
           }
         }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const MyApp = () => (
 
 
 ### Слоу-старт
-Необходимо в [конфиг webpack](http://webpack.github.io/docs/configuration.html#module-loaders) добавить следующие лоадеры:
+Необходимо в [конфиг webpack](https://webpack.js.org/configuration/) добавить следующие лоадеры:
 ```javascript
 /* ... */
 module: {
@@ -36,18 +36,25 @@ module: {
   loaders: [
     {
       test: /\.jsx?$/,
-      loader: 'babel-loader',
-      query: {
-        presets: ['es2015', 'stage-0', 'react']
-      },
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            presets: ['env', 'stage-0', 'react']
+          }
+        }
+      ],
       include: /retail-ui/
     },
     {
       test: /\.less$/,
-      loaders: ['style', 'css', 'less'],
+      use: ['style-loader', 'css-loader', 'less-loader'],
       include: /retail-ui/
     },
-    {test: /\.(png|woff|woff2|eot)$/, loader: "file-loader"}
+    {
+      test: /\.(png|woff|woff2|eot)$/,
+      use: ['file-loader']
+    }
   ]
   /* ... */
 }


### PR DESCRIPTION
1. Добавил ремарку про Слоу-старт.
В `@skbkontur/react-ui` стили предсобраны. Если её просто заменить прежнюю `retail-ui` и использовать старый конфиг для сборки, то `less-loader` всё сломает. Если в логах проглядеть, что сломал он всё в ЦСС-файле, то можно пойти по ложному пути и наткнуться на ишью о похожей проблеме совместимости `css-loader` и `file-loader`. Сценарий кажется невероятным, но полдня он у меня отнял.

2. Поправил ссылку на новую документацию Вебпака, старая умерла. И привёл пример в соответствии с этой новой документацией.