### PR TITLE
fix(SidePage): fix blockBackground=false

### DIFF
--- a/packages/retail-ui/components/SidePage/SidePage.tsx
+++ b/packages/retail-ui/components/SidePage/SidePage.tsx
@@ -198,15 +198,16 @@ class SidePage extends React.Component<SidePageProps, SidePageState> {
         onScroll={LayoutEvents.emit}
         style={style}
       >
-        <HideBodyVerticalScroll allowScrolling={!blockBackground} />
-        {blockBackground && (
+        {blockBackground && [
+          <HideBodyVerticalScroll key="hbvs" />,
           <div
+            key="overlay"
             className={classNames(
               styles.background,
               this.state.hasBackground && styles.gray
             )}
           />
-        )}
+        ]}
       </ZIndex>
     );
   }

--- a/packages/retail-ui/components/SidePage/__stories__/SidePage.stories.tsx
+++ b/packages/retail-ui/components/SidePage/__stories__/SidePage.stories.tsx
@@ -487,4 +487,15 @@ storiesOf('SidePage', module)
     <OpenSidePageWithLeftPosition />
   ))
   .add('Simple', () => <SimpleSidePage />)
-  .add('SidePage with variable content', () => <WithVariableContent />);
+  .add('SidePage with variable content', () => <WithVariableContent />)
+  .add('With scrollable parent content and scrolling before open', () => (
+    <div style={{ width: '300px' }}>
+      {textSample}
+      {textSample}
+      {textSample}
+      {textSample}
+      <Sample total={1} current={1} ignoreBackgroundClick withContent />
+      {textSample}
+      {textSample}
+    </div>
+  ));


### PR DESCRIPTION
При `blockBackground === false`, `HideBodyVerticalScroll` не рэндерится.
Нет элемента - нет проблем.

Fix #822