### PR TITLE
Fix popup positioning

### DIFF
--- a/components/Popup/Popup.js
+++ b/components/Popup/Popup.js
@@ -21,6 +21,7 @@ function getTempNode() {
   let tempNode = document.createElement('div');
   tempNode.style.opacity = '0';
   tempNode.style.position = 'absolute';
+  tempNode.className = 'react-ui';
   document.body && document.body.appendChild(tempNode);
 
   return tempNode;

--- a/components/Popup/PopupHelper.js
+++ b/components/Popup/PopupHelper.js
@@ -47,8 +47,8 @@ function _getWindowRelativeRect(): Rect {
   return {
     top: 0,
     left: 0,
-    width: window.innerWidth || _getViewProperty(x => x.clientWidth),
-    height: window.innerHeight || _getViewProperty(x => x.clientHeight)
+    width: _getViewProperty(x => x.clientWidth) || window.innerWidth,
+    height: _getViewProperty(x => x.clientHeight) || window.innerHeight
   };
 }
 


### PR DESCRIPTION
**Повышение специфичности селекторов**
Если библиотека контролов используется в проекте с собственными глобальными стилями, которые влияют на контролы из библиотеки и при этом такие стили никак нельзя переделать, то можно использовать повышение специфичности селекторов с за счет класса retail-ui. Popup при предварительно отрисовке не добавлял на контейнер спец класс и при увеличенной специфичности стили просто не применялись на его внутренности, поэтому размер в пререндере мог отличаться от реальных размеров

Popup вправо - нормально:

![image](https://user-images.githubusercontent.com/5162965/35397292-e69128ae-0210-11e8-8e35-620f1a0a8b90.png)

Popup влево - имеет неправильное позиционирвоание:

![image](https://user-images.githubusercontent.com/5162965/35397034-2aa49e00-0210-11e8-9c56-f36c6969da2d.png)


**Позиционирование с учетом скролов**
Фикс проблемы: скроллбар не учитывался и Popup мог показаться под ним, теперь скроллбар учитывается
![image](https://user-images.githubusercontent.com/5162965/35397075-4b53fcae-0210-11e8-9453-478b9af5f4f0.png)
