### PR TITLE
Общий стек для Modal и SidePage

### DIFF
--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -21,10 +21,8 @@ const KEY_CODE_ESCAPE = 27;
 
 let mountedModalsCount = 0;
 
-type ModalChild = React.Node;
-
 type Props = {
-  children?: ModalChild,
+  children?: React.Node,
   disableClose?: boolean,
   ignoreBackgroundClick?: boolean,
   noClose?: boolean,
@@ -170,7 +168,7 @@ class Modal extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    this._stackSubscription = ModalStack.add(this, this._handleStackChange);
+    this._stackSubscription = ModalStack.add(1, this._handleStackChange);
     if (mountedModalsCount === 0) {
       events.addEventListener(
         window,
@@ -198,8 +196,8 @@ class Modal extends React.Component<Props, State> {
     ModalStack.remove(this);
   }
 
-  _handleStackChange = (stack: React.Node[]) => {
-    this.setState({ stackPosition: stack.findIndex(x => x === this) });
+  _handleStackChange = (stack: React.ComponentType<*>[]) => {
+    this.setState({ stackPosition: stack.indexOf(this) });
   };
 
   _handleContainerClick = event => {

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -199,8 +199,7 @@ class Modal extends React.Component<Props, State> {
   }
 
   _handleStackChange = (stack: React.Node[]) => {
-    let lol = stack.findIndex(x => x === this);
-    this.setState({ stackPosition: lol });
+    this.setState({ stackPosition: stack.findIndex(x => x === this) });
   };
 
   _handleContainerClick = event => {

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -168,7 +168,7 @@ class Modal extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    this._stackSubscription = ModalStack.add(1, this._handleStackChange);
+    this._stackSubscription = ModalStack.add(this, this._handleStackChange);
     if (mountedModalsCount === 0) {
       events.addEventListener(
         window,

--- a/components/ModalStack/ModalStack.js.flow
+++ b/components/ModalStack/ModalStack.js.flow
@@ -1,0 +1,11 @@
+//@flow
+import * as React from 'react';
+import { EventSubscription } from 'fbemitter';
+
+export default class ModalStack {
+  static add(component: React.Node, onChange: (stack: React.Node[]) => void): EventSubscription {
+  }
+
+  static remove(component: React.Node) {
+  }
+}

--- a/components/ModalStack/ModalStack.js.flow
+++ b/components/ModalStack/ModalStack.js.flow
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { EventSubscription } from 'fbemitter';
 
 export default class ModalStack {
-  static add(component: React.Node, onChange: (stack: React.Node[]) => void): EventSubscription {
+  static add(component: React.ComponentType<*>, onChange: (stack: React.ComponentType<*>[]) => void): EventSubscription {
   }
 
-  static remove(component: React.Node) {
+  static remove(component: React.ComponentType<*>) {
   }
 }

--- a/components/ModalStack/ModalStack.ts
+++ b/components/ModalStack/ModalStack.ts
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { EventEmitter, EventSubscription } from 'fbemitter';
-import Global = NodeJS.Global;
 
 interface StackInfo {
   emitter: EventEmitter;
-  mounted: React.ReactNode[];
+  mounted: React.Component[];
 }
 
 interface GlobalWithStackInfo {
@@ -13,8 +12,8 @@ interface GlobalWithStackInfo {
 
 export default class ModalStack {
   public static add(
-    component: React.ReactNode,
-    onChange: (stack: React.ReactNode[]) => void
+    component: React.Component,
+    onChange: (stack: ReadonlyArray<React.Component>) => void
   ): EventSubscription {
     const { emitter, mounted } = ModalStack.getStackInfo();
     mounted.unshift(component);
@@ -25,9 +24,9 @@ export default class ModalStack {
     return subscription;
   }
 
-  public static remove(component: React.ReactNode) {
+  public static remove(component: React.Component) {
     const { emitter, mounted } = ModalStack.getStackInfo();
-    const index = mounted.findIndex(x => x === component);
+    const index = mounted.indexOf(component);
     if (index !== -1) {
       mounted.splice(index, 1);
     }
@@ -35,7 +34,7 @@ export default class ModalStack {
   }
 
   private static getStackInfo(): StackInfo {
-    const globalWithStack = global as GlobalWithStackInfo & Global;
+    const globalWithStack = global as GlobalWithStackInfo;
     return (
       globalWithStack.__ReactUIStackInfo ||
       (globalWithStack.__ReactUIStackInfo = {

--- a/components/ModalStack/ModalStack.ts
+++ b/components/ModalStack/ModalStack.ts
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { EventEmitter, EventSubscription } from 'fbemitter';
+import Global = NodeJS.Global;
+
+interface StackInfo {
+  emitter: EventEmitter;
+  mounted: React.ReactNode[];
+}
+
+interface GlobalWithStackInfo {
+  __ReactUIStackInfo?: StackInfo;
+}
+
+export default class ModalStack {
+  public static add(
+    component: React.ReactNode,
+    onChange: (stack: React.ReactNode[]) => void
+  ): EventSubscription {
+    const { emitter, mounted } = ModalStack.getStackInfo();
+    mounted.unshift(component);
+    const subscription = emitter.addListener('change', () =>
+      onChange([...mounted])
+    );
+    emitter.emit('change');
+    return subscription;
+  }
+
+  public static remove(component: React.ReactNode) {
+    const { emitter, mounted } = ModalStack.getStackInfo();
+    const index = mounted.findIndex(x => x === component);
+    if (index !== -1) {
+      mounted.splice(index, 1);
+    }
+    emitter.emit('change');
+  }
+
+  private static getStackInfo(): StackInfo {
+    const globalWithStack = global as GlobalWithStackInfo & Global;
+    return (
+      globalWithStack.__ReactUIStackInfo ||
+      (globalWithStack.__ReactUIStackInfo = {
+        emitter: new EventEmitter(),
+        mounted: []
+      })
+    );
+  }
+}

--- a/components/ModalStack/index.js.flow
+++ b/components/ModalStack/index.js.flow
@@ -1,0 +1,2 @@
+import ModalStack from './ModalStack';
+export default ModalStack;

--- a/components/ModalStack/index.ts
+++ b/components/ModalStack/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ModalStack';

--- a/components/SidePage/SidePage.js
+++ b/components/SidePage/SidePage.js
@@ -146,19 +146,20 @@ class SidePage extends React.Component<Props, State> {
     );
   }
 
-  _handleStackChange = (stack: React.Node[]) => {
+  _handleStackChange = (stack: React.ComponentType<*>[]) => {
     const sidePages = stack.filter(x => x instanceof SidePage);
-    const currentIndex = sidePages.findIndex(x => x === this);
+    const currentSidePagePosition = sidePages.indexOf(this);
+    const isSidePageOnStackTop = stack[0] instanceof SidePage;
 
     const hasMarginRight =
-      sidePages.length > 1 && currentIndex === sidePages.length - 1;
+      sidePages.length > 1 && currentSidePagePosition === sidePages.length - 1;
     const hasShadow =
-      sidePages.length < 3 || currentIndex > sidePages.length - 3;
+      sidePages.length < 3 || currentSidePagePosition > sidePages.length - 3;
     const hasBackground =
-      currentIndex === sidePages.length - 1 && stack[0] instanceof SidePage;
+      currentSidePagePosition === sidePages.length - 1 && isSidePageOnStackTop;
 
     this.setState({
-      stackPosition: stack.findIndex(x => x === this),
+      stackPosition: stack.indexOf(this),
       hasMarginRight,
       hasShadow,
       hasBackground

--- a/components/SidePage/SidePage.js
+++ b/components/SidePage/SidePage.js
@@ -3,6 +3,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import events from 'add-event-listener';
 import LayoutEvents from '../../lib/LayoutEvents';
 import RenderContainer from '../RenderContainer';
 import RenderLayer from '../RenderLayer';
@@ -12,6 +13,9 @@ import HideBodyVerticalScroll from '../HideBodyVerticalScroll';
 import ModalStack from '../ModalStack';
 
 import styles from './SidePage.less';
+import stopPropagation from '../../lib/events/stopPropagation';
+
+const KEY_CODE_ESCAPE = 27;
 
 type Props = {
   children?: React.Node,
@@ -88,10 +92,12 @@ class SidePage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    events.addEventListener(window, 'keydown', this._handleKeyDown);
     this._stackSubscription = ModalStack.add(this, this._handleStackChange);
   }
 
   componentWillUnmount() {
+    events.removeEventListener(window, 'keydown', this._handleKeyDown);
     this._stackSubscription && this._stackSubscription.remove();
     ModalStack.remove(this);
   }
@@ -161,6 +167,16 @@ class SidePage extends React.Component<Props, State> {
 
   _handleClickOutside = () => {
     if (this.state.stackPosition === 0 && !this.props.ignoreBackgroundClick) {
+      this._requestClose();
+    }
+  };
+
+  _handleKeyDown = event => {
+    if (this.state.stackPosition !== 0) {
+      return;
+    }
+    if (event.keyCode === KEY_CODE_ESCAPE) {
+      stopPropagation(event);
       this._requestClose();
     }
   };

--- a/components/SidePage/SidePage.js
+++ b/components/SidePage/SidePage.js
@@ -1,7 +1,6 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
 import classNames from 'classnames';
-import { EventEmitter } from 'fbemitter';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import LayoutEvents from '../../lib/LayoutEvents';
@@ -10,13 +9,9 @@ import RenderLayer from '../RenderLayer';
 import Sticky from '../Sticky';
 import ZIndex from '../ZIndex';
 import HideBodyVerticalScroll from '../HideBodyVerticalScroll';
+import ModalStack from '../ModalStack';
 
 import styles from './SidePage.less';
-
-const stack = {
-  emitter: new EventEmitter(),
-  mounted: []
-};
 
 type Props = {
   children?: React.Node,
@@ -29,7 +24,10 @@ type Props = {
 };
 
 type State = {
-  stackPosition: number
+  stackPosition?: number,
+  hasMarginRight?: boolean,
+  hasShadow?: boolean,
+  hasBackground?: boolean
 };
 
 /**
@@ -81,17 +79,7 @@ class SidePage extends React.Component<Props, State> {
 
   _stackSubscription = null;
 
-  constructor(props: Props, context: mixed) {
-    super(props, context);
-    stack.mounted.push(this);
-    this._stackSubscription = stack.emitter.addListener(
-      'change',
-      this._handleStackChange
-    );
-    this.state = {
-      stackPosition: stack.mounted.length - 1
-    };
-  }
+  state = {};
 
   getChildContext() {
     return {
@@ -99,14 +87,20 @@ class SidePage extends React.Component<Props, State> {
     };
   }
 
+  componentDidMount() {
+    this._stackSubscription = ModalStack.add(this, this._handleStackChange);
+  }
+
+  componentWillUnmount() {
+    this._stackSubscription && this._stackSubscription.remove();
+    ModalStack.remove(this);
+  }
+
   render() {
     const rootStyle = this.props.blockBackground ? { width: '100%' } : {};
     const sidePageStyle = {
       width: this.props.width || (this.props.blockBackground ? 800 : 500),
-      marginRight:
-        this.state.stackPosition === 0 && stack.mounted.length > 1
-          ? 20
-          : undefined
+      marginRight: this.state.hasMarginRight ? 20 : undefined
     };
 
     return (
@@ -124,7 +118,7 @@ class SidePage extends React.Component<Props, State> {
             <div
               className={classNames(
                 styles.background,
-                this.state.stackPosition === 0 && styles.gray
+                this.state.hasBackground && styles.gray
               )}
             />
           )}
@@ -132,7 +126,7 @@ class SidePage extends React.Component<Props, State> {
             <div
               className={classNames(
                 styles.container,
-                this.state.stackPosition < 2 && styles.shadow
+                this.state.hasShadow && styles.shadow
               )}
               style={sidePageStyle}
             >
@@ -146,29 +140,27 @@ class SidePage extends React.Component<Props, State> {
     );
   }
 
-  componentDidMount() {
-    stack.emitter.emit('change');
-  }
+  _handleStackChange = (stack: React.Node[]) => {
+    const sidePages = stack.filter(x => x instanceof SidePage);
+    const currentIndex = sidePages.findIndex(x => x === this);
 
-  componentWillUnmount() {
-    this._stackSubscription && this._stackSubscription.remove();
-    const inStackIndex = stack.mounted.findIndex(x => x === this);
-    if (inStackIndex !== -1) {
-      stack.mounted.splice(inStackIndex, 1);
-    }
-    stack.emitter.emit('change');
-  }
+    const hasMarginRight =
+      sidePages.length > 1 && currentIndex === sidePages.length - 1;
+    const hasShadow =
+      sidePages.length < 3 || currentIndex > sidePages.length - 3;
+    const hasBackground =
+      currentIndex === sidePages.length - 1 && stack[0] instanceof SidePage;
 
-  _handleStackChange = () => {
-    const stackPosition = stack.mounted.findIndex(x => x === this);
-    this.setState({ stackPosition });
+    this.setState({
+      stackPosition: stack.findIndex(x => x === this),
+      hasMarginRight,
+      hasShadow,
+      hasBackground
+    });
   };
 
   _handleClickOutside = () => {
-    if (
-      this.state.stackPosition === stack.mounted.length - 1 &&
-      !this.props.ignoreBackgroundClick
-    ) {
+    if (this.state.stackPosition === 0 && !this.props.ignoreBackgroundClick) {
       this._requestClose();
     }
   };

--- a/components/SidePage/__tests__/SidePage.stories.js
+++ b/components/SidePage/__tests__/SidePage.stories.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
-import React, { Component } from 'react';
+import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import SidePage from '../SidePage';
@@ -30,6 +30,7 @@ const textSample = (
 );
 
 type SampleProps = {
+  children?: React.Node,
   total?: number,
   current: number,
   ignoreBackgroundClick?: boolean,
@@ -78,6 +79,7 @@ class Sample extends React.Component<SampleProps, SampleState> {
             />{' '}
             Panel {this.state.panel ? 'enabled' : 'disabled'}
           </div>
+          {this.props.children}
           {this.props.withContent && (
             <div>
               {textSample}
@@ -102,7 +104,45 @@ class Sample extends React.Component<SampleProps, SampleState> {
   );
 }
 
-class SidePageWithScrollableContent extends Component<{}, {}> {
+type SampleConfiguratorProps = {
+  ignoreBackgroundClick: boolean,
+  blockBackground: boolean,
+  withContent: boolean,
+  onChange: (name: string) => void
+};
+
+class SampleConfigurator extends React.Component<SampleConfiguratorProps> {
+  render() {
+    return (
+      <div>
+        <div>
+          <Toggle
+            checked={this.props.ignoreBackgroundClick}
+            onChange={() => this.props.onChange('ignoreBackgroundClick')}
+          />{' '}
+          ignoreBackgroundClick{' '}
+          {this.props.ignoreBackgroundClick ? 'enabled' : 'disabled'}
+        </div>
+        <div>
+          <Toggle
+            checked={this.props.blockBackground}
+            onChange={() => this.props.onChange('blockBackground')}
+          />{' '}
+          blockBackground {this.props.blockBackground ? 'enabled' : 'disabled'}
+        </div>
+        <div>
+          <Toggle
+            checked={this.props.withContent}
+            onChange={() => this.props.onChange('withContent')}
+          />{' '}
+          withContent {this.props.withContent ? 'enabled' : 'disabled'}
+        </div>
+      </div>
+    );
+  }
+}
+
+class SidePageWithScrollableContent extends React.Component<{}, {}> {
   render() {
     return (
       <div style={{ width: '300px' }}>
@@ -114,7 +154,10 @@ class SidePageWithScrollableContent extends Component<{}, {}> {
   }
 }
 
-class SidePageWithInputInHeader extends Component<{}, { opened: boolean }> {
+class SidePageWithInputInHeader extends React.Component<
+  {},
+  { opened: boolean }
+> {
   state = {
     opened: false
   };
@@ -158,7 +201,7 @@ class SidePageWithInputInHeader extends Component<{}, { opened: boolean }> {
   };
 }
 
-class SidePageOverAnotherSidePage extends Component<{}, *> {
+class SidePageOverAnotherSidePage extends React.Component<{}, *> {
   render() {
     return (
       <Sample
@@ -172,7 +215,7 @@ class SidePageOverAnotherSidePage extends Component<{}, *> {
   }
 }
 
-class SidePageWithCloseConfiguration extends Component<
+class SidePageWithCloseConfiguration extends React.Component<
   {},
   {
     ignoreBackgroundClick: boolean,
@@ -196,69 +239,54 @@ class SidePageWithCloseConfiguration extends Component<
           blockBackground={this.state.blockBackground}
           withContent={this.state.withContent}
         />
-        <div>
-          <Toggle
-            checked={this.state.ignoreBackgroundClick}
-            onChange={() =>
-              this.setState(({ ignoreBackgroundClick }) => ({
-                ignoreBackgroundClick: !ignoreBackgroundClick
-              }))
-            }
-          />{' '}
-          ignoreBackgroundClick{' '}
-          {this.state.ignoreBackgroundClick ? 'enabled' : 'disabled'}
-        </div>
-        <div>
-          <Toggle
-            checked={this.state.blockBackground}
-            onChange={() =>
-              this.setState(({ blockBackground }) => ({
-                blockBackground: !blockBackground
-              }))
-            }
-          />{' '}
-          blockBackground {this.state.blockBackground ? 'enabled' : 'disabled'}
-        </div>
-        <div>
-          <Toggle
-            checked={this.state.withContent}
-            onChange={() =>
-              this.setState(({ withContent }) => ({
-                withContent: !withContent
-              }))
-            }
-          />{' '}
-          withContent {this.state.withContent ? 'enabled' : 'disabled'}
-        </div>
+        <SampleConfigurator
+          onChange={name => this.setState(state => ({ [name]: !state[name] }))}
+          ignoreBackgroundClick={this.state.ignoreBackgroundClick}
+          blockBackground={this.state.blockBackground}
+          withContent={this.state.withContent}
+        />
       </div>
     );
   }
 }
 
-class SidePageWithModalInside extends Component<
+class SidePageWithModalInside extends React.Component<
   {},
   {
     isModalOpened: boolean,
-    isSidePageOpened: boolean
+    ignoreBackgroundClick: boolean,
+    blockBackground: boolean,
+    withContent: boolean
   }
 > {
-  constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      isModalOpened: false,
-      isSidePageOpened: false
-    };
-  }
+  state = {
+    isModalOpened: false,
+    ignoreBackgroundClick: true,
+    blockBackground: false,
+    withContent: false
+  };
 
   render() {
     return (
       <div>
         {this.state.isModalOpened && this.renderModal()}
-        {this.state.isSidePageOpened && this.renderSidePage()}
-        <Button onClick={() => this.setState({ isSidePageOpened: true })}>
-          Открыть sidepage
-        </Button>
+        <Sample
+          current={1}
+          ignoreBackgroundClick={this.state.ignoreBackgroundClick}
+          blockBackground={this.state.blockBackground}
+        >
+          <Button onClick={() => this.setState({ isModalOpened: true })}>
+            Открыть modal
+          </Button>
+          <SampleConfigurator
+            onChange={name =>
+              this.setState(state => ({ [name]: !state[name] }))
+            }
+            ignoreBackgroundClick={this.state.ignoreBackgroundClick}
+            blockBackground={this.state.blockBackground}
+            withContent={true}
+          />
+        </Sample>
         {textSample}
         {textSample}
       </div>
@@ -272,19 +300,6 @@ class SidePageWithModalInside extends Component<
     >
       <Modal.Header>Хедер</Modal.Header>
     </Modal>
-  );
-
-  renderSidePage = () => (
-    <SidePage
-      onClose={() => this.setState({ isSidePageOpened: false })}
-      ignoreBackgroundClick
-    >
-      <SidePage.Body>
-        <Button onClick={() => this.setState({ isModalOpened: true })}>
-          Открыть modal
-        </Button>
-      </SidePage.Body>
-    </SidePage>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@storybook/react": "3.3.15",
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.40",
+    "@types/fbemitter": "^2.0.32",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.4.1",


### PR DESCRIPTION
До этого момента Modal и SidePage создавали каждый свой стек. В некоторых сценариях нужно, чтобы они находились в одном стеке, например, нажате кнопки Esc должно закрывать только верхний сайдпейдж или модалку, а не сразу две.
Вот списочек кейсов, которые нужно было поддержать при смердживании стеков:

- Клик на фон. Клик на фон должен обрабатывать только верхний элемент стека. Остальные его игнорируют.
- Сдвиг сайдпейджа влево на 20 пикслей. Если открыто больше одного сайдпеджа, самый первый сайдпейдж должен сдвинуться влево на 20 пикселей. Он не должен сдвигаться, когда по верх него открылась модалка.
- Тени у сайпейджей. Начиная со второго, сайдпеджи открываются друг над другом. Это суммирует тень, которую они отбрасывают. Поэтому тень должна появляться только у первого (который сдвигается) и у второго сайдпейджа. История с модалкой из пункта выше тоже не должна влиять на логику теней.
- Затенение фона. У модалок фон затеняет самая последняя модалка. У сайдпейджей все наоборт - самый первый. Это получилось сделать просто, но сайдпейдж не нужно рендерить над модалкой :D

Дополнительные фиксы, которые случайно (или нет) почининилсь:

- Сайпейдж закрывается на Esc. Самый верхний естественно.
- Модалка в componentWillUnmount удаляет свой eventListener на 'keydown'