### PR TITLE
fix-font-size-leak Переопределяем font-size в корне компонента Checkbox

### DIFF
--- a/components/Checkbox/Checkbox.flat.less
+++ b/components/Checkbox/Checkbox.flat.less
@@ -1,5 +1,5 @@
-@import "../variables.less";
-@import "../variables.flat.less";
+@import '../variables.less';
+@import '../variables.flat.less';
 
 :local {
   .root {
@@ -10,6 +10,7 @@
     -moz-user-select: none;
     -ms-user-select: none;
     line-height: 20px;
+    font-size: 14px;
 
     &.withoutCaption .box {
       position: relative;

--- a/components/Checkbox/Checkbox.less
+++ b/components/Checkbox/Checkbox.less
@@ -7,6 +7,7 @@
     position: relative;
     user-select: none;
     line-height: 20px;
+    font-size: 14px;
 
     &.withoutCaption .box {
       position: relative;


### PR DESCRIPTION
Если у родительского элемента переопределен, например `font-size: 20px;`. Стиль текет вниз на чекбокс и ломает отображение иконки.