### PR TITLE
fix(HBVS): окончательно отремонтирован

### DIFF
--- a/packages/retail-ui/components/SidePage/__stories__/SidePage.stories.tsx
+++ b/packages/retail-ui/components/SidePage/__stories__/SidePage.stories.tsx
@@ -295,11 +295,7 @@ class SidePageWithModalInside extends React.Component<
     return (
       <div>
         {this.state.isModalOpened && this.renderModal()}
-        <Sample
-          current={1}
-          ignoreBackgroundClick={this.state.ignoreBackgroundClick}
-          blockBackground={this.state.blockBackground}
-        >
+        <Sample current={1} ignoreBackgroundClick={false} blockBackground>
           <Button onClick={() => this.setState({ isModalOpened: true })}>
             Открыть modal
           </Button>
@@ -385,6 +381,91 @@ class SimpleSidePage extends React.Component<{}, {}> {
   }
 }
 
+interface WithVariableContentState {
+  opened: boolean;
+  sidePageText: string[];
+  pageText: string[];
+}
+class WithVariableContent extends React.Component<
+  {},
+  WithVariableContentState
+> {
+  public state: WithVariableContentState = {
+    opened: false,
+    sidePageText: [],
+    pageText: []
+  };
+
+  public render() {
+    return (
+      <div>
+        {this.state.opened && this.renderSidePage()}
+        {this.state.pageText.map(() => (
+          <div style={{ height: '400px' }}>
+            A lotta people ask me where the fuck I've been at the last few
+            years.
+          </div>
+        ))}
+        <Button onClick={this.open}>Open</Button>
+      </div>
+    );
+  }
+
+  private renderSidePage = () => (
+    <SidePage onClose={this.close} blockBackground>
+      <SidePage.Header>Title</SidePage.Header>
+      <SidePage.Body>
+        <div
+          style={{
+            background: `repeating-linear-gradient(
+                          60deg,
+                          #fafafa,
+                          #fafafa 20px,
+                          #dfdede 20px,
+                          #dfdede 40px
+                        )`,
+            height: 600,
+            padding: '20px 0'
+          }}
+        >
+          <SidePage.Container>
+            <p>
+              A lotta people ask me where the fuck I've been at the last few
+              years.
+            </p>
+            {this.state.sidePageText.map((_item, index) => (
+              <div key={index} style={{ height: '400px' }}>
+                A lotta people ask me where the fuck I've been at the last few
+                years.
+              </div>
+            ))}
+          </SidePage.Container>
+        </div>
+      </SidePage.Body>
+      <SidePage.Footer panel>
+        <Button onClick={this.hendleAddSidePageClick}>Add sidePageText</Button>
+        <Button onClick={this.handleAddPageClick}>Add pageText</Button>
+      </SidePage.Footer>
+    </SidePage>
+  );
+
+  private hendleAddSidePageClick = () => {
+    this.setState(state => ({ sidePageText: [...state.sidePageText, 'text'] }));
+  };
+
+  private handleAddPageClick = () => {
+    this.setState(state => ({ pageText: [...state.pageText, 'text'] }));
+  };
+
+  private open = () => {
+    this.setState({ opened: true });
+  };
+
+  private close = () => {
+    this.setState({ opened: false });
+  };
+}
+
 storiesOf('SidePage', module)
   .add('With scrollable parent content', () => (
     <SidePageWithScrollableContent />
@@ -405,4 +486,5 @@ storiesOf('SidePage', module)
   .add('Open SidePage with left position', () => (
     <OpenSidePageWithLeftPosition />
   ))
-  .add('Simple', () => <SimpleSidePage />);
+  .add('Simple', () => <SimpleSidePage />)
+  .add('SidePage with variable content', () => <WithVariableContent />);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,7 +1613,7 @@ aws4@^1.2.1, aws4@^1.6.0, aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-babel-cli@^6.22.2:
+babel-cli@^6.22.2, babel-cli@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   integrity sha1-UCq1SHTX24itALiHoGODzgPQAvE=
@@ -2841,7 +2841,7 @@ babel-preset-react@6.16.0:
     babel-plugin-transform-react-jsx-self "^6.11.0"
     babel-plugin-transform-react-jsx-source "^6.3.13"
 
-babel-preset-react@^6.22.0, babel-preset-react@^6.24.1:
+babel-preset-react@^6.22.0, babel-preset-react@^6.23.0, babel-preset-react@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
   integrity sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=


### PR DESCRIPTION
После пересчета скролла на каждый `didUpdate` сломалась очистка добавленных стилей. Из-за этого страница не скроллилась после удаления компонента с `HBVS`.

- Добавлена очистка стилей перед пересчетом скролла
- Добавлена очистка на `willUnmount`
- Починен флаг `allowScrolling`, который давно ни на что не влиял
