### PR TITLE
Когда рендерим Popup в пререндере не создаем ZIndex

### DIFF
--- a/components/Popup/Popup.js
+++ b/components/Popup/Popup.js
@@ -2,7 +2,7 @@
 /* eslint-disable flowtype/no-weak-types */
 import cn from 'classnames';
 import * as React from 'react';
-import { render, findDOMNode } from 'react-dom';
+import { render, unmountComponentAtNode, findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import RenderContainer from '../RenderContainer';
 import RenderLayer from '../RenderLayer';
@@ -71,7 +71,6 @@ export default class Popup extends React.Component<Props, State> {
 
   _layoutEventsToken;
   _popupElement: ?HTMLElement;
-  _inQueue: boolean = false;
   _containerDidMount: boolean = false;
   _tempNode: HTMLElement;
 
@@ -94,6 +93,7 @@ export default class Popup extends React.Component<Props, State> {
   componentWillUnmount() {
     this._layoutEventsToken.remove();
     if (this._tempNode) {
+      unmountComponentAtNode(this._tempNode);
       document.body && document.body.removeChild(this._tempNode);
     }
   }
@@ -121,11 +121,11 @@ export default class Popup extends React.Component<Props, State> {
   }, 50);
 
   render() {
-    const { opened } = this.props;
+    const {opened} = this.props;
     if (!opened && !this._containerDidMount) {
       return null;
     }
-    const { location } = this.state;
+    const {location} = this.state;
     const directionClass = location
       ? location.position.split(' ')[0]
       : 'bottom';
@@ -150,22 +150,17 @@ export default class Popup extends React.Component<Props, State> {
             transitionEnterTimeout={200}
             transitionLeaveTimeout={200}
           >
-            {location ? this._renderContent(location) : null}
+            {location
+              ? this._renderContent(location, true)
+              : null}
           </Transition>
         </RenderContainer>
       </RenderLayer>
     );
   }
 
-  _renderContent(location) {
-    let {
-      hasPin,
-      children,
-      pinSize,
-      pinOffset,
-      backgroundColor,
-      hasShadow
-    } = this.props;
+  _renderContent(location, withZIndex?: boolean) {
+    const backgroundColor = this.props.backgroundColor;
 
     const style = {
       top: location.coordinates.top,
@@ -173,11 +168,14 @@ export default class Popup extends React.Component<Props, State> {
       backgroundColor
     };
 
-    // prettier-ignore
-    const pinBorder
-      = ieVerison === 8 ? '#e5e5e5'
-        : isIE ? 'rgba(0, 0, 0, 0.09)'
-          : 'transparent';
+    return withZIndex ? this._renderRealContent(location, style) : this._renderTempContent(location, style);
+  }
+
+  _renderRealContent(location, style) {
+    let {
+      children,
+      hasShadow
+    } = this.props;
 
     return (
       <ZIndex
@@ -187,19 +185,55 @@ export default class Popup extends React.Component<Props, State> {
         style={style}
       >
         {children}
-        {hasPin && (
-          <PopupPin
-            popupElement={this._popupElement}
-            popupPosition={location.position}
-            size={pinSize}
-            offset={pinOffset}
-            borderWidth={hasShadow ? 1 : 0}
-            backgroundColor={backgroundColor}
-            borderColor={pinBorder}
-          />
-        )}
+        {this._renderPin(location)}
       </ZIndex>
     );
+  }
+
+  _renderTempContent(location, style) {
+    let {
+      children,
+      hasShadow
+    } = this.props;
+
+    return (
+      <div
+        ref={e => (this._popupElement = e)}
+        className={cn(styles.popup, hasShadow && styles.shadow)}
+        style={style}
+      >
+        {children}
+        {this._renderPin(location)}
+      </div>
+    );
+  }
+
+  _renderPin(location) {
+    const {
+      hasPin,
+      pinSize,
+      pinOffset,
+      backgroundColor,
+      hasShadow
+    } = this.props;
+
+    // prettier-ignore
+    const pinBorder
+      = ieVerison === 8 ? '#e5e5e5'
+      : isIE ? 'rgba(0, 0, 0, 0.09)'
+        : 'transparent';
+
+    return hasPin && (
+      <PopupPin
+        popupElement={this._popupElement}
+        popupPosition={location.position}
+        size={pinSize}
+        offset={pinOffset}
+        borderWidth={hasShadow ? 1 : 0}
+        backgroundColor={backgroundColor}
+        borderColor={pinBorder}
+      />
+    )
   }
 
   _handleClickOutside = () => {
@@ -250,7 +284,7 @@ export default class Popup extends React.Component<Props, State> {
     const anchorRect = PopupHelper.getElementAbsoluteRect(anchorElement);
     const popupRect = PopupHelper.getElementAbsoluteRect(popupElement);
 
-    for (var i = 0; i < positions.length; ++i) {
+    for (let i = 0; i < positions.length; ++i) {
       const position = PopupHelper.getPositionObject(positions[i]);
       const coordinates = this._getCoordinates(
         anchorRect,
@@ -307,7 +341,7 @@ export default class Popup extends React.Component<Props, State> {
       case 'top':
         return {
           top: anchorRect.top - popupRect.height - margin,
-          left: this._getHorisontalPosition(
+          left: this._getHorizontalPosition(
             anchorRect,
             popupRect,
             position.align,
@@ -317,7 +351,7 @@ export default class Popup extends React.Component<Props, State> {
       case 'bottom':
         return {
           top: anchorRect.top + anchorRect.height + margin,
-          left: this._getHorisontalPosition(
+          left: this._getHorizontalPosition(
             anchorRect,
             popupRect,
             position.align,
@@ -349,7 +383,7 @@ export default class Popup extends React.Component<Props, State> {
     }
   }
 
-  _getHorisontalPosition(anchorRect, popupRect, align, popupOffset) {
+  _getHorizontalPosition(anchorRect, popupRect, align, popupOffset) {
     switch (align) {
       case 'left':
         return anchorRect.left - popupOffset;

--- a/components/ZIndex/ZIndex.js
+++ b/components/ZIndex/ZIndex.js
@@ -14,7 +14,7 @@ type Props = {
   [key: string]: any
 };
 
-export default class Zindex extends React.Component<Props> {
+export default class ZIndex extends React.Component<Props> {
   static propTypes = {
     /**
      * Приращение к z-index

--- a/components/ZIndex/__tests__/ZIndex.stories.js
+++ b/components/ZIndex/__tests__/ZIndex.stories.js
@@ -220,7 +220,7 @@ class Demo extends React.Component<{}> {
   }
 }
 
-storiesOf('Zindex', module)
+storiesOf('ZIndex', module)
   .add('LightboxUnderLightbox', () => <LightboxUnderLightbox />)
   .add('ZSample', () => <ZSample total={3} />)
   .add('Demo', () => <Demo />);


### PR DESCRIPTION
У попапа есть метода `_prerender`. Он нужен для анимации и рендерит компонент где-то вне поля видимости пользователя, чтобы рассчитать размеры этого компонента. Проблема в том, что у этого компонента есть ZIndex, который глобально увеличивается. Компонент, который нарендерили не удаляется нормально, из-а чего глобальная переменная ZIndex-а не уменьшается и происходит страшное