### PR TITLE
fix(CurrencyInput): починено поведение плэйсхолдера

### DIFF
--- a/packages/retail-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/retail-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -391,7 +391,7 @@ export default class CurrencyInput extends React.Component<
     }
   };
 
-  private refInput = (element: Input) => {
+  private refInput = (element: Nullable<Input>) => {
     this.input = element;
   };
 }

--- a/packages/retail-ui/components/FxInput/FxInput.adapter.ts
+++ b/packages/retail-ui/components/FxInput/FxInput.adapter.ts
@@ -25,10 +25,9 @@ const FxInputAdapter = {
     }
     if (inst instanceof CurrencyInput) {
       // tslint:disable-next-line:no-string-literal
-      inst['_handleChange'](
-        { target: { value } } as ChangeEvent<HTMLInputElement>,
-        value
-      );
+      inst['handleChange']({ target: { value } } as ChangeEvent<
+        HTMLInputElement
+      >);
     }
   }
 };


### PR DESCRIPTION
- Плэйсхолдер исчезает при фокусе (как в гайде написано)
- Переименованы методы: без **_**
- Состояние фокуса хранится в стэйте, а не в поле класса
- Fixed #413 