### PR TITLE
Radio.d.ts fix

### DIFF
--- a/components/Radio/Radio.d.ts
+++ b/components/Radio/Radio.d.ts
@@ -29,7 +29,7 @@ export interface RadioProps<T> {
   onMouseOver?: (event: SyntheticRadioEvent<T>) => void;
 }
 
-export default class RadioGroup<Value = any> extends React.Component<
+export default class Radio<Value = any> extends React.Component<
   RadioProps<Value>
 > {
   focus(): void;


### PR DESCRIPTION
Make default export to match component name. Fixes TSLint warning 'match-default-export-name'.