### PR TITLE
Spinner wrong type fix

### DIFF
--- a/components/Spinner/Spinner.js
+++ b/components/Spinner/Spinner.js
@@ -1,4 +1,5 @@
 // @flow
+
 import classnames from 'classnames';
 import * as React from 'react';
 
@@ -117,21 +118,18 @@ class Spinner extends React.Component<Props> {
       [styles.captionBottom]: type !== types.mini
     });
 
-    return (
-      <span className={spanClassName}>
-        {caption}
-      </span>
-    );
+    return <span className={spanClassName}>{caption}</span>;
   };
 
   render() {
     const { type, caption } = this.props;
+    const verifiedType = sizeMaps[type] ? type : Spinner.defaultProps.type;
 
     return (
       <div className={styles.spinner}>
-        {hasSvgAnimationSupport && this._renderSpinner(type)}
-        {!hasSvgAnimationSupport && <SpinnerFallback type={type} />}
-        {caption && this._renderCaption(type, caption)}
+        {hasSvgAnimationSupport && this._renderSpinner(verifiedType)}
+        {!hasSvgAnimationSupport && <SpinnerFallback type={verifiedType} />}
+        {caption && this._renderCaption(verifiedType, caption)}
       </div>
     );
   }

--- a/components/Spinner/__stories__/Spinner.stories.js
+++ b/components/Spinner/__stories__/Spinner.stories.js
@@ -1,0 +1,10 @@
+// @flow
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import Spinner from '../Spinner';
+
+storiesOf('Spinner', module)
+  .addDecorator(story => (
+    <div style={{ height: 150, width: 200, padding: 4 }}>{story()}</div>
+  ))
+  .add('Simple', () => <Spinner />);

--- a/components/Spinner/__tests__/Spinner-test.js
+++ b/components/Spinner/__tests__/Spinner-test.js
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import Spinner from '../Spinner';
+import styles from '../Spinner.less';
+import { sizeMaps } from '../settings';
+
+const render = props => mount(<Spinner {...props} />);
+const generateSelector = name => `.${styles[name]}`;
+
+describe('Spinner', () => {
+  beforeEach(() => {
+    Spinner.__Rewire__('hasSvgAnimationSupport', true);
+  });
+
+  it('renders default Spinner', () => {
+    render();
+  });
+
+  it('renders correct size of default Spinner', () => {
+    const component = render();
+    const cloudProps = component.find(generateSelector('cloud')).props();
+    const { width, height } = cloudProps;
+    const defaultType = Spinner.defaultProps.type;
+
+    expect(width).toEqual(sizeMaps[defaultType].width);
+    expect(height).toEqual(sizeMaps[defaultType].height);
+  });
+
+  it('renders correct default Spinner caption text', () => {
+    const component = render();
+    const captionText = component
+      .find(generateSelector('captionBottom'))
+      .text();
+
+    expect(captionText).toEqual('Загрузка');
+  });
+
+  it('prints correct caption text', () => {
+    const component = render({ caption: 'test' });
+    const captionText = component
+      .find(generateSelector('captionBottom'))
+      .text();
+
+    expect(captionText).toEqual('test');
+  });
+
+  it('should render mini Spinner', () => {
+    const component = render({ type: 'mini' });
+    const circle = component.find(generateSelector('circle'));
+    const captionRight = component.find(generateSelector('captionRight'));
+
+    expect(circle).toHaveLength(1);
+    expect(captionRight).toHaveLength(1);
+  });
+
+  it('should render big Spinner', () => {
+    const component = render({ type: 'big' });
+    const cloud = component.find(generateSelector('cloud'));
+    const { width, height } = cloud.props();
+
+    expect(width).toEqual(sizeMaps.big.width);
+    expect(height).toEqual(sizeMaps.big.height);
+  });
+
+  it('should render default Spinner if passed type is incorrect', () => {
+    const component = render({ type: '1231' });
+    const cloud = component.find(generateSelector('cloud'));
+    const { width, height } = cloud.props();
+    const defaultType = Spinner.defaultProps.type;
+
+    expect(width).toEqual(sizeMaps[defaultType].width);
+    expect(height).toEqual(sizeMaps[defaultType].height);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "babel-eslint": "^8.1.1",
     "babel-jest": "^21.2.0",
     "babel-loader": "7.1.2",
+    "babel-plugin-rewire": "^1.1.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -15,7 +15,11 @@ module.exports = {
         ],
         'react'
       ],
-      plugins: ['transform-class-properties', 'transform-object-rest-spread'],
+      plugins: [
+        'transform-class-properties',
+        'transform-object-rest-spread',
+        'rewire'
+      ],
       retainLines: true
     }).code;
   }


### PR DESCRIPTION
Если передать невалидный type (например: 'small') в Spinner — приложение ломается.
Теперь в этом случае рендерится спиннер с дефолтным типом.