### PR TITLE
fix(ResizeDetector): удален `removeEventListener` :green_apple:

### DIFF
--- a/packages/retail-ui/components/internal/ResizeDetector/ResizeDetector.tsx
+++ b/packages/retail-ui/components/internal/ResizeDetector/ResizeDetector.tsx
@@ -16,12 +16,6 @@ export default class ResizeDetector extends React.Component<
     }
   }
 
-  public componentWillUnmount() {
-    if (this.iframeWindow) {
-      this.iframeWindow.removeEventListener('resize', this.handleResize);
-    }
-  }
-
   public render() {
     return (
       <div className={styles.root}>


### PR DESCRIPTION
`removeEventListener` ломал iphone 5s, поэтому убрали удаление слушателя.
Это не должно ни на что повлять, т.к. событие было повешено на `window`
iFrame'а который удалется при unmount'е