### PR TITLE
Размер шрифта в размере Medium для Input должен быть 16px

### DIFF
--- a/components/Input/Input.less
+++ b/components/Input/Input.less
@@ -34,6 +34,7 @@
 
   .sizeMedium .input {
     line-height: 38px;
+    font-size: 16px;
   }
 
   .sizeLarge {

--- a/components/Input/Input.styles.js
+++ b/components/Input/Input.styles.js
@@ -42,7 +42,8 @@ export default (theme: ITheme) => ({
   },
   sizeMedium: {
     '& $input': {
-      lineHeight: '38px'
+      lineHeight: '38px',
+      fontSize: '16px'
     },
     '& $leftIcon': {
       lineHeight: '40px',


### PR DESCRIPTION
При size = medium сейчас размер шрифта в полях ввода равен 14px, хотя Саша Храмцов говорит, что правильнее было бы сделать 16px как в size = large.

Не уверен, что этот pull request будет работать во всех случаях и во всех контролах, так как там есть флаги process.env.EXPERIMENTAL_CSS_IN_JS и войти во весь код который там есть достаточно не легко. 

Но в моем случае в DatePicker эти правки выглядят хорошо:
![image](https://user-images.githubusercontent.com/22623111/35565660-40fcd2ca-05e0-11e8-8c5e-6713244c2831.png)
