### PR TITLE
docs(reatil-ui): tune styleguidist config

### DIFF
--- a/packages/retail-ui/components/Kebab/README.md
+++ b/packages/retail-ui/components/Kebab/README.md
@@ -1,8 +1,4 @@
 ```jsx
-const { default: Gapped } = require('../Gapped');
-const { default: MenuItem } = require('../MenuItem');
-const { default: Toast } = require('../Toast');
-
 let style = {
   alignItems: 'center',
   background: 'white',

--- a/packages/retail-ui/styleguide.config.js
+++ b/packages/retail-ui/styleguide.config.js
@@ -126,9 +126,6 @@ const styles = {
 };
 
 const webpackConfig = {
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.jsx']
-  },
   module: {
     rules: [
       {
@@ -194,6 +191,10 @@ module.exports = {
     return parseJsComponent(...rest);
   },
   webpackConfig,
+  dangerouslyUpdateWebpackConfig: config => {
+    config.resolve.extensions = ['.ts', '.tsx', '.js', '.jsx', '.json'];
+    return config;
+  },
   version: libraryVersion,
   ribbon: {
     url: 'https://github.com/skbkontur/retail-ui'


### PR DESCRIPTION
Лечит проблему при которой **styleguidist** в первую очередь использует файлы с расширением `.js`. Для нас важно, чтобы первыми в приоритете были `.ts, .tsx` файлы. Иначе возникали проблемы, что в бандж документации могли попасть неактуальные компоненты.

По умолчанию, **styleguidist** вмерживает `webpackConfig` при помощи утилитки [webpack-merge](https://github.com/survivejs/webpack-merge). Из-за этого свойство `resolve.extensions` не подменялось, а конкатилось к существующему. Для его замены заиспользован параметр `dangerouslyUpdateWebpackConfig`
