### PR TITLE
feat[Paging]: управление клавиатурой без фокуса

### DIFF
--- a/packages/retail-ui/components/Paging/NavigationHelper.tsx
+++ b/packages/retail-ui/components/Paging/NavigationHelper.tsx
@@ -3,7 +3,9 @@ import { Nullable } from '../../typings/utility-types';
 
 export interface KeyDescriptionType {
   name: string;
-  checkPressed: (event: React.KeyboardEvent<HTMLElement>) => boolean;
+  checkPressed: (
+    event: React.KeyboardEvent<HTMLElement> | KeyboardEvent
+  ) => boolean;
 }
 
 let keyDescription: Nullable<KeyDescriptionType> = null;
@@ -15,18 +17,22 @@ const createKeyDescription = () =>
   navigator.platform.includes('Mac')
     ? {
         name: 'Alt',
-        checkPressed: (event: React.KeyboardEvent<HTMLElement>) => event.altKey
+        checkPressed: (
+          event: React.KeyboardEvent<HTMLElement> | KeyboardEvent
+        ) => event.altKey
       }
     : {
         name: 'Ctrl',
-        checkPressed: (event: React.KeyboardEvent<HTMLElement>) => event.ctrlKey
+        checkPressed: (
+          event: React.KeyboardEvent<HTMLElement> | KeyboardEvent
+        ) => event.ctrlKey
       };
 
 export default {
   getKeyName() {
     return getKeyDescription().name;
   },
-  checkKeyPressed(event: React.KeyboardEvent<HTMLElement>) {
+  checkKeyPressed(event: KeyboardEvent | React.KeyboardEvent<HTMLElement>) {
     return getKeyDescription().checkPressed(event);
   }
 };

--- a/packages/retail-ui/components/Paging/Paging.less
+++ b/packages/retail-ui/components/Paging/Paging.less
@@ -93,4 +93,8 @@
       background: #e8e8e8;
     }
   }
+
+  .pageLinkHintPlaceHolder {
+    height: 15px;
+  }
 }

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -39,7 +39,7 @@ export interface PagingProps {
    * **Paging** с withoutNavigationHint === true, то обработчик keyDown будет вызываться
    * на каждом из них. Такие случаи лучше обрабатывать отдельно.
    */
-  useGlobalListener?: boolean;
+  useGlobalListener: boolean;
 }
 
 export interface PagingState {
@@ -55,7 +55,8 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     component: ({ className, onClick, children }: any) => (
       <span className={className} onClick={onClick} children={children} />
     ),
-    strings: { forward: 'Дальше' }
+    strings: { forward: 'Дальше' },
+    useGlobalListener: false
   };
 
   public static propTypes = {};
