### PR TITLE
default box-sizing value for some elements

### DIFF
--- a/components/Menu/Menu.less
+++ b/components/Menu/Menu.less
@@ -5,6 +5,7 @@
     background: @bg-default;
     overflow: auto;
     padding: 5px 0;
+    box-sizing: content-box;
   }
 
   .shadow {

--- a/components/Tooltip/Tooltip.less
+++ b/components/Tooltip/Tooltip.less
@@ -33,6 +33,7 @@
     height: 11px;
     white-space: nowrap;
     line-height: 10px;
+    box-sizing: content-box;
   }
 
   .cross:hover {


### PR DESCRIPTION
Используем retail-ui в виджете. На странице, куда его встраиваем заданы стили через звездочку 
* {
    box-sizing: border-box;
    margin: 0;
    padding: 0;
}
box-sizing: border-box; ломает верстку в Tooltip и ComboBox. Поэтому для некоторых элементов пришлось добавить значение по умолчанию.