### PR TITLE
Сайдпейдж Footer и поведение

### DIFF
--- a/components/RenderLayer/index.js
+++ b/components/RenderLayer/index.js
@@ -15,24 +15,28 @@ type Props = {
 };
 
 class RenderLayer extends Component<Props> {
-  unsibscribeFocusOutside: () => void;
-  unsibscribeClickOutside: () => void;
+  unsubscribeFocusOutside: () => void;
+  unsubscribeClickOutside: () => void;
 
   componentDidMount() {
-    this.unsibscribeFocusOutside = this.props.subscribeToOutsideFocus(
-      this.props.onFocusOutside
-    );
-    this.unsibscribeClickOutside = this.props.subscribeToOutsideClicks(
-      this.props.onClickOutside
-    );
+    if (this.props.onFocusOut) {
+      this.unsubscribeFocusOutside = this.props.subscribeToOutsideFocus(
+        this.props.onFocusOutside
+      );
+    }
+    if (this.props.onClickOutside) {
+      this.unsubscribeClickOutside = this.props.subscribeToOutsideClicks(
+        this.props.onClickOutside
+      );
+    }
   }
 
   componentWillUnmount() {
-    if (this.unsibscribeFocusOutside) {
-      this.unsibscribeFocusOutside();
+    if (this.unsubscribeFocusOutside) {
+      this.unsubscribeFocusOutside();
     }
-    if (this.unsibscribeClickOutside) {
-      this.unsibscribeClickOutside();
+    if (this.unsubscribeClickOutside) {
+      this.unsubscribeClickOutside();
     }
   }
 

--- a/components/SidePage/SidePage.d.ts
+++ b/components/SidePage/SidePage.d.ts
@@ -5,7 +5,6 @@ export interface SidePageProps {
   blockBackground?: boolean;
   disableClose?: boolean;
   ignoreBackgroundClick?: boolean;
-  ignoreFocusOut?: boolean;
   width?: number;
   onClose?: () => void;
 }
@@ -25,9 +24,7 @@ export interface SidePageBodyProps {
   children?: React.ReactNode;
 }
 
-export interface SidePageBodyState {
-  left: number;
-}
+export interface SidePageBodyState {}
 
 export interface SidePageFooterProps {
   children?: React.ReactNode;

--- a/components/SidePage/SidePage.d.ts
+++ b/components/SidePage/SidePage.d.ts
@@ -5,6 +5,7 @@ export interface SidePageProps {
   blockBackground?: boolean;
   disableClose?: boolean;
   ignoreBackgroundClick?: boolean;
+  ignoreFocusOut?: boolean;
   width?: number;
   onClose?: () => void;
 }

--- a/components/SidePage/SidePage.d.ts
+++ b/components/SidePage/SidePage.d.ts
@@ -25,7 +25,9 @@ export interface SidePageBodyProps {
   children?: React.ReactNode;
 }
 
-export interface SidePageBodyState {}
+export interface SidePageBodyState {
+  left: number;
+}
 
 export interface SidePageFooterProps {
   children?: React.ReactNode;

--- a/components/SidePage/SidePage.js
+++ b/components/SidePage/SidePage.js
@@ -121,30 +121,25 @@ class SidePage extends React.Component<Props, State> {
     };
 
     return (
-      <RenderLayer
-        onClickOutside={this._handleClickOutside}
-        onFocusOutside={this._handleFocusOutside}
-        active={true}
-      >
-        <RenderContainer>
-          <ZIndex
-            delta={1000}
-            className={styles.root}
-            onScroll={LayoutEvents.emit}
-            style={rootStyle}
-          >
-            <HideBodyVerticalScroll
-              allowScrolling={!this.props.blockBackground}
+      <RenderContainer>
+        <ZIndex
+          delta={1000}
+          className={styles.root}
+          onScroll={LayoutEvents.emit}
+          style={rootStyle}
+        >
+          <HideBodyVerticalScroll
+            allowScrolling={!this.props.blockBackground}
+          />
+          {this.props.blockBackground && (
+            <div
+              className={classNames(
+                styles.background,
+                this.state.stackPosition === 0 && styles.gray
+              )}
             />
-            {this.props.blockBackground && (
-              <div
-                className={classNames(
-                  styles.background,
-                  this.state.stackPosition === 0 && styles.gray
-                )}
-                onClick={this._handleBackgroundClick}
-              />
-            )}
+          )}
+          <RenderLayer onClickOutside={this._handleClickOutside} active={true}>
             <div
               className={classNames(
                 styles.container,
@@ -152,11 +147,11 @@ class SidePage extends React.Component<Props, State> {
               )}
               style={sidePageStyle}
             >
-              <div>{this.props.children}</div>
+              {this.props.children}
             </div>
-          </ZIndex>
-        </RenderContainer>
-      </RenderLayer>
+          </RenderLayer>
+        </ZIndex>
+      </RenderContainer>
     );
   }
 
@@ -181,24 +176,6 @@ class SidePage extends React.Component<Props, State> {
   _handleClickOutside = () => {
     if (
       this.state.stackPosition === stack.mounted.length - 1 &&
-      !this.props.ignoreBackgroundClick
-    ) {
-      this._requestClose();
-    }
-  };
-
-  _handleFocusOutside = () => {
-    if (
-      this.state.stackPosition === stack.mounted.length - 1 &&
-      !this.props.ignoreFocusOut
-    ) {
-      this._requestClose();
-    }
-  };
-
-  _handleBackgroundClick = event => {
-    if (
-      event.target === event.currentTarget &&
       !this.props.ignoreBackgroundClick
     ) {
       this._requestClose();
@@ -318,21 +295,21 @@ class Footer extends React.Component<FooterProps, FooterState> {
   }
 
   render() {
-    const names = classNames({
-      [styles.footer]: true,
-      [styles.panel]: this.props.panel
-    });
-
     return (
       <Sticky side="bottom">
-        {fixed => (
-          <div
-            className={classNames(names, fixed && styles.fixed)}
-            style={{ left: this.state.left }}
-          >
-            {this.props.children}
-          </div>
-        )}
+        {fixed => {
+          const names = classNames({
+            [styles.footer]: true,
+            [styles.panel]: this.props.panel,
+            [styles.fixed]: fixed
+          });
+
+          return (
+            <div className={names} style={{ left: this.state.left }}>
+              {this.props.children}
+            </div>
+          );
+        }}
       </Sticky>
     );
   }

--- a/components/SidePage/SidePage.js
+++ b/components/SidePage/SidePage.js
@@ -23,7 +23,6 @@ type Props = {
   blockBackground?: boolean,
   disableClose?: boolean,
   ignoreBackgroundClick?: boolean,
-  ignoreFocusOut?: boolean,
   noClose?: boolean,
   width?: number,
   onClose?: () => void
@@ -60,11 +59,6 @@ class SidePage extends React.Component<Props, State> {
     ignoreBackgroundClick: PropTypes.bool,
 
     /**
-     * Не закрывать сайдпедж при потере фокуса
-     */
-    ignoreFocusOut: PropTypes.bool,
-
-    /**
      * Задать ширину сайдпейджа
      */
     width: PropTypes.number,
@@ -77,8 +71,7 @@ class SidePage extends React.Component<Props, State> {
   };
 
   static childContextTypes = {
-    requestClose: PropTypes.func.isRequired,
-    width: PropTypes.number.isRequired
+    requestClose: PropTypes.func.isRequired
   };
 
   static Header: Class<Header>;
@@ -101,19 +94,14 @@ class SidePage extends React.Component<Props, State> {
 
   getChildContext() {
     return {
-      requestClose: this._requestClose,
-      width: this._getWidth()
+      requestClose: this._requestClose
     };
-  }
-
-  _getWidth(): number {
-    return this.props.width || this.props.blockBackground ? 800 : 500;
   }
 
   render() {
     const rootStyle = this.props.blockBackground ? { width: '100%' } : {};
     const sidePageStyle = {
-      width: this._getWidth(),
+      width: this.props.width || this.props.blockBackground ? 800 : 500,
       marginRight:
         this.state.stackPosition === 0 && stack.mounted.length > 1
           ? 20
@@ -147,7 +135,9 @@ class SidePage extends React.Component<Props, State> {
               )}
               style={sidePageStyle}
             >
-              {this.props.children}
+              <table>
+                <tbody>{this.props.children}</tbody>
+              </table>
             </div>
           </RenderLayer>
         </ZIndex>
@@ -209,16 +199,22 @@ class Header extends React.Component<HeaderProps> {
 
   render() {
     return (
-      <Sticky side="top">
-        {fixed => (
-          <div className={classNames(styles.header, fixed && styles.fixed)}>
-            {this.renderClose()}
-            <div className={classNames(styles.title, fixed && styles.fixed)}>
-              {this.props.children}
-            </div>
-          </div>
-        )}
-      </Sticky>
+      <tr>
+        <td>
+          <Sticky side="top">
+            {fixed => (
+              <div className={classNames(styles.header, fixed && styles.fixed)}>
+                {this.renderClose()}
+                <div
+                  className={classNames(styles.title, fixed && styles.fixed)}
+                >
+                  {this.props.children}
+                </div>
+              </div>
+            )}
+          </Sticky>
+        </td>
+      </tr>
     );
   }
 
@@ -241,7 +237,11 @@ type BodyProps = {
 
 class Body extends React.Component<BodyProps> {
   render() {
-    return this.props.children;
+    return (
+      <tr className={styles.body}>
+        <td>{this.props.children}</td>
+      </tr>
+    );
   }
 }
 
@@ -250,75 +250,33 @@ type FooterProps = {
   panel?: boolean
 };
 
-type FooterState = {
-  left: number
-};
-
-type FooterContext = {
-  width: number
-};
-
 /**
  * Футер модального окна.
  */
-class Footer extends React.Component<FooterProps, FooterState> {
+class Footer extends React.Component<FooterProps> {
   static propTypes = {
     /** Включает серый цвет в футере */
     panel: PropTypes.bool
   };
 
-  static contextTypes = {
-    width: PropTypes.number.isRequired
-  };
-
-  _layoutSubscription;
-  context: FooterContext;
-
-  constructor(props: FooterProps, context: mixed) {
-    super(props, context);
-
-    this.state = {
-      left: this._getLeft()
-    };
-  }
-
-  componentDidMount() {
-    this._layoutSubscription = LayoutEvents.addListener(() =>
-      this.setState({ left: this._getLeft() })
-    );
-  }
-
-  componentWillUnmount() {
-    if (this._layoutSubscription) {
-      this._layoutSubscription.remove();
-    }
-  }
-
   render() {
     return (
-      <Sticky side="bottom">
-        {fixed => {
-          const names = classNames({
-            [styles.footer]: true,
-            [styles.panel]: this.props.panel,
-            [styles.fixed]: fixed
-          });
+      <tr>
+        <td>
+          <Sticky side="bottom">
+            {fixed => {
+              const names = classNames({
+                [styles.footer]: true,
+                [styles.panel]: this.props.panel,
+                [styles.fixed]: fixed
+              });
 
-          return (
-            <div className={names} style={{ left: this.state.left }}>
-              {this.props.children}
-            </div>
-          );
-        }}
-      </Sticky>
+              return <div className={names}>{this.props.children}</div>;
+            }}
+          </Sticky>
+        </td>
+      </tr>
     );
-  }
-
-  _getLeft(): number {
-    const { documentElement } = document;
-    return documentElement
-      ? documentElement.clientWidth - this.context.width
-      : 0;
   }
 }
 

--- a/components/SidePage/SidePage.js
+++ b/components/SidePage/SidePage.js
@@ -26,6 +26,7 @@ type Props = {
   blockBackground?: boolean,
   disableClose?: boolean,
   ignoreBackgroundClick?: boolean,
+  ignoreFocusOut?: boolean,
   noClose?: boolean,
   width?: number,
   onClose?: () => void
@@ -62,6 +63,11 @@ class SidePage extends React.Component<Props, State> {
     ignoreBackgroundClick: PropTypes.bool,
 
     /**
+     * Не закрывать сайдпедж при потере фокуса
+     */
+    ignoreFocusOut: PropTypes.bool,
+
+    /**
      * Задать ширину сайдпейджа
      */
     width: PropTypes.number,
@@ -82,7 +88,6 @@ class SidePage extends React.Component<Props, State> {
   static Footer: Class<Footer>;
 
   _stackSubscription = null;
-  _originalBodyOverflowY = null;
 
   constructor(props: Props, context: mixed) {
     super(props, context);
@@ -182,7 +187,7 @@ class SidePage extends React.Component<Props, State> {
   _handleFocusOutside = () => {
     if (
       this.state.stackPosition === stack.mounted.length - 1 &&
-      !this.props.ignoreBackgroundClick
+      !this.props.ignoreFocusOut
     ) {
       this._requestClose();
     }

--- a/components/SidePage/SidePage.less
+++ b/components/SidePage/SidePage.less
@@ -72,13 +72,11 @@
     }
   }
 
-  .body {
-    margin-bottom: 100px;
-  }
-
   .footer {
     bottom: 0;
     padding: 20px 30px 20px 30px;
+    position: fixed;
+    right: 0;
 
     &.panel {
       background: #e9e9e9;
@@ -87,6 +85,7 @@
     &.fixed {
       background: #fff;
       border-top: @border-color-gray-light solid 1px;
+      position: static;
 
       &.panel {
         border-top: 0;

--- a/components/SidePage/SidePage.less
+++ b/components/SidePage/SidePage.less
@@ -1,6 +1,17 @@
 @import "../variables.less";
 
 :local {
+  table {
+    border-spacing: 0;
+    height: 100%;
+    width: 100%;
+  }
+
+  td {
+    padding: 0;
+    vertical-align: text-bottom;
+  }
+
   .root {
     position: fixed;
     right: 0;
@@ -72,11 +83,12 @@
     }
   }
 
+  .body {
+    height: 100%;
+  }
+
   .footer {
-    bottom: 0;
     padding: 20px 30px 20px 30px;
-    position: fixed;
-    right: 0;
 
     &.panel {
       background: #e9e9e9;
@@ -85,7 +97,6 @@
     &.fixed {
       background: #fff;
       border-top: @border-color-gray-light solid 1px;
-      position: static;
 
       &.panel {
         border-top: 0;

--- a/components/SidePage/__tests__/SidePage.stories.js
+++ b/components/SidePage/__tests__/SidePage.stories.js
@@ -69,6 +69,8 @@ class Sample extends React.Component<SampleProps, SampleState> {
                 current={this.props.current + 1}
                 total={this.props.total}
                 ignoreBackgroundClick={this.props.ignoreBackgroundClick}
+                ignoreFocusOut={this.props.ignoreFocusOut}
+                withContent={this.props.withContent}
                 blockBackground={this.props.blockBackground}
               />
             )}
@@ -107,7 +109,13 @@ class SidePageWithScrollableContent extends Component<{}, {}> {
   render() {
     return (
       <div style={{ width: '300px' }}>
-        <Sample total={1} current={1} ignoreBackgroundClick withContent />
+        <Sample
+          total={1}
+          current={1}
+          ignoreBackgroundClick
+          ignoreFocusOut
+          withContent
+        />
         {textSample}
         {textSample}
       </div>
@@ -162,7 +170,14 @@ class SidePageWithInputInHeader extends Component<{}, { opened: boolean }> {
 class SidePageOverAnotherSidePage extends Component<{}, *> {
   render() {
     return (
-      <Sample current={1} total={5} ignoreBackgroundClick blockBackground />
+      <Sample
+        current={1}
+        total={5}
+        ignoreBackgroundClick
+        ignoreFocusOut
+        blockBackground
+        withContent
+      />
     );
   }
 }

--- a/components/SidePage/__tests__/SidePage.stories.js
+++ b/components/SidePage/__tests__/SidePage.stories.js
@@ -33,7 +33,9 @@ type SampleProps = {
   total?: number,
   current: number,
   ignoreBackgroundClick?: boolean,
-  blockBackground?: boolean
+  ignoreFocusOut?: boolean,
+  blockBackground?: boolean,
+  withContent?: boolean
 };
 
 type SampleState = {
@@ -55,6 +57,7 @@ class Sample extends React.Component<SampleProps, SampleState> {
       width={785}
       onClose={this.close}
       ignoreBackgroundClick={this.props.ignoreBackgroundClick}
+      ignoreFocusOut={this.props.ignoreFocusOut}
       blockBackground={this.props.blockBackground}
     >
       <SidePage.Header>Title</SidePage.Header>
@@ -76,8 +79,12 @@ class Sample extends React.Component<SampleProps, SampleState> {
             />{' '}
             Panel {this.state.panel ? 'enabled' : 'disabled'}
           </div>
-          {textSample}
-          {textSample}
+          {this.props.withContent && (
+            <div>
+              {textSample}
+              {textSample}
+            </div>
+          )}
         </div>
       </SidePage.Body>
       <SidePage.Footer panel={this.state.panel}>
@@ -100,7 +107,7 @@ class SidePageWithScrollableContent extends Component<{}, {}> {
   render() {
     return (
       <div style={{ width: '300px' }}>
-        <Sample total={1} current={1} ignoreBackgroundClick />
+        <Sample total={1} current={1} ignoreBackgroundClick withContent />
         {textSample}
         {textSample}
       </div>
@@ -164,12 +171,16 @@ class SidePageWithCloseConfiguration extends Component<
   {},
   {
     ignoreBackgroundClick: boolean,
-    blockBackground: boolean
+    ignoreFocusOut: boolean,
+    blockBackground: boolean,
+    withContent: boolean
   }
 > {
   state = {
     ignoreBackgroundClick: false,
-    blockBackground: false
+    ignoreFocusOut: false,
+    blockBackground: false,
+    withContent: false
   };
 
   render() {
@@ -179,7 +190,9 @@ class SidePageWithCloseConfiguration extends Component<
           total={1}
           current={1}
           ignoreBackgroundClick={this.state.ignoreBackgroundClick}
+          ignoreFocusOut={this.state.ignoreFocusOut}
           blockBackground={this.state.blockBackground}
+          withContent={this.state.withContent}
         />
         <div>
           <Toggle
@@ -195,6 +208,17 @@ class SidePageWithCloseConfiguration extends Component<
         </div>
         <div>
           <Toggle
+            checked={this.state.ignoreFocusOut}
+            onChange={() =>
+              this.setState(({ ignoreFocusOut }) => ({
+                ignoreFocusOut: !ignoreFocusOut
+              }))
+            }
+          />{' '}
+          ignoreFocusOut {this.state.ignoreFocusOut ? 'enabled' : 'disabled'}
+        </div>
+        <div>
+          <Toggle
             checked={this.state.blockBackground}
             onChange={() =>
               this.setState(({ blockBackground }) => ({
@@ -203,6 +227,17 @@ class SidePageWithCloseConfiguration extends Component<
             }
           />{' '}
           blockBackground {this.state.blockBackground ? 'enabled' : 'disabled'}
+        </div>
+        <div>
+          <Toggle
+            checked={this.state.withContent}
+            onChange={() =>
+              this.setState(({ withContent }) => ({
+                withContent: !withContent
+              }))
+            }
+          />{' '}
+          withContent {this.state.withContent ? 'enabled' : 'disabled'}
         </div>
       </div>
     );

--- a/components/SidePage/__tests__/SidePage.stories.js
+++ b/components/SidePage/__tests__/SidePage.stories.js
@@ -33,7 +33,6 @@ type SampleProps = {
   total?: number,
   current: number,
   ignoreBackgroundClick?: boolean,
-  ignoreFocusOut?: boolean,
   blockBackground?: boolean,
   withContent?: boolean
 };
@@ -57,7 +56,6 @@ class Sample extends React.Component<SampleProps, SampleState> {
       width={785}
       onClose={this.close}
       ignoreBackgroundClick={this.props.ignoreBackgroundClick}
-      ignoreFocusOut={this.props.ignoreFocusOut}
       blockBackground={this.props.blockBackground}
     >
       <SidePage.Header>Title</SidePage.Header>
@@ -69,7 +67,6 @@ class Sample extends React.Component<SampleProps, SampleState> {
                 current={this.props.current + 1}
                 total={this.props.total}
                 ignoreBackgroundClick={this.props.ignoreBackgroundClick}
-                ignoreFocusOut={this.props.ignoreFocusOut}
                 withContent={this.props.withContent}
                 blockBackground={this.props.blockBackground}
               />
@@ -109,13 +106,7 @@ class SidePageWithScrollableContent extends Component<{}, {}> {
   render() {
     return (
       <div style={{ width: '300px' }}>
-        <Sample
-          total={1}
-          current={1}
-          ignoreBackgroundClick
-          ignoreFocusOut
-          withContent
-        />
+        <Sample total={1} current={1} ignoreBackgroundClick withContent />
         {textSample}
         {textSample}
       </div>
@@ -174,7 +165,6 @@ class SidePageOverAnotherSidePage extends Component<{}, *> {
         current={1}
         total={5}
         ignoreBackgroundClick
-        ignoreFocusOut
         blockBackground
         withContent
       />
@@ -186,14 +176,12 @@ class SidePageWithCloseConfiguration extends Component<
   {},
   {
     ignoreBackgroundClick: boolean,
-    ignoreFocusOut: boolean,
     blockBackground: boolean,
     withContent: boolean
   }
 > {
   state = {
     ignoreBackgroundClick: false,
-    ignoreFocusOut: false,
     blockBackground: false,
     withContent: false
   };
@@ -205,7 +193,6 @@ class SidePageWithCloseConfiguration extends Component<
           total={1}
           current={1}
           ignoreBackgroundClick={this.state.ignoreBackgroundClick}
-          ignoreFocusOut={this.state.ignoreFocusOut}
           blockBackground={this.state.blockBackground}
           withContent={this.state.withContent}
         />
@@ -220,17 +207,6 @@ class SidePageWithCloseConfiguration extends Component<
           />{' '}
           ignoreBackgroundClick{' '}
           {this.state.ignoreBackgroundClick ? 'enabled' : 'disabled'}
-        </div>
-        <div>
-          <Toggle
-            checked={this.state.ignoreFocusOut}
-            onChange={() =>
-              this.setState(({ ignoreFocusOut }) => ({
-                ignoreFocusOut: !ignoreFocusOut
-              }))
-            }
-          />{' '}
-          ignoreFocusOut {this.state.ignoreFocusOut ? 'enabled' : 'disabled'}
         </div>
         <div>
           <Toggle

--- a/components/internal/withFocusOutside.js
+++ b/components/internal/withFocusOutside.js
@@ -24,16 +24,16 @@ function withFocusOutside<Props: ParamsProps>(
     _focusHandlers: Array<(e: Event) => mixed> = [];
     _clickHandlers: Array<(e: Event) => mixed> = [];
 
-    _focusSubscribtion: ?{ remove: () => void } = null;
+    _focusSubscription: ?{ remove: () => void } = null;
     _unmounted = false;
 
     _component;
 
     componentWillReceiveProps(nextProps: Props) {
-      if (this.props.active && !nextProps.active && this._focusSubscribtion) {
+      if (this.props.active && !nextProps.active && this._focusSubscription) {
         this._flush();
       }
-      if (!this.props.active && nextProps.active && !this._focusSubscribtion) {
+      if (!this.props.active && nextProps.active && !this._focusSubscription) {
         this._listen();
       }
     }
@@ -41,7 +41,7 @@ function withFocusOutside<Props: ParamsProps>(
     _ref = el => {
       this._component = el;
 
-      if (this._focusSubscribtion) {
+      if (this._focusSubscription) {
         this._flush();
       }
 
@@ -51,7 +51,7 @@ function withFocusOutside<Props: ParamsProps>(
     };
 
     _listen = () => {
-      this._focusSubscribtion = listenFocusOutside(
+      this._focusSubscription = listenFocusOutside(
         [this._getDomNode()],
         this._handleFocusOutside
       );
@@ -66,9 +66,9 @@ function withFocusOutside<Props: ParamsProps>(
     };
 
     _flush() {
-      if (this._focusSubscribtion) {
-        this._focusSubscribtion.remove();
-        this._focusSubscribtion = null;
+      if (this._focusSubscription) {
+        this._focusSubscription.remove();
+        this._focusSubscription = null;
       }
 
       events.removeEventListener(window, 'blur', this._handleFocusOutside);
@@ -119,7 +119,7 @@ function withFocusOutside<Props: ParamsProps>(
     };
 
     componentWillUnmount() {
-      if (this._focusSubscribtion) {
+      if (this._focusSubscription) {
         this._flush();
       }
       this._unmounted = true;


### PR DESCRIPTION
Порешал 2 проблемы:

1. Footer не был прижат к нижней части сайдпейджа, если весь контент в него влазил.
2. Сайдпейдж закрывался на событие FocusOut у RanderLayer. Хочется иметь поведение, при котором клик на фоне бы закрывал сайдпейдж, а переход на другую вкладку или другое окно операционной системы не закрывал бы его