### PR TITLE
fix(Modal): not adaptive

### DIFF
--- a/packages/retail-ui/components/Modal/Modal.less
+++ b/packages/retail-ui/components/Modal/Modal.less
@@ -43,7 +43,8 @@
         padding: 0;
 
         .centerContainer {
-          padding: 0;
+          margin: 0;
+          width: 100%;
         }
       }
     }


### PR DESCRIPTION
Change `centerContainer` mobile padding to margin to match actual styles

Closes #847