### PR TITLE
fix(Sticky): вернули старое поведение с бесконечной рекурсией

### DIFF
--- a/packages/retail-ui/components/Sticky/Sticky.less
+++ b/packages/retail-ui/components/Sticky/Sticky.less
@@ -1,8 +1,4 @@
 :local {
-  .inner {
-    overflow: auto;
-  }
-
   .innerFixed {
     position: fixed;
     z-index: 100;

--- a/packages/retail-ui/components/Sticky/Sticky.tsx
+++ b/packages/retail-ui/components/Sticky/Sticky.tsx
@@ -15,11 +15,12 @@ export interface StickyProps {
   children?: React.ReactNode | ((fixed: boolean) => React.ReactNode);
 
   /**
-   * Вызывать `Maximum update depth exceeded error`, если у потомка определены марджины.
-   * Классическое поведение компонента, для тех кто использует отрицательные марджины внутри `Sticky`.
-   * @default true
+   *
+   * Если `false`, вызывает `Maximum update depth exceeded error` когда у потомка определены марджины.
+   * Если `true` - добавляет контейнеру `overflow: auto`, тем самым предотвращая схлопывание марджинов
+   * @default false
    */
-  allowMaximumUpdateDepthExceeded?: boolean;
+  allowChildWithMargins?: boolean;
 }
 
 export interface StickyState {
@@ -46,12 +47,12 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
     offset: PropTypes.number,
 
     side: PropTypes.oneOf(['top', 'bottom']).isRequired,
-    maximumUpdateDepthExceeded: PropTypes.bool
+    allowChildWithMargins: PropTypes.bool
   };
 
   public static defaultProps = {
     offset: 0,
-    maximumUpdateDepthExceeded: true
+    allowChildWithMargins: true
   };
 
   public state: StickyState = {
@@ -124,7 +125,7 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
       children = children(this.state.fixed);
     }
 
-    if (!this.props.allowMaximumUpdateDepthExceeded) {
+    if (this.props.allowChildWithMargins) {
       innerStyle.overflow = 'auto';
     }
 

--- a/packages/retail-ui/components/Sticky/Sticky.tsx
+++ b/packages/retail-ui/components/Sticky/Sticky.tsx
@@ -136,7 +136,7 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
             [styles.innerFixed]: this.state.fixed,
             [styles.innerStopped]: this.state.stopped
           })}
-          style={{ ...innerStyle }}
+          style={innerStyle}
           ref={this._refInner}
         >
           {children}

--- a/packages/retail-ui/components/Sticky/Sticky.tsx
+++ b/packages/retail-ui/components/Sticky/Sticky.tsx
@@ -13,6 +13,13 @@ export interface StickyProps {
   offset?: number;
   getStop?: () => Nullable<HTMLElement>;
   children?: React.ReactNode | ((fixed: boolean) => React.ReactNode);
+
+  /**
+   * Вызывать `Maximum update depth exceeded error`, если у потомка определены марджины.
+   * Классическое поведение компонента, для тех кто использует отрицательные марджины внутри `Sticky`.
+   * @default true
+   */
+  allowMaximumUpdateDepthExceeded?: boolean;
 }
 
 export interface StickyState {
@@ -38,11 +45,13 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
      */
     offset: PropTypes.number,
 
-    side: PropTypes.oneOf(['top', 'bottom']).isRequired
+    side: PropTypes.oneOf(['top', 'bottom']).isRequired,
+    maximumUpdateDepthExceeded: PropTypes.bool
   };
 
   public static defaultProps = {
-    offset: 0
+    offset: 0,
+    maximumUpdateDepthExceeded: true
   };
 
   public state: StickyState = {
@@ -115,14 +124,18 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
       children = children(this.state.fixed);
     }
 
+    if (!this.props.allowMaximumUpdateDepthExceeded) {
+      innerStyle.overflow = 'auto';
+    }
+
     return (
       <div style={wrapperStyle} ref={this._refWrapper}>
         <div
-          className={classNames(styles.inner, {
+          className={classNames({
             [styles.innerFixed]: this.state.fixed,
             [styles.innerStopped]: this.state.stopped
           })}
-          style={innerStyle}
+          style={{ ...innerStyle }}
           ref={this._refInner}
         >
           {children}


### PR DESCRIPTION
Добавлен флаг `allowMaximumUpdateDepthExceeded`