### PR TITLE
fix(Button): fix flat styles

### DIFF
--- a/packages/retail-ui/components/Button/Button.flat.less
+++ b/packages/retail-ui/components/Button/Button.flat.less
@@ -53,7 +53,7 @@
       right: 0;
     }
 
-    .warning {
+    &:not(.link) .warning {
       box-shadow: 0 0 0 2px @border-color-warning;
 
       :global(.rt-ie8) & {
@@ -61,7 +61,7 @@
       }
     }
 
-    .error {
+    &:not(.link) .error {
       box-shadow: 0 0 0 2px @border-color-error;
 
       :global(.rt-ie8) & {
@@ -247,8 +247,7 @@
     .error {
       left: -2px;
       right: -2px;
-      top: 3px;
-      bottom: 2px;
+      bottom: -2px;
     }
 
     .error {


### PR DESCRIPTION
- Починено позиционирование красной подложки у кнопки-ссылки во flat-теме
в сосотоянии `error === true`;
- Для `use="link"` в сосотоянии `error === true` убрана красная рамка во
flat-теме

Fix #856