### PR TITLE
Cange display to inline

### DIFF
--- a/components/Hint/Hint.js
+++ b/components/Hint/Hint.js
@@ -102,7 +102,7 @@ export default class Hint extends React.Component<Props, State> {
 
   render() {
     return (
-      <span ref={this._ref} style={{ display: 'inline-block' }}>
+      <span ref={this._ref} style={{ display: 'inline' }}>
         <span
           onMouseEnter={this._handleMouseEnter}
           onMouseLeave={this._handleMouseLeave}


### PR DESCRIPTION
При обертке элемента с шириной 100% хинтом, элемент схлопывается по ширине. Например, проявляется на combobox'e.