### PR TITLE
fix(Modal): fix after Sticky hotfix

### DIFF
--- a/packages/retail-ui/components/Modal/ModalFooter.tsx
+++ b/packages/retail-ui/components/Modal/ModalFooter.tsx
@@ -30,6 +30,7 @@ export class Footer extends React.Component<FooterProps> {
           <Sticky
             side="bottom"
             offset={horizontalScroll ? this.scrollbarWidth : 0}
+            allowChildWithMargins
           >
             {fixed => (
               <div className={classNames(names, fixed && styles.fixedFooter)}>

--- a/packages/retail-ui/components/Modal/ModalHeader.tsx
+++ b/packages/retail-ui/components/Modal/ModalHeader.tsx
@@ -15,7 +15,7 @@ export class Header extends React.Component<HeaderProps> {
     return (
       <ModalContext.Consumer>
         {({ close, additionalPadding }) => (
-          <Sticky side="top">
+          <Sticky side="top" allowChildWithMargins>
             {fixed => (
               <div
                 className={classNames(


### PR DESCRIPTION
После срочного ремонта `Sticky` немного развалились `Modal.Header` и `Modal.Footer`.
Этот фикс включает `allowChildWithMargins` у `Sticky` в вышеозначенных компонентах.