### PR TITLE
z-index synchronization

### DIFF
--- a/components/Center/Center.js
+++ b/components/Center/Center.js
@@ -31,14 +31,14 @@ export default class Center extends React.Component<Props> {
   };
 
   render() {
-    const { align, style, ...rest } = this.props;
+    const { align, style, children, ...rest } = this.props;
 
     const styleJoined = Object.assign({ textAlign: align }, style);
 
     return (
       <div className={styles.root} {...rest} style={styleJoined}>
         <span className={styles.spring} />
-        <span className={styles.container}>{this.props.children}</span>
+        <span className={styles.container}>{children}</span>
       </div>
     );
   }

--- a/components/DropdownContainer/DropdownContainer.js
+++ b/components/DropdownContainer/DropdownContainer.js
@@ -1,12 +1,13 @@
 // @flow
+/* eslint-disable flowtype/no-weak-types */
 
 import * as React from 'react';
-
-import PropTypes from 'prop-types';
+import { findDOMNode } from 'react-dom';
 
 import LayoutEvents from '../../lib/LayoutEvents';
 import getComputedStyle from '../../lib/dom/getComputedStyle';
 import RenderContainer from '../RenderContainer/RenderContainer';
+import ZIndex from '../ZIndex';
 
 type Props = {
   align: 'left' | 'right',
@@ -28,10 +29,6 @@ type State = {
 };
 
 export default class DropdownContainer extends React.Component<Props, State> {
-  static contextTypes = {
-    rt_inModal: PropTypes.bool
-  };
-
   static defaultProps = {
     align: 'left',
     disablePortal: false,
@@ -44,7 +41,7 @@ export default class DropdownContainer extends React.Component<Props, State> {
     hasStaticRoot: true
   };
 
-  _dom;
+  _dom: ?HTMLElement;
   _layoutSub;
 
   render() {
@@ -52,8 +49,7 @@ export default class DropdownContainer extends React.Component<Props, State> {
       position: 'absolute',
       top: '0',
       left: null,
-      right: null,
-      zIndex: this.context.rt_inModal ? 1100 : 900
+      right: null
     };
     if (this.state.position) {
       style = {
@@ -73,9 +69,9 @@ export default class DropdownContainer extends React.Component<Props, State> {
     }
 
     const content = (
-      <div ref={this._ref} style={style}>
+      <ZIndex delta={1000} ref={this._ref} style={style}>
         {this.props.children}
-      </div>
+      </ZIndex>
     );
 
     return this.props.disablePortal ? (
@@ -85,8 +81,8 @@ export default class DropdownContainer extends React.Component<Props, State> {
     );
   }
 
-  _ref = (dom: ?HTMLElement) => {
-    this._dom = dom;
+  _ref = e => {
+    this._dom = e && (findDOMNode(e): any);
   };
 
   componentDidMount() {
@@ -101,7 +97,7 @@ export default class DropdownContainer extends React.Component<Props, State> {
     let bodyPosition = getComputedStyle(document.body).position;
 
     if (htmlPosition !== 'static' || bodyPosition !== 'static') {
-      this.setState({hasStaticRoot: false})
+      this.setState({ hasStaticRoot: false });
     }
   }
 
@@ -146,7 +142,6 @@ export default class DropdownContainer extends React.Component<Props, State> {
       const dropdownHeight = this._getHeight();
 
       if (distanceToBottom < dropdownHeight && distanceToTop > dropdownHeight) {
-
         top = null;
 
         if (this.state.hasStaticRoot) {
@@ -157,7 +152,6 @@ export default class DropdownContainer extends React.Component<Props, State> {
             targetRect.bottom -
             targetRect.top;
         } else {
-
           let bodyScrollHeight = 0;
           if (document.body) {
             bodyScrollHeight = document.body.scrollHeight;

--- a/components/Hint/Hint.d.ts
+++ b/components/Hint/Hint.d.ts
@@ -8,7 +8,7 @@ export interface HintProps {
   onMouseLeave?: React.MouseEventHandler<HTMLSpanElement>;
   opened?: boolean;
   pos?: 'top' | 'right' | 'bottom' | 'left';
-  text: string;
+  text: React.ReactNode;
 }
 
 export interface HintState {}

--- a/components/Hint/Hint.js
+++ b/components/Hint/Hint.js
@@ -12,7 +12,7 @@ type Props = {
   onMouseLeave: (e: SyntheticMouseEvent<>) => void,
   opened: boolean,
   pos: 'top' | 'right' | 'bottom' | 'left',
-  text: string
+  text: React.Node
 };
 
 type State = {
@@ -73,13 +73,14 @@ export default class Hint extends React.Component<Props, State> {
         style={{ display: 'inline-block' }}
       >
         {this.props.children}
-        {this.isOpened() &&
+        {this.isOpened() && (
           <HintBox
             getTarget={this._getDOM}
             text={this.props.text}
             pos={this.props.pos}
             maxWidth={this.props.maxWidth}
-          />}
+          />
+        )}
       </span>
     );
   }

--- a/components/Hint/HintBox.js
+++ b/components/Hint/HintBox.js
@@ -1,20 +1,22 @@
 // @flow
+/* eslint-disable flowtype/no-weak-types */
 
 import * as React from 'react';
-
+import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 
 import RenderContainer from '../RenderContainer/RenderContainer';
 import position from '../Tooltip/position';
 import type { Result } from '../Tooltip/position';
 import renderPin from '../Tooltip/renderPin';
+import ZIndex from '../ZIndex';
 
 import styles from './HintBox.less';
 
 type Props = {
   getTarget: () => ?HTMLElement,
   pos: 'top' | 'right' | 'bottom' | 'left',
-  text: string,
+  text: React.Node,
   maxWidth: string | number
 };
 
@@ -24,8 +26,7 @@ type State = {
 
 export default class HintBox extends React.Component<Props, State> {
   static contextTypes = {
-    insideFixedContainer: PropTypes.bool,
-    rt_inModal: PropTypes.bool
+    insideFixedContainer: PropTypes.bool
   };
 
   state: State = {
@@ -37,7 +38,6 @@ export default class HintBox extends React.Component<Props, State> {
 
   render() {
     let style = {
-      zIndex: this.context.rt_inModal ? 1100 : 900,
       maxWidth: this.props.maxWidth
     };
     let className = styles.root;
@@ -52,10 +52,15 @@ export default class HintBox extends React.Component<Props, State> {
 
     return (
       <RenderContainer>
-        <div ref={this._ref} style={style} className={className}>
+        <ZIndex
+          delta={1000}
+          ref={this._ref}
+          style={style}
+          className={className}
+        >
           {this.props.text}
           {renderPin(this.state.pos, styles.pin, styles.pinInner)}
-        </div>
+        </ZIndex>
       </RenderContainer>
     );
   }
@@ -68,8 +73,8 @@ export default class HintBox extends React.Component<Props, State> {
     this._position();
   }
 
-  _ref = (el: ?HTMLElement) => {
-    this._dom = el;
+  _ref = e => {
+    this._dom = e && (findDOMNode(e): any);
   };
 
   _position() {

--- a/components/Loader/Loader.less
+++ b/components/Loader/Loader.less
@@ -1,4 +1,4 @@
-@import '../variables.less';
+@import "../variables.less";
 
 :local {
   .fillContainerPosition() {
@@ -18,10 +18,10 @@
 
     &.active:after {
       background: @loader-bg;
-      content: ' ';
-      filter: ~`'alpha(opacity = (' + @{loader-opacity} * 100 + '))'`;
+      content: " ";
+      filter: ~`"alpha(opacity = (" + @{loader-opacity} * 100 + "))"`;
       opacity: @loader-opacity;
-      z-index: 1000;
+      z-index: 25;
       .fillContainerPosition;
     }
   }
@@ -30,7 +30,7 @@
     display: block;
     margin: auto;
     text-align: center;
-    z-index: 1001;
+    z-index: 26;
   }
 
   .spinnerContainerCenter {
@@ -38,7 +38,7 @@
     .fillContainerPosition;
 
     &:before {
-      content: ' ';
+      content: " ";
       display: inline-block;
       height: 100%;
       min-height: 100%;

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -13,6 +13,7 @@ import getComputedStyle from '../../lib/dom/getComputedStyle';
 import LayoutEvents from '../../lib/LayoutEvents';
 import removeClass from '../../lib/dom/removeClass';
 import RenderContainer from '../RenderContainer';
+import ZIndex from '../ZIndex';
 import stopPropagation from '../../lib/events/stopPropagation';
 import Sticky from '../Sticky';
 
@@ -78,10 +79,6 @@ class Modal extends React.Component<Props, State> {
     onClose: PropTypes.func
   };
 
-  static childContextTypes = {
-    rt_inModal: PropTypes.bool
-  };
-
   static Header: Class<Header>;
   static Body: Class<Body>;
   static Footer: Class<Footer>;
@@ -102,10 +99,6 @@ class Modal extends React.Component<Props, State> {
       'change',
       this._handleStackChange
     );
-  }
-
-  getChildContext() {
-    return { rt_inModal: true };
   }
 
   render() {
@@ -140,8 +133,8 @@ class Modal extends React.Component<Props, State> {
       style.width = this.props.width;
     }
     return (
-      <RenderContainer containerClassName="rt_modal">
-        <div className={styles.root}>
+      <RenderContainer>
+        <ZIndex delta={1000} className={styles.root}>
           {!this.state.shadowed && <div className={styles.bg} />}
           <div
             ref={this._refCenter}
@@ -155,7 +148,7 @@ class Modal extends React.Component<Props, State> {
               </div>
             </div>
           </div>
-        </div>
+        </ZIndex>
       </RenderContainer>
     );
   }

--- a/components/Modal/Modal.less
+++ b/components/Modal/Modal.less
@@ -1,4 +1,4 @@
-@import '../variables.less';
+@import "../variables.less";
 
 :local {
   .bodyClass {
@@ -11,13 +11,12 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: 1000;
   }
 
   .bg {
     background: #333;
     bottom: 0;
-    -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=60)';
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=60)";
     left: 0;
     opacity: 0.6;
     position: absolute;
@@ -37,7 +36,7 @@
   }
 
   .container:before {
-    content: '';
+    content: "";
     display: inline-block;
     vertical-align: middle;
     height: 80%; // to vertical align modal 40%/60% of screen height
@@ -103,7 +102,7 @@
 
   .fixedHeader:after,
   .fixedFooter:before {
-    content: '';
+    content: "";
     position: absolute;
     height: 1px;
     width: 100%;

--- a/components/Popup/Popup.js
+++ b/components/Popup/Popup.js
@@ -1,10 +1,12 @@
 // @flow
+/* eslint-disable flowtype/no-weak-types */
 import cn from 'classnames';
 import * as React from 'react';
-import { render } from 'react-dom';
+import { render, findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import RenderContainer from '../RenderContainer';
 import RenderLayer from '../RenderLayer';
+import ZIndex from '../ZIndex';
 import Transition from 'react-addons-css-transition-group';
 import shallowEqual from 'fbjs/lib/shallowEqual';
 
@@ -171,8 +173,9 @@ export default class Popup extends React.Component<Props, State> {
           : 'transparent';
 
     return (
-      <div
-        ref={e => (this._popupElement = e)}
+      <ZIndex
+        delta={1000}
+        ref={e => (this._popupElement = e && (findDOMNode(e): any))}
         className={cn(styles.popup, hasShadow && styles.shadow)}
         style={style}
       >
@@ -188,7 +191,7 @@ export default class Popup extends React.Component<Props, State> {
             borderColor={pinBorder}
           />
         )}
-      </div>
+      </ZIndex>
     );
   }
 

--- a/components/Popup/Popup.less
+++ b/components/Popup/Popup.less
@@ -1,4 +1,4 @@
-@import '../variables.less';
+@import "../variables.less";
 
 @show-transtion: transform 0.18s cubic-bezier(0.22, 0.61, 0.36, 1),
   opacity 0.18s cubic-bezier(0.22, 0.61, 0.36, 1);
@@ -11,7 +11,6 @@
     max-width: 500px;
     background: @bg-default;
     border-radius: @popup-border-radius;
-    z-index: 900;
   }
 
   :global(.rt-ie-any) {

--- a/components/Toast/Toast.less
+++ b/components/Toast/Toast.less
@@ -9,7 +9,6 @@
     right: 0;
     height: 0;
     text-align: center;
-    z-index: 1200;
   }
 
   .root {

--- a/components/Toast/ToastView.js
+++ b/components/Toast/ToastView.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import CROSS from '../internal/cross';
+import ZIndex from '../ZIndex/ZIndex';
 
 import styles from './Toast.less';
 
@@ -33,26 +34,26 @@ class ToastView extends Component<Props> {
   render() {
     const { children, action, onClose, ...rest } = this.props;
 
-    const link = action
-      ? <span className={styles.link} onClick={action.handler}>
-          {action.label}
-        </span>
-      : null;
+    const link = action ? (
+      <span className={styles.link} onClick={action.handler}>
+        {action.label}
+      </span>
+    ) : null;
 
-    const close = action
-      ? <span className={styles.close} onClick={onClose}>
-          {CROSS}
-        </span>
-      : null;
+    const close = action ? (
+      <span className={styles.close} onClick={onClose}>
+        {CROSS}
+      </span>
+    ) : null;
 
     return (
-      <div className={styles.wrapper}>
+      <ZIndex delta={1000} className={styles.wrapper}>
         <div className={styles.root} {...rest}>
           {children}
           {link}
           {close}
         </div>
-      </div>
+      </ZIndex>
     );
   }
 }

--- a/components/Tooltip/Box.js
+++ b/components/Tooltip/Box.js
@@ -8,14 +8,14 @@ import throttle from 'lodash.throttle';
 
 import position from './position';
 import renderPin from './renderPin';
+import ZIndex from '../ZIndex';
 
 import '../ensureOldIEClassName';
 import styles from './Box.less';
 
 class Box extends React.Component {
   static contextTypes = {
-    insideFixedContainer: PropTypes.bool,
-    rt_inModal: PropTypes.bool
+    insideFixedContainer: PropTypes.bool
   };
 
   state = {
@@ -26,12 +26,11 @@ class Box extends React.Component {
 
   render() {
     const style = {
-      ...(this.state.pos ? this.state.pos.boxStyle : { left: 0, top: 0 }),
-      zIndex: this.context.rt_inModal ? 1100 : 900
+      ...(this.state.pos ? this.state.pos.boxStyle : { left: 0, top: 0 })
     };
 
     return (
-      <div className={styles.root} style={style}>
+      <ZIndex delta={1000} className={styles.root} style={style}>
         {renderPin(this.state.pos, styles.pin, styles.pinInner)}
         <div className={styles.inner}>
           {this.props.close && (
@@ -41,7 +40,7 @@ class Box extends React.Component {
           )}
           {this.props.children}
         </div>
-      </div>
+      </ZIndex>
     );
   }
 

--- a/components/ZIndex/ZIndex.d.ts
+++ b/components/ZIndex/ZIndex.d.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface ZIndexProps {
+  delta: number;
+  render?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+export default class ZIndex extends React.Component<ZIndexProps> {}

--- a/components/ZIndex/ZIndex.js
+++ b/components/ZIndex/ZIndex.js
@@ -1,0 +1,74 @@
+// @flow
+/* eslint-disable flowtype/no-weak-types */
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+type Props = {
+  delta: number,
+  render?: boolean,
+  children?: React.Node,
+  className?: string,
+  // eslint-disable-next-line flowtype/no-weak-types
+  style?: Object,
+  // eslint-disable-next-line flowtype/no-weak-types
+  [key: string]: any
+};
+
+export default class Zindex extends React.Component<Props> {
+  static propTypes = {
+    /**
+     * Приращение к z-index
+     */
+    delta: PropTypes.number.isRequired,
+    render: PropTypes.bool
+  };
+
+  static defaultProps = {
+    render: true
+  };
+
+  zIndex: number;
+
+  componentWillMount() {
+    this.zIndex = ZIndexStorage.incrementZIndex(this.props.delta);
+  }
+
+  componentWillUnmount() {
+    ZIndexStorage.removeZIndex(this.zIndex);
+  }
+
+  render() {
+    const { render, style, children, ...props } = this.props;
+    delete props.delta;
+    return render ? (
+      <div style={{ ...style, zIndex: this.zIndex }} {...props}>
+        {children}
+      </div>
+    ) : (
+      children
+    );
+  }
+}
+
+class ZIndexStorage {
+  static _getZIndexes = (): number[] => {
+    return global.__RetailUiZIndexes || (global.__RetailUiZIndexes = [0]);
+  };
+
+  static incrementZIndex = (delta: number): number => {
+    if (delta <= 0) {
+      throw new Error();
+    }
+    const zIndexes = ZIndexStorage._getZIndexes();
+    const top = zIndexes[zIndexes.length - 1];
+    const zIndex = top + delta;
+    zIndexes.push(zIndex);
+    return zIndex;
+  };
+
+  static removeZIndex = (zIndex: number): void => {
+    const zIndexes = ZIndexStorage._getZIndexes();
+    const i = zIndexes.indexOf(zIndex);
+    zIndexes.splice(i, 1);
+  };
+}

--- a/components/ZIndex/__tests__/ZIndex.stories.js
+++ b/components/ZIndex/__tests__/ZIndex.stories.js
@@ -16,6 +16,7 @@ import ZIndex from '../ZIndex';
 import Button from '../../Button';
 import Toggle from '../../Toggle';
 import Popup from '../../Popup/Popup';
+import Toast from '../../Toast';
 
 class ZKebab extends React.Component<{}> {
   render() {
@@ -101,6 +102,7 @@ class ZSample extends React.Component<ZSampleProps, ZSampleState> {
   };
 
   popupAnchor: ?HTMLElement;
+  notifier: ?Toast;
 
   render() {
     const controls = (
@@ -119,6 +121,7 @@ class ZSample extends React.Component<ZSampleProps, ZSampleState> {
     const { total = 0, current = 0 } = this.props;
     return (
       <Gapped vertical>
+        <Toast ref={e => (this.notifier = e)} />
         {controls}
         <Gapped>
           <ZLoader size={150} />
@@ -144,10 +147,14 @@ class ZSample extends React.Component<ZSampleProps, ZSampleState> {
           )}
         </Gapped>
         {controls}
-
-        {current < total && (
-          <Button onClick={() => this.setState({ modal: true })}>OPEN</Button>
-        )}
+        <Gapped gap={10}>
+          <Button onClick={() => this.notify(current)}>TOAST</Button>
+          {current < total && (
+            <Button onClick={() => this.setState({ modal: true })}>
+              MODAL
+            </Button>
+          )}
+        </Gapped>
         {this.state.modal && (
           <Modal onClose={() => this.setState({ modal: false })}>
             <Modal.Header>M #{current}</Modal.Header>
@@ -160,6 +167,10 @@ class ZSample extends React.Component<ZSampleProps, ZSampleState> {
         )}
       </Gapped>
     );
+  }
+
+  notify(value: number) {
+    this.notifier && this.notifier.push('Message from #' + value);
   }
 
   renderBlock(content: React.Node, width: number, height?: number) {

--- a/components/ZIndex/__tests__/ZIndex.stories.js
+++ b/components/ZIndex/__tests__/ZIndex.stories.js
@@ -1,0 +1,215 @@
+// @flow
+/* eslint-disable react/no-multi-comp */
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Gapped from '../../Gapped';
+import Modal from '../../Modal';
+import Loader from '../../Loader';
+import Select from '../../Select';
+import Kebab from '../../Kebab';
+import MenuItem from '../../MenuItem';
+import Center from '../../Center';
+import Hint from '../../Hint';
+import Tooltip from '../../Tooltip';
+import ZIndex from '../ZIndex';
+import Button from '../../Button';
+import Toggle from '../../Toggle';
+import Popup from '../../Popup/Popup';
+
+class ZKebab extends React.Component<{}> {
+  render() {
+    return (
+      <Kebab>
+        <MenuItem>1</MenuItem>
+        <MenuItem>2</MenuItem>
+        <MenuItem>3</MenuItem>
+        <MenuItem>4</MenuItem>
+        <MenuItem>5</MenuItem>
+        <MenuItem>6</MenuItem>
+      </Kebab>
+    );
+  }
+}
+
+class ZSelect extends React.Component<{}> {
+  render() {
+    return <Select value={1} items={[1, 2, 3, 4, 5, 6]} />;
+  }
+}
+
+class ZLoader extends React.Component<{ size: number }> {
+  render() {
+    const size = this.props.size + 'px';
+    const style = { height: size, fontSize: '20px', border: 'solid red 1px' };
+    return (
+      <div style={{ width: size }}>
+        <Loader active>
+          <div style={style}>
+            <Center>
+              <b>
+                Content<br />under<br />loader
+              </b>
+            </Center>
+          </div>
+        </Loader>
+      </div>
+    );
+  }
+}
+
+class ZModal extends React.Component<{ size: number, children?: React.Node }> {
+  render() {
+    const size = this.props.size + 'px';
+    return (
+      <Modal>
+        <Modal.Body>
+          <div style={{ minWidth: size, minHeight: size }}>
+            {this.props.children}
+          </div>
+        </Modal.Body>
+      </Modal>
+    );
+  }
+}
+
+class LightboxUnderLightbox extends React.Component<{}> {
+  render() {
+    return (
+      <div>
+        <ZModal size={200}>xxx</ZModal>
+        <ZModal size={100}>zzz</ZModal>
+      </div>
+    );
+  }
+}
+
+type ZSampleProps = {
+  total?: number,
+  current?: number
+};
+
+type ZSampleState = {
+  modal: boolean,
+  popup: boolean
+};
+
+class ZSample extends React.Component<ZSampleProps, ZSampleState> {
+  state = {
+    modal: false,
+    popup: false
+  };
+
+  popupAnchor: ?HTMLElement;
+
+  render() {
+    const controls = (
+      <Gapped>
+        <Tooltip
+          render={() => this.renderBlock('TOOLTIP', 150)}
+          trigger={'hover'}
+        >
+          T
+        </Tooltip>
+        <Hint text={this.renderBlock('HINT', 150)}>H</Hint>
+        <ZSelect />
+        <ZKebab />
+      </Gapped>
+    );
+    const { total = 0, current = 0 } = this.props;
+    return (
+      <Gapped vertical>
+        {controls}
+        <Gapped>
+          <ZLoader size={150} />
+          <div ref={e => (this.popupAnchor = e)}>
+            <Toggle
+              checked={this.state.popup}
+              onChange={v => this.setState({ popup: v })}
+            />
+          </div>
+          {this.popupAnchor && (
+            <Popup
+              anchorElement={this.popupAnchor}
+              positions={['left middle']}
+              popupOffset={10}
+              opened={this.state.popup}
+              margin={5}
+              hasShadow
+              hasPin
+              pinOffset={15}
+            >
+              {this.renderBlock('POPUP POPUP POPUP', 300, 50)}
+            </Popup>
+          )}
+        </Gapped>
+        {controls}
+
+        {current < total && (
+          <Button onClick={() => this.setState({ modal: true })}>OPEN</Button>
+        )}
+        {this.state.modal && (
+          <Modal onClose={() => this.setState({ modal: false })}>
+            <Modal.Header>M #{current}</Modal.Header>
+            <Modal.Body>
+              <div style={{ width: 200 * (total - current) }}>
+                <ZSample total={total} current={current + 1} />
+              </div>
+            </Modal.Body>
+          </Modal>
+        )}
+      </Gapped>
+    );
+  }
+
+  renderBlock(content: React.Node, width: number, height?: number) {
+    return (
+      <Center style={{ width, height: height || width }}>{content}</Center>
+    );
+  }
+}
+
+class Demo extends React.Component<{}> {
+  render() {
+    return (
+      <div>
+        {this.renderDiv('red', 200, 0, 0)}
+        {this.renderDiv('green', 100, 20, 20)}
+        {
+          <ZIndex delta={500} render={false}>
+            {this.renderDiv('blue', 100, 40, 40)}
+          </ZIndex>
+        }
+        <ZIndex delta={400} render={false}>
+          <ZIndex delta={200} style={{ position: 'absolute' }}>
+            {this.renderDiv('orange', 100, 40, 40)}
+          </ZIndex>
+        </ZIndex>
+        <ZIndex delta={300} style={{ position: 'absolute' }}>
+          {this.renderDiv('black', 100, 60, 60)}
+        </ZIndex>
+      </div>
+    );
+  }
+
+  renderDiv(background, zIndex, left, top) {
+    return (
+      <div
+        style={{
+          height: '100px',
+          width: '100px',
+          background,
+          position: 'absolute',
+          zIndex,
+          left,
+          top
+        }}
+      />
+    );
+  }
+}
+
+storiesOf('Zindex', module)
+  .add('LightboxUnderLightbox', () => <LightboxUnderLightbox />)
+  .add('ZSample', () => <ZSample total={3} />)
+  .add('Demo', () => <Demo />);

--- a/components/ZIndex/index.d.ts
+++ b/components/ZIndex/index.d.ts
@@ -1,0 +1,1 @@
+export { default, ZIndexProps } from './ZIndex';

--- a/components/ZIndex/index.js
+++ b/components/ZIndex/index.js
@@ -1,0 +1,3 @@
+// @flow
+import ZIndex from './ZIndex';
+export default ZIndex;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@storybook/react": "3.2.17",
     "@types/react": "^16.0.29",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.1.1",
     "babel-jest": "^21.2.0",
     "babel-loader": "7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
Добавил компонент ZIndex - это механизм для работы с z-index
 -- по умолчанию рисует div и проставляет ему z-index в style, а также запоминает все нарисованные z-index
 -- можно отключить отрисовку div, тогда компонент только увеличит текущее значение z-index на дельту в хранилище - это нужно чтобы задать начальное смещение для компонент из retail-ui если они должны отображаться поверх каких-то элементов окружения нарисованных другими средствами


#302 [Loader] [Popup] (Kebab) z-index
#304 [Loader] in Modal.Body
#334 [TopBar] Выпадающее меню под лоадером