### PR TITLE
Dotnet core

### DIFF
--- a/packages/react-ui-testing/SeleniumTesting.sln
+++ b/packages/react-ui-testing/SeleniumTesting.sln
@@ -10,17 +10,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		DebugCore|Any CPU = DebugCore|Any CPU
 		Release|Any CPU = Release|Any CPU
+		ReleaseCore|Any CPU = ReleaseCore|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99A2553D-9B4E-410C-870B-665CADB13070}.DebugCore|Any CPU.ActiveCfg = DebugCore|Any CPU
+		{99A2553D-9B4E-410C-870B-665CADB13070}.DebugCore|Any CPU.Build.0 = DebugCore|Any CPU
+		{99A2553D-9B4E-410C-870B-665CADB13070}.ReleaseCore|Any CPU.ActiveCfg = ReleaseCore|Any CPU
+		{99A2553D-9B4E-410C-870B-665CADB13070}.ReleaseCore|Any CPU.Build.0 = ReleaseCore|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.DebugCore|Any CPU.ActiveCfg = DebugCore|Any CPU
+		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.DebugCore|Any CPU.Build.0 = DebugCore|Any CPU
+		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.ReleaseCore|Any CPU.ActiveCfg = ReleaseCore|Any CPU
+		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.ReleaseCore|Any CPU.Build.0 = ReleaseCore|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Kontur.ReactUI.SeleniumTesting</AssemblyName>
     <Authors>Kontur</Authors>
@@ -12,12 +12,23 @@
     <PackageLicenseUrl>https://github.com/skbkontur/react-ui-testing/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skbkontur/react-ui-testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skbkontur/react-ui-testing</RepositoryUrl>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <Configurations>Debug;Release;DebugCore;ReleaseCore</Configurations>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugCore|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseCore|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <OutputPath>..\Output</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -9,10 +9,10 @@
     <Version>2.0.5.0$(VersionSuffix)</Version>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net45</TargetFramework>
     <PackageLicenseUrl>https://github.com/skbkontur/react-ui-testing/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skbkontur/react-ui-testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skbkontur/react-ui-testing</RepositoryUrl>
+    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug\</OutputPath>
@@ -24,6 +24,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="10.0.0" />
     <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.1" />
     <PackageReference Include="Kontur.Selone" Version="0.0.4" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.1" />
     <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>SKBKontur.SeleniumTesting.Tests</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug\</OutputPath>
@@ -28,6 +28,6 @@
     <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Management" />
+    <Reference Include="System.Management" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Kontur.ReactUI.SeleniumTesting.Tests</AssemblyName>
     <Authors>Kontur</Authors>
@@ -7,12 +7,23 @@
     <RootNamespace>SKBKontur.SeleniumTesting.Tests</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <Configurations>Debug;Release;DebugCore;ReleaseCore</Configurations>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugCore|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseCore|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
> Before bringing existing .NET Framework code to a .NET Core project, we recommend you first add the Windows Compatibility Pack by installing the NuGet package Microsoft.Windows.Compatibility. This maximizes the number of APIs you have at your disposal.

https://blogs.msdn.microsoft.com/dotnet/2017/11/16/announcing-the-windows-compatibility-pack-for-net-core/