### PR TITLE
fix ReactTesting.call() arguments passing

### DIFF
--- a/testing/ReactTesting.js
+++ b/testing/ReactTesting.js
@@ -59,7 +59,7 @@ function findDOMNodes(path, parentNode = document.body) {
   });
 }
 
-function call(node, method, args = []) {
+function call(node, method, ...args) {
   return Lookup.getAdapter(node.lookupElement)[method](...args);
 }
 


### PR DESCRIPTION
PR fixing `ReactTesting.call(datePicker, 'setStringValue', '07.03.2018')` arguments passing.
Without fix only first character of string was passed to `setStringValue` function of DatePicker-adapter.