### PR TITLE
fix(Tab): исправлено попадание лишнего пропа в разметку

### DIFF
--- a/packages/retail-ui/components/Tabs/Tab.tsx
+++ b/packages/retail-ui/components/Tabs/Tab.tsx
@@ -157,6 +157,7 @@ class Tab extends React.Component<TabProps, TabState> {
       warning,
       success,
       primary,
+      component,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
- 'component' не попадает в в рендер
- Fixed #605