### PR TITLE
feat(retail-ui Calendar): открывается ближайший доступный месяц

### DIFF
--- a/packages/retail-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/retail-ui/components/DatePicker/DatePicker.tsx
@@ -81,7 +81,7 @@ class DatePicker extends React.Component<
     /**
      * Строка формата `dd.mm.yyyy`
      */
-    value: PropTypes.string.isRequired,
+    value: PropTypes.string,
 
     warning: PropTypes.bool,
 

--- a/packages/retail-ui/components/DatePicker/Picker.tsx
+++ b/packages/retail-ui/components/DatePicker/Picker.tsx
@@ -6,6 +6,7 @@ import { formatDate } from './DatePickerHelpers';
 
 import styles = require('./Picker.less');
 import { Nullable } from '../../typings/utility-types';
+import { isLess, isGreater } from '../Calendar/CalendarDateShape';
 
 interface Props {
   maxDate?: CalendarDateShape;
@@ -37,7 +38,7 @@ export default class Picker extends React.Component<Props, State> {
     super(props);
     const today = getTodayCalendarDate();
     this.state = {
-      date: this.props.value || today,
+      date: this.getInitialDate(today),
       today
     };
   }
@@ -95,5 +96,21 @@ export default class Picker extends React.Component<Props, State> {
       const { month, year } = today;
       this._calendar.scrollToMonth(month, year);
     }
+  };
+
+  private getInitialDate = (today: CalendarDateShape) => {
+    if (this.props.value) {
+      return this.props.value;
+    }
+
+    if (this.props.minDate && isLess(today, this.props.minDate)) {
+      return this.props.minDate;
+    }
+
+    if (this.props.maxDate && isGreater(today, this.props.maxDate)) {
+      return this.props.maxDate;
+    }
+
+    return today;
   };
 }

--- a/packages/retail-ui/components/DatePicker/__tests__/DatePicker-test.tsx
+++ b/packages/retail-ui/components/DatePicker/__tests__/DatePicker-test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import DatePicker, { DatePickerProps } from '../DatePicker';
 import { mount } from 'enzyme';
+import Calendar from '../../Calendar';
 
 const handleChange = () => undefined;
 const renderDatePicker = (props?: Partial<DatePickerProps<string>>) =>
@@ -30,5 +31,31 @@ describe('DatePicker', () => {
     );
     expect(yearSelect.prop('minValue')).toEqual(2017);
     expect(yearSelect.prop('maxValue')).toEqual(2020);
+  });
+
+  it('correctly initial month/year with min date', () => {
+    const datePicker = renderDatePicker({
+      minDate: '21.01.2099'
+    });
+
+    datePicker.setState({ opened: true });
+
+    const calendar = datePicker.find(Calendar);
+
+    expect(calendar.prop('initialMonth')).toBe(0);
+    expect(calendar.prop('initialYear')).toBe(2099);
+  });
+
+  it('correctly initial month/year with max date', () => {
+    const datePicker = renderDatePicker({
+      maxDate: '15.11.1959'
+    });
+
+    datePicker.setState({ opened: true });
+
+    const calendar = datePicker.find(Calendar);
+
+    expect(calendar.prop('initialMonth')).toBe(10);
+    expect(calendar.prop('initialYear')).toBe(1959);
   });
 });


### PR DESCRIPTION
- Если передана минимальная или максимальная дата, календарь открывается на ближайшем к сегодняшнему дню доступном месяце
- Испрвлены PropTypes, не позволяющие передать null в value
- Closed #658