### PR TITLE
fix(Textarea): fix % width

### DIFF
--- a/packages/retail-ui/components/Textarea/Textarea.flat.less
+++ b/packages/retail-ui/components/Textarea/Textarea.flat.less
@@ -5,8 +5,6 @@
   .root {
     position: relative;
     display: inline-block;
-    max-width: 100%;
-    width: 250px;
   }
 
   .textarea {
@@ -20,6 +18,7 @@
     padding: 8px;
     vertical-align: middle;
     width: 100%;
+    max-width: 100%;
     -webkit-appearance: none;
     transition: height 0.2s ease-out;
     background-clip: padding-box;

--- a/packages/retail-ui/components/Textarea/Textarea.less
+++ b/packages/retail-ui/components/Textarea/Textarea.less
@@ -4,7 +4,6 @@
   .root {
     position: relative;
     display: inline-block;
-    max-width: 100%;
   }
 
   .textarea {

--- a/packages/retail-ui/components/Textarea/Textarea.tsx
+++ b/packages/retail-ui/components/Textarea/Textarea.tsx
@@ -205,7 +205,10 @@ class Textarea extends React.Component<TextareaProps, TextareaState> {
       onMouseUp,
       onMouseDown,
       onClick,
-      onDoubleClick
+      onDoubleClick,
+      style: {
+        width
+      }
     };
 
     const textareaClassNames = classNames({
@@ -215,8 +218,7 @@ class Textarea extends React.Component<TextareaProps, TextareaState> {
     });
 
     const textAreaStyle = {
-      resize: autoResize ? 'none' : resize,
-      width
+      resize: autoResize ? 'none' : resize
     };
 
     let placeholder = null;


### PR DESCRIPTION
- Теперь ширина передается врапперу
- У самой `textarea` в стилях `width: 100%;`  и `max-width: 100%;`
- Стили поправлены в дефолтной и flat-темах
- Fixed #724 