### PR TITLE
docs(retail-ui): почищена дока в styleguidist

### DIFF
--- a/packages/retail-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/retail-ui/components/Autocomplete/Autocomplete.tsx
@@ -11,16 +11,28 @@ import { createPropsGetter } from '../internal/createPropsGetter';
 import { Nullable } from '../../typings/utility-types';
 
 export interface AutocompleteProps extends InputProps {
-  renderItem?: (item: string) => React.ReactNode;
+  /** Функция отрисовки элемента меню */
+  renderItem: (item: string) => React.ReactNode;
+  /** Промис, резолвящий элементы меню */
   source?: string[] | ((patter: string) => Promise<string[]>);
-  disablePortal?: boolean;
-  hasShadow?: boolean;
-  menuAlign?: 'left' | 'right';
-  menuMaxHeight?: number | string;
+  /** Отключает использование портала  */
+  disablePortal: boolean;
+  /** Отрисовка тени у выпадающего меню */
+  hasShadow: boolean;
+  /** Выравнивание выпадающего меню */
+  menuAlign: 'left' | 'right';
+  /** Максимальная высота меню */
+  menuMaxHeight: number | string;
+  /** Ширина меню */
   menuWidth?: number | string;
-  preventWindowScroll?: boolean;
+  /** Отключить скролл окна, когда меню открыто */
+  preventWindowScroll: boolean;
+  /** onChange */
   onChange: (event: { target: { value: string } }, value: string) => void;
+  /** onBlur */
   onBlur?: () => void;
+  /** Размер инпута */
+  size: InputProps['size'];
 }
 
 export interface AutocomplpeteState {

--- a/packages/retail-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
+++ b/packages/retail-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
@@ -5,13 +5,13 @@ import Icon from '../../Icon';
 import * as Enzyme from 'enzyme';
 
 const render = (
-  props: AutocompleteProps
+  props: Partial<AutocompleteProps>
 ): Enzyme.ReactWrapper<AutocompleteProps> =>
-  Enzyme.mount(<Autocomplete {...props} />);
+  Enzyme.mount(<Autocomplete {...props as AutocompleteProps} />);
 
-const renderUnc = (props: AutocompleteProps) =>
+const renderUnc = (props: Partial<AutocompleteProps>) =>
   Enzyme.mount<AutocompleteProps>(
-    React.createElement(UncontrolledAutocomplete, props)
+    React.createElement(UncontrolledAutocomplete, props as AutocompleteProps)
   );
 
 describe('<Autocomplete />', () => {

--- a/packages/retail-ui/components/Center/Center.tsx
+++ b/packages/retail-ui/components/Center/Center.tsx
@@ -1,25 +1,31 @@
 import * as React from 'react';
 
 import styles = require('./Center.less');
+import { Override } from '../../typings/utility-types';
 
 export type HorizontalAlign = 'left' | 'center' | 'right';
 
-export interface CenterProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Горизонтальное выравнивание контента.
-   */
-  align?: HorizontalAlign;
+export type CenterProps = Override<
+  React.HTMLAttributes<HTMLDivElement>,
+  {
+    /**
+     * Горизонтальное выравнивание контента.
+     */
+    align?: HorizontalAlign;
 
-  style?: React.CSSProperties;
-
-  children?: React.ReactNode;
-}
+    /**
+     * **Используй с осторожностью!**
+     * Дополнительные стили
+     */
+    style?: React.CSSProperties;
+  }
+>;
 
 export interface CenterState {}
 
 /**
  * Контейнер для вертикального центрирования. В компонент можно передавать
- * свойства как в любой div.
+ * свойства как в любой *div* (кроме `className`)
  */
 export default class Center extends React.Component<CenterProps, CenterState> {
   public static defaultProps = {

--- a/packages/retail-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/retail-ui/components/Checkbox/Checkbox.tsx
@@ -33,12 +33,19 @@ function listenTabPresses() {
 export type CheckboxProps = Override<
   React.InputHTMLAttributes<HTMLInputElement>,
   {
+    /** Контент `label` */
     children?: React.ReactNode;
+    /** Состояние ошибки */
     error?: boolean;
+    /** Состояние Предупреждения */
     warning?: boolean;
+    /** Вызывается на label */
     onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
+    /** Вызывается на label */
     onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
+    /** Вызывается на label */
     onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
+    /** onChange */
     onChange?: (
       event: React.ChangeEvent<HTMLInputElement>,
       value: boolean
@@ -50,6 +57,9 @@ export interface CheckboxState {
   focusedByTab: boolean;
 }
 
+/**
+ * Все свойства, кроме перечисленных, `className` и `style` передаются в `input`.
+ */
 class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
   public static propTypes = {
     checked: PropTypes.bool,

--- a/packages/retail-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/retail-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -18,15 +18,19 @@ import { Nullable, Override } from '../../typings/utility-types';
 export type CurrencyInputProps = Override<
   InputProps,
   {
+    /** Значение */
     value: Nullable<number>;
+    /** Кол-во цифр после зяпятой */
     fractionDigits?: Nullable<number>;
+    /** Отрицательные значения */
     signed?: boolean;
+    /** onChange */
     onChange: (
       e: { target: { value: Nullable<number> } },
       value: Nullable<number>
     ) => void;
+    /** onSubmit */
     onSubmit?: () => void;
-    onFocus?: () => void;
   }
 >;
 
@@ -35,6 +39,10 @@ export interface CurrencyInputState {
   selection: Selection;
 }
 
+/**
+ * Поле для денежных сумм (и других числовых значений).
+ * Принимает любые свойства `Input`
+ */
 export default class CurrencyInput extends React.Component<
   CurrencyInputProps,
   CurrencyInputState
@@ -91,7 +99,13 @@ export default class CurrencyInput extends React.Component<
   }
 
   public render() {
-    const { fractionDigits, signed, onSubmit, ...rest } = this.props;
+    const {
+      fractionDigits,
+      signed,
+      onSubmit,
+      mainInGroup,
+      ...rest
+    } = this.props;
     const placeholder =
       this.props.placeholder == null
         ? CurrencyHelper.format(0, {
@@ -363,7 +377,7 @@ export default class CurrencyInput extends React.Component<
   private _handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
     this._focused = true;
     if (this.props.onFocus) {
-      this.props.onFocus();
+      this.props.onFocus(event);
     }
   };
 

--- a/packages/retail-ui/components/FxInput/FxInput.tsx
+++ b/packages/retail-ui/components/FxInput/FxInput.tsx
@@ -14,11 +14,17 @@ import { Override } from '../../typings/utility-types';
 export type FxInputProps = Override<
   CurrencyInputProps,
   {
+    /** Авто-режим */
     auto?: boolean;
+    /** Тип инпута */
     type?: 'currency' | InputProps['type'];
+    /** onRestore */
     onRestore?: () => void;
+    /** onChange */
     onChange: CurrencyInputProps['onChange'] | InputProps['onChange'];
+    /** Значение */
     value?: React.ReactText;
+    /** ref Input'а */
     refInput?: (element: CurrencyInput | Input | null) => void;
   }
 >;
@@ -28,6 +34,7 @@ export interface FxInputDefaultProps {
   type: FxInputProps['type'];
 }
 
+/** Принимает все свойства `Input`'a */
 class FxInput extends React.Component<FxInputProps> {
   public static propTypes = {
     auto: PropTypes.bool,
@@ -44,7 +51,7 @@ class FxInput extends React.Component<FxInputProps> {
   private getProps = createPropsGetter(FxInput.defaultProps);
 
   public render(): JSX.Element {
-    const { type, ...rest } = this.props;
+    const { type, onRestore, auto, ...rest } = this.props;
     const inputProps: {
       align: InputProps['align'];
       mainInGroup: boolean;
@@ -56,7 +63,7 @@ class FxInput extends React.Component<FxInputProps> {
 
     let button = null;
 
-    if (this.props.auto) {
+    if (auto) {
       inputProps.leftIcon = <Icon name="Function" />;
     } else {
       button = (

--- a/packages/retail-ui/components/Input/Input.tsx
+++ b/packages/retail-ui/components/Input/Input.tsx
@@ -26,27 +26,49 @@ export type InputType = 'password' | 'text';
 export type InputProps = Override<
   React.InputHTMLAttributes<HTMLInputElement>,
   {
+    /** Иконка слева */
     leftIcon?: React.ReactNode;
+    /** Иконка справа */
     rightIcon?: React.ReactNode;
+    /** Состояние ошибки */
     error?: boolean;
+    /** Состояние предупреждения */
     warning?: boolean;
+    /** Режим прозрачной рамки */
     borderless?: boolean;
+    /** Выравнивание текста */
     align?: InputAlign;
+    /** Паттерн маски */
     mask?: Nullable<string>;
+    /** Символ маски */
     maskChar?: Nullable<string>;
+    /** Показывать символы маски */
     alwaysShowMask?: boolean;
+    /** Размер */
     size?: InputSize;
+    /** onChange */
     onChange?: (
       event: React.ChangeEvent<HTMLInputElement>,
       value: string
     ) => void;
+    /** Вызывается на label */
     onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
+    /** Вызывается на label */
     onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
+    /** Вызывается на label */
     onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
+    /** Тип */
     type?: InputType;
+    /** Значение */
     value?: string;
     className?: undefined;
+    style?: undefined;
     capture?: boolean;
+    /**
+     * @deprecated
+     * Главный инпут в Group
+     */
+    mainInGroup?: boolean;
   }
 >;
 
@@ -55,6 +77,10 @@ export interface InputState {
   blinking: boolean;
 }
 
+/**
+ * Интерфес пропсов наследуется от `React.InputHTMLAttributes<HTMLInputElement>`.
+ *  Все пропсы кроме перечисленных, `className` и `style` передаются в `<input>`
+ */
 class Input extends React.Component<InputProps, InputState> {
   public static defaultProps: {
     size: InputSize;
@@ -158,6 +184,7 @@ class Input extends React.Component<InputProps, InputState> {
       className,
       size,
       placeholder,
+      mainInGroup,
       ...rest
     } = this.props;
     const labelProps = {

--- a/packages/retail-ui/components/Link/Link.tsx
+++ b/packages/retail-ui/components/Link/Link.tsx
@@ -9,6 +9,7 @@ import Icon, { IconName } from '../Icon';
 import styles = require('./Link.less');
 
 import { createPropsGetter } from '../internal/createPropsGetter';
+import { Override } from '../../typings/utility-types';
 
 const useClasses = {
   default: styles.useDefault,
@@ -31,20 +32,26 @@ function listenTabPresses() {
   }
 }
 
-export interface LinkProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  disabled?: boolean;
-  href?: string;
-  icon?: IconName | React.ReactElement<any>;
-  onClick?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
-  use?: 'default' | 'success' | 'danger' | 'grayed';
-  children?: React.ReactNode;
-  /** @ignore */
-  _button?: boolean;
-  /** @ignore */
-  _buttonOpened?: boolean;
-  tabIndex?: number;
-}
+export type LinkProps = Override<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  {
+    /** Неактивное состояние */
+    disabled?: boolean;
+    /** href */
+    href?: string;
+    /** Иконка */
+    icon?: IconName | React.ReactElement<any>;
+    /** Тип */
+    use?: 'default' | 'success' | 'danger' | 'grayed';
+    _button?: boolean;
+    _buttonOpened?: boolean;
+    tabIndex?: number;
+    className?: undefined;
+    style?: undefined;
+    /** onClick */
+    onClick?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
+  }
+>;
 
 export interface LinkState {
   focusedByTab: boolean;
@@ -52,7 +59,9 @@ export interface LinkState {
 
 /**
  * Стандартная ссылка.
- * Все свойства передаются в элемент *<a>*.
+ * Интерфес пропсов наследуется от `React.AnchorHTMLAttributes<HTMLAnchorElement>`.
+ * Все свойства передаются в элемент `<a>`.
+ * `className` и `style` не поддерживаются
  */
 class Link extends React.Component<LinkProps, LinkState> {
   public static __ADAPTER__: any;

--- a/packages/retail-ui/components/Radio/Radio.tsx
+++ b/packages/retail-ui/components/Radio/Radio.tsx
@@ -26,16 +26,27 @@ export interface SyntheticRadioEvent<T> {
 export type RadioProps<T> = Override<
   React.InputHTMLAttributes<HTMLInputElement>,
   {
+    /** Состояние ошибки */
     error?: boolean;
+    /** Состояние Предупреждения */
     warning?: boolean;
+    /** Состояние фокуса */
     focused?: boolean;
+    /** Состояние нажатия */
     pressed?: boolean;
+    /** Состояние hover */
     hovered?: boolean;
+    /** Состояние active */
     active?: boolean;
+    /** onChange */
     onChange?: (event: SyntheticRadioEvent<T>, value: T) => void;
+    /** onChange */
     onMouseEnter?: (event: SyntheticRadioEvent<T>) => void;
+    /** onChange */
     onMouseLeave?: (event: SyntheticRadioEvent<T>) => void;
+    /** onChange */
     onMouseOver?: (event: SyntheticRadioEvent<T>) => void;
+    /** Значение */
     value: T;
   }
 >;

--- a/packages/retail-ui/styleguide.config.js
+++ b/packages/retail-ui/styleguide.config.js
@@ -1,7 +1,27 @@
 const fs = require('fs');
 const path = require('path');
 const parseTsComponent = require('react-docgen-typescript').withCustomConfig(
-  './tsconfig.json'
+  './tsconfig.json',
+  {
+    propFilter: (prop, component) => {
+      const FILTERED_COMPONENTS = [
+        'Link',
+        'Input',
+        'Center',
+        'Autocomplete',
+        'Checkbox',
+        'CurrencyInput',
+        'FxInput',
+        'Radio'
+      ];
+
+      if (FILTERED_COMPONENTS.indexOf(component.name) > -1) {
+        return !!prop.description;
+      }
+
+      return true;
+    }
+  }
 ).parse;
 const parseJsComponent = require('react-docgen').parse;
 const libraryVersion = require('./package.json').version;


### PR DESCRIPTION
Сделал фильтрацию пропсов для документации средствами `react-docgen-typescript`.
Фильтруются все пропсы без описания компонентов:

- Autocomplete
- Center
- Checkbox
- CurrencyInput
- FxInput
- Input
- Link
- Radio