### PR TITLE
(WIP) Fix Tooltip

### DIFF
--- a/packages/retail-ui/components/Tooltip/__stories__/Tooltip.stories.tsx
+++ b/packages/retail-ui/components/Tooltip/__stories__/Tooltip.stories.tsx
@@ -5,6 +5,7 @@ import Tooltip, { TooltipTrigger, TooltipProps } from '../Tooltip';
 import Button from '../../Button';
 import { PopupPosition } from '../../Popup';
 import { createPropsGetter } from '../../internal/createPropsGetter';
+import Textarea from '../../Textarea';
 
 interface TestTooltipProps {
   pos?: PopupPosition;
@@ -140,6 +141,38 @@ storiesOf('Tooltip', module)
         I'm inline-block with paddings
       </span>
     </TestTooltip>
+  ))
+  .add('tooltip with 50% width element', () => (
+    <div style={{ width: '500px' }}>
+      <Tooltip
+        trigger="opened"
+        pos="bottom center"
+        render={() => '50% width content'}
+      >
+        <Button width="50%">50% width content</Button>
+      </Tooltip>
+    </div>
+  ))
+  .add('tooltip with multiline element', () => (
+    <div style={{ width: '500px' }}>
+      <Tooltip trigger="opened" pos="bottom center" render={() => 'Textarea'}>
+        <Textarea rows={5} width="50%" />
+      </Tooltip>
+    </div>
+  ))
+  .add('tooltip with multiple inline elements', () => (
+    <div style={{ width: '500px' }}>
+      <Tooltip
+        trigger="opened"
+        pos="bottom center"
+        render={() => '50% width content'}
+      >
+        <span style={{ width: '100%', display: 'inline-block' }}>
+          <Button width="50%">50% width content</Button>
+          <Button width="50%">50% width content</Button>
+        </span>
+      </Tooltip>
+    </div>
   ));
 
 interface MyCustomTooltipState {


### PR DESCRIPTION
Короче. Я думаю что есть смысл откатить фикс #721, который за собой тащит кучу других проблем. В частности таких как:
- Невозможность задавать ширину элементов в процентах, обернутых в тултип #741 и #745 
- Этот фикс включает в себя обход проверки React.Children.only, ломает вложенные тултипы

Те же проблемы есть например в Hint'е

Есть ещё один вариант решения этой проблемы к findDOMNode добавить поиск всех соседей и подписываться на события от них. Но кажется, что тоже самое надо делать и в RenderLayer и возможно в других компонентах. И это ещё не факт, что порталы, которые сейчас используются будут работать с этим корректно, особенно учитывая то что мы поддерживаем реакт 0.14+.