### PR TITLE
fix(ComboBox): update textValue even if empty (autocomplete mode)

### DIFF
--- a/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -316,6 +316,57 @@ describe('ComboBox', () => {
     expect(wrapper.find('input').prop('value')).toBe('');
   });
 
+  it('update input text on focus in autocomplete mode', async () => {
+    class ExampleComboBox extends React.Component {
+      state: any = {
+        value: {
+          value: 1,
+          label: 'one'
+        }
+      };
+      combobox: ComboBox<any> | null = null;
+
+      resetValue = () => {
+        this.setState({ value: null })
+      };
+
+      focus = () => {
+        if (this.combobox) {
+          this.combobox.focus();
+        }
+      };
+
+      ref = (element: ComboBox<any>) => {
+        this.combobox = element;
+      };
+
+      render() {
+        return (
+          <ComboBox
+            value={this.state.value}
+            autocomplete={true}
+            ref={this.ref}
+          />
+        )
+      }
+    }
+
+    const wrapper = mount<ExampleComboBox>(
+      <ExampleComboBox/>
+    );
+
+    wrapper.instance().focus();
+    wrapper.update();
+    expect(wrapper.find('input').prop('value')).toBe('one');
+
+    clickOutside();
+    wrapper.instance().resetValue();
+
+    wrapper.instance().focus();
+    wrapper.update();
+    expect(wrapper.find('input').prop('value')).toBe('');
+  });
+
   it('reset', () => {
     const wrapper = mount<ComboBox<any>>(<ComboBox />);
 

--- a/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -317,42 +317,14 @@ describe('ComboBox', () => {
   });
 
   it('update input text on focus in autocomplete mode', async () => {
-    class ExampleComboBox extends React.Component {
-      state: any = {
-        value: {
+    const wrapper = mount<ComboBox<any>>(
+      <ComboBox
+        value={{
           value: 1,
           label: 'one'
-        }
-      };
-      combobox: ComboBox<any> | null = null;
-
-      resetValue = () => {
-        this.setState({ value: null })
-      };
-
-      focus = () => {
-        if (this.combobox) {
-          this.combobox.focus();
-        }
-      };
-
-      ref = (element: ComboBox<any>) => {
-        this.combobox = element;
-      };
-
-      render() {
-        return (
-          <ComboBox
-            value={this.state.value}
-            autocomplete={true}
-            ref={this.ref}
-          />
-        )
-      }
-    }
-
-    const wrapper = mount<ExampleComboBox>(
-      <ExampleComboBox/>
+        }}
+        autocomplete={true}
+      />
     );
 
     wrapper.instance().focus();
@@ -360,7 +332,7 @@ describe('ComboBox', () => {
     expect(wrapper.find('input').prop('value')).toBe('one');
 
     clickOutside();
-    wrapper.instance().resetValue();
+    wrapper.setProps({ value: null });
 
     wrapper.instance().focus();
     wrapper.update();

--- a/packages/retail-ui/components/CustomComboBox/reducer/autocomplete.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/autocomplete.tsx
@@ -25,6 +25,7 @@ const reducers: { [key: string]: Reducer } = {
       return [
         {
           ...state,
+          textValue,
           focused: true,
           editing: true,
           opened: false,


### PR DESCRIPTION
![Demo](https://image.ibb.co/cu6xdV/ezgif-com-video-to-gif.gif)

В режиме `autocomplete={true}`, после редактирования инпута и удаления `value` комбобокса "извне", при следующем фокусе инпут покажет старый текст.

```
let delay = ms => v => new Promise(resolve => setTimeout(resolve, ms, v));

let getItems = q =>
  Promise.resolve(
    [
      { value: 1, label: 'First' },
      { value: 2, label: 'Second' },
      { value: 3, label: 'Third' },
      { value: 4, label: 'Fourth' },
      { value: 5, label: 'Fifth' },
      { value: 6, label: 'Sixth' }
    ].filter(
      x =>
        x.label.toLowerCase().includes(q.toLowerCase()) ||
        x.value.toString(10) === q
    )
  )
    .then(delay(500));

let initialState = {
  selected: null,
  error: false
};

let handleChange = (_, item) => setState({ selected: item, error: false });

let handleUnexpectedInput = () => setState({ error: true, selected: null });

let handleFocus = () => setState({ error: false });

<div>
  <ComboBox
    error={state.error}
    getItems={getItems}
    onChange={handleChange}
    onFocus={handleFocus}
    onUnexpectedInput={handleUnexpectedInput}
    placeholder="Enter number"
    value={state.selected}
  />
  <ComboBox
    error={state.error}
    getItems={getItems}
    onChange={handleChange}
    onFocus={handleFocus}
    onUnexpectedInput={handleUnexpectedInput}
    placeholder="Enter number"
    value={state.selected}
    autocomplete={true}
  />
  
</div>
```

Воспроизведение:
Комбобоксы делят один и тот же `value`. Если выбрать значение во втором комбобоксе, потом удалить его через первый, то во втором при фокусе увидим старый текст.