@@ -69,7 +70,7 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
   public state: PagingState = {
     focusedByTab: false,
     focusedItem: null,
-    keybordControl: this.props.useGlobalListener || false
+    keybordControl: this.props.useGlobalListener
   };
 
   private addedGlobalListener: boolean = false;

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -39,7 +39,7 @@ export interface PagingProps {
    * **Paging** с withoutNavigationHint === true, то обработчик keyDown будет вызываться
    * на каждом из них. Такие случаи лучше обрабатывать отдельно.
    */
-  globalListener?: boolean;
+  useGlobalListener?: boolean;
 }
 
 export interface PagingState {
@@ -69,7 +69,7 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
   public state: PagingState = {
     focusedByTab: false,
     focusedItem: null,
-    keybordControl: this.props.globalListener || false
+    keybordControl: this.props.useGlobalListener || false
   };
 
   private addedGlobalListener: boolean = false;
@@ -77,17 +77,17 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
   public componentDidMount() {
     listenTabPresses();
 
-    if (this.props.globalListener) {
+    if (this.props.useGlobalListener) {
       this.addGlobalListener();
     }
   }
 
   public componentDidUpdate(prevProps: PagingProps) {
-    if (!prevProps.globalListener && this.props.globalListener) {
+    if (!prevProps.useGlobalListener && this.props.useGlobalListener) {
       this.addGlobalListener();
     }
 
-    if (prevProps.globalListener && !this.props.globalListener) {
+    if (prevProps.useGlobalListener && !this.props.useGlobalListener) {
       this.removeGlobalListener();
     }
   }
@@ -267,7 +267,7 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
   private handleBlur = () => {
     this.setState({
       focusedByTab: false,
-      keybordControl: this.props.globalListener || false
+      keybordControl: this.props.useGlobalListener || false
     });
   };
 

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -72,32 +72,32 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
       <span
         tabIndex={0}
         className={styles.paging}
-        onKeyDown={this._handleKeyDown}
+        onKeyDown={this.handleKeyDown}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-        onMouseDown={this._handleMouseDown}
+        onMouseDown={this.handleMouseDown}
       >
-        {this.getItems().map(this._renderItem)}
+        {this.getItems().map(this.renderItem)}
       </span>
     );
   }
 
-  private _renderItem = (item: ItemType, index: number) => {
+  private renderItem = (item: ItemType, index: number) => {
     const focused = this.getFocusedItem() === item;
     switch (item) {
       case '.':
         const key = `dots${index < 5 ? 'Left' : 'Right'}`;
-        return this._renderDots(key);
+        return this.renderDots(key);
       case 'forward':
-        const disabled = this._isItemDisabled(item);
-        return this._renderForwardLink(disabled, focused);
+        const disabled = this.isItemDisabled(item);
+        return this.renderForwardLink(disabled, focused);
       default:
         const active = this.props.activePage === item;
-        return this._renderPageLink(item, active, focused);
+        return this.renderPageLink(item, active, focused);
     }
   };
 
-  private _renderDots = (key: string) => {
+  private renderDots = (key: string) => {
     return (
       <span key={key} className={styles.dots}>
         {'...'}
@@ -105,7 +105,7 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     );
   };
 
-  private _renderForwardLink = (
+  private renderForwardLink = (
     disabled: boolean,
     focused: boolean
   ): JSX.Element => {
@@ -124,7 +124,7 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
         key={'forward'}
         active={false}
         className={classes}
-        onClick={disabled ? noop : this._goForward}
+        onClick={disabled ? noop : this.goForward}
         tabIndex={-1}
         pageNumber={'forward' as 'forward'}
       >
@@ -136,7 +136,7 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     );
   };
 
-  private _renderPageLink = (
+  private renderPageLink = (
     pageNumber: number,
     active: boolean,
     focused: boolean
@@ -156,20 +156,20 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
           active={active}
           className={classes}
           // tslint:disable-next-line:jsx-no-lambda
-          onClick={() => this._goToPage(pageNumber)}
+          onClick={() => this.goToPage(pageNumber)}
           tabIndex={-1}
           pageNumber={pageNumber}
         >
           {pageNumber}
         </Component>
-        {shouldRenderHint && this._renderNavigationHint()}
+        {shouldRenderHint && this.renderNavigationHint()}
       </span>
     );
   };
 
-  private _renderNavigationHint = () => {
-    const canGoBackward = this._canGoBackward();
-    const canGoForward = this._canGoForward();
+  private renderNavigationHint = () => {
+    const canGoBackward = this.canGoBackward();
+    const canGoForward = this.canGoForward();
 
     return (
       (canGoBackward || canGoForward) && (
@@ -182,34 +182,34 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     );
   };
 
-  private _handleMouseDown = () => {
+  private handleMouseDown = () => {
     this.setState({ focusedByTab: false, focusedItem: null });
   };
 
-  private _handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
+  private handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     if (NavigationHelper.checkKeyPressed(event) && event.key === 'ArrowLeft') {
       event.preventDefault();
-      this.setState({ focusedItem: null }, this._goBackward);
+      this.setState({ focusedItem: null }, this.goBackward);
       return;
     }
     if (NavigationHelper.checkKeyPressed(event) && event.key === 'ArrowRight') {
       event.preventDefault();
-      this.setState({ focusedItem: null }, this._goForward);
+      this.setState({ focusedItem: null }, this.goForward);
       return;
     }
     if (event.key === 'ArrowLeft') {
       event.preventDefault();
-      this.setState({ focusedByTab: true }, this._moveFocusLeft);
+      this.setState({ focusedByTab: true }, this.moveFocusLeft);
       return;
     }
     if (event.key === 'ArrowRight') {
       event.preventDefault();
-      this.setState({ focusedByTab: true }, this._moveFocusRight);
+      this.setState({ focusedByTab: true }, this.moveFocusRight);
       return;
     }
     if (event.key === 'Enter') {
       event.preventDefault();
-      this._executeItemAction(this.getFocusedItem());
+      this.executeItemAction(this.getFocusedItem());
       return;
     }
   };
@@ -260,38 +260,38 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
   };
 
   private isItemFocusable = (item: ItemType) => {
-    return !this._isItemDisabled(item);
+    return !this.isItemDisabled(item);
   };
 
-  private _isItemDisabled = (item: ItemType) => {
+  private isItemDisabled = (item: ItemType) => {
     switch (item) {
       case '.':
         return true;
       case 'forward':
-        return !this._canGoForward();
+        return !this.canGoForward();
       default:
         return false;
     }
   };
 
-  private _executeItemAction = (item: Nullable<ItemType>) => {
+  private executeItemAction = (item: Nullable<ItemType>) => {
     if (item === 'forward') {
-      this._goForward();
+      this.goForward();
     }
     if (typeof item === 'number') {
-      this._goToPage(item);
+      this.goToPage(item);
     }
   };
 
-  private _moveFocusLeft = () => {
-    this._moveFocus(-1);
+  private moveFocusLeft = () => {
+    this.moveFocus(-1);
   };
 
-  private _moveFocusRight = () => {
-    this._moveFocus(1);
+  private moveFocusRight = () => {
+    this.moveFocus(1);
   };
 
-  private _moveFocus = (step: number) => {
+  private moveFocus = (step: number) => {
     const focusedItem = this.getFocusedItem();
     const items = this.getItems();
     let index = items.findIndex(x => x === focusedItem);
@@ -301,23 +301,23 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     this.setState({ focusedItem: items[index] });
   };
 
-  private _canGoBackward = (): boolean => {
+  private canGoBackward = (): boolean => {
     return this.props.activePage > 1;
   };
 
-  private _canGoForward = (): boolean => {
+  private canGoForward = (): boolean => {
     return this.props.activePage < this.props.pagesCount;
   };
 
-  private _goBackward = () => {
-    this._goToPage(this.props.activePage - 1);
+  private goBackward = () => {
+    this.goToPage(this.props.activePage - 1);
   };
 
-  private _goForward = () => {
-    this._goToPage(this.props.activePage + 1);
+  private goForward = () => {
+    this.goToPage(this.props.activePage + 1);
   };
 
-  private _goToPage = (pageNumber: number) => {
+  private goToPage = (pageNumber: number) => {
     if (
       1 <= pageNumber &&
       pageNumber !== this.props.activePage &&

--- a/packages/retail-ui/components/Paging/README.md
+++ b/packages/retail-ui/components/Paging/README.md
@@ -1,3 +1,11 @@
+Управление с клавиатуры работает в двух вариантах:
+
+- **useGlobalListener === true** слушатель keydown событий на document, если на стринице несколько компонентов Paging,
+  обработчик будет срабатывать на каждом
+- **useGlobalListener === false** обработка нажатия клавиш будет работать только когда компонент в фокусе.
+
+Навигационные подсказки появляются когда доступно управлнеие с клавиатуры и `withoutNavigationHint != true`
+
 ```js
 class Paginator3000 extends React.Component {
   constructor() {

--- a/packages/retail-ui/components/Paging/__stories__/Paging.stories.tsx
+++ b/packages/retail-ui/components/Paging/__stories__/Paging.stories.tsx
@@ -45,7 +45,7 @@ class PagingWithState extends Component<any, any> {
         <Paging
           activePage={this.state.activePage}
           pagesCount={this.props.pagesCount}
-          globalListener={this.props.globalListener}
+          useGlobalListener={this.props.useGlobalListener}
           onPageChange={this._handlePageChange}
         />
       </div>
@@ -120,5 +120,5 @@ storiesOf('Paging', module)
     <PagingWithCustomComponent pagesCount={12} />
   ))
   .add('Paging with global listener', () => (
-    <PagingWithState globalListener pagesCount={12} />
+    <PagingWithState useGlobalListener pagesCount={12} />
   ));

--- a/packages/retail-ui/components/Paging/__stories__/Paging.stories.tsx
+++ b/packages/retail-ui/components/Paging/__stories__/Paging.stories.tsx
@@ -1,20 +1,7 @@
-
 import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import Paging from '../Paging';
-
-storiesOf('Paging', module).addDecorator(story => <div>{story()}</div>).add('GoToAbsensePage', () => <GoToAbsensePage />).add('SimpleSamples', () => {
-    return (
-      <div>
-        <PagingWithState pagesCount={1} />
-        <PagingWithState pagesCount={7} />
-        <PagingWithState pagesCount={8} />
-        <PagingWithState pagesCount={12} />
-      </div>
-    );
-  }).add('PagingWithCustomComponent', () => (
-    <PagingWithCustomComponent pagesCount={12} />
-  ));
+import { action } from '@storybook/addon-actions';
 
 class GoToAbsensePage extends Component<{}, any> {
   public state = {
@@ -58,6 +45,7 @@ class PagingWithState extends Component<any, any> {
         <Paging
           activePage={this.state.activePage}
           pagesCount={this.props.pagesCount}
+          globalListener={this.props.globalListener}
           onPageChange={this._handlePageChange}
         />
       </div>
@@ -65,7 +53,9 @@ class PagingWithState extends Component<any, any> {
   }
 
   private _handlePageChange = (pageNumber: number) => {
-    this.setState({ activePage: pageNumber });
+    this.setState({ activePage: pageNumber }, () =>
+      action('page cahnged')(this.state.activePage)
+    );
   };
 }
 
@@ -114,3 +104,21 @@ class PagingWithCustomComponent extends Component<any, any> {
     this.setState({ activePage: getPageFromHash() });
   };
 }
+
+storiesOf('Paging', module)
+  .addDecorator(story => <div>{story()}</div>)
+  .add('GoToAbsensePage', () => <GoToAbsensePage />)
+  .add('SimpleSamples', () => (
+    <>
+      <PagingWithState pagesCount={1} />
+      <PagingWithState pagesCount={7} />
+      <PagingWithState pagesCount={8} />
+      <PagingWithState pagesCount={12} />
+    </>
+  ))
+  .add('PagingWithCustomComponent', () => (
+    <PagingWithCustomComponent pagesCount={12} />
+  ))
+  .add('Paging with global listener', () => (
+    <PagingWithState globalListener pagesCount={12} />
+  ));

--- a/packages/retail-ui/components/Paging/__tests__/Paging-test.tsx
+++ b/packages/retail-ui/components/Paging/__tests__/Paging-test.tsx
@@ -146,4 +146,31 @@ describe('Pager', () => {
     root.simulate('keydown', { key: 'ArrowLeft', ctrlKey: true });
     expect(onPageChange).toHaveBeenCalledWith(1);
   });
+
+  it('keyboard control available with global listener', () => {
+    const onPageChange = jest.fn();
+    const wrapper = mount(
+      <Paging
+        globalListener
+        pagesCount={2}
+        activePage={2}
+        onPageChange={onPageChange}
+      />
+    );
+
+    expect(wrapper.state('keybordControl')).toBe(true);
+  });
+
+  it('keyboard control available with focus', () => {
+    const onPageChange = jest.fn();
+    const wrapper = mount(
+      <Paging pagesCount={2} activePage={2} onPageChange={onPageChange} />
+    );
+
+    expect(wrapper.state('keybordControl')).toBe(false);
+
+    wrapper.simulate('focus');
+
+    expect(wrapper.state('keybordControl')).toBe(true);
+  });
 });

--- a/packages/retail-ui/components/Paging/__tests__/Paging-test.tsx
+++ b/packages/retail-ui/components/Paging/__tests__/Paging-test.tsx
@@ -151,7 +151,7 @@ describe('Pager', () => {
     const onPageChange = jest.fn();
     const wrapper = mount(
       <Paging
-        globalListener
+        useGlobalListener
         pagesCount={2}
         activePage={2}
         onPageChange={onPageChange}


### PR DESCRIPTION
- Добавлен проп `globalListener`, для добавления слушателя **keydown** на `window`
- Навигационные подсказки появляются только когда доступно управление клавиатурой (`globalListener === true` или фокус)
- Избавление от `_` в названии приватных методов
- Небольшой рефакторинг
- Close #321 