### PR TITLE
SC cleaning

### DIFF
--- a/packages/react-ui-testing/README.md
+++ b/packages/react-ui-testing/README.md
@@ -1,6 +1,6 @@
 # react-ui-testing
 
-[![TeamCity](https://tcat.skbkontur.ru/app/rest/builds/buildType:(id:ReactUiSeleniumTesting_Tests)/statusIcon)](https://tcat.skbkontur.ru/project.html?projectId=ReactUiSeleniumTesting&tab=projectOverview)
+[![Build Status](https://travis-ci.org/skbkontur/retail-ui.svg?branch=master)](https://travis-ci.org/skbkontur/retail-ui)
 
 Набор инструментов для тестирования фронтэнд приложений написаных на React-е, в том числе с использованием библиотеки
 [react-ui](https://github.com/skbkontur/retail-ui).

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Drawing;
+using System.Linq;
 using System.Threading;
-#if NETCOREAPP2_1
-using dotenv.net;
 using System.IO;
-#endif
 using Kontur.Selone.Extensions;
 using NUnit.Framework;
 using OpenQA.Selenium;
@@ -73,9 +71,11 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
 
                 if (!TravisEnvironment.IsExecutionViaTravis)
                 {
-#if NETCOREAPP2_1
-                    DotEnv.Config(filePath: Path.Combine(PathUtils.FindProjectRootFolder(), ".env"));
-#endif
+                        File.ReadAllLines(Path.Combine(PathUtils.FindProjectRootFolder(), ".env"))
+                            .Select(line => line.Split('='))
+                            .Where(splitLine => splitLine.Length == 2)
+                            .ToList()
+                            .ForEach(parameters => Environment.SetEnvironmentVariable(parameters[0].Trim(), parameters[1].Trim()));
                 }
 
                 var sauceUserName = Environment.GetEnvironmentVariable("SAUCE_USERNAME", EnvironmentVariableTarget.Process);

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -70,11 +70,15 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
 
                 if (!TravisEnvironment.IsExecutionViaTravis)
                 {
-                        File.ReadAllLines(Path.Combine(PathUtils.FindProjectRootFolder(), ".env"))
-                            .Select(line => line.Split('='))
-                            .Where(splitLine => splitLine.Length == 2)
-                            .ToList()
-                            .ForEach(parameters => Environment.SetEnvironmentVariable(parameters[0].Trim(), parameters[1].Trim()));
+                    var fileName = Path.Combine(PathUtils.FindProjectRootFolder(), ".env");
+                    var pairs = File.ReadLines(fileName)
+                        .Select(line => line.Split('=', 2))
+                        .Where(splitLine => splitLine.Length == 2)
+                        .Select(x => (key: x[0].Trim(), value: x[1].Trim()));
+                    foreach (var (key, value) in pairs)
+                    {
+                        Environment.SetEnvironmentVariable(key, value);
+                    }
                 }
 
                 var sauceUserName = Environment.GetEnvironmentVariable("SAUCE_USERNAME", EnvironmentVariableTarget.Process);

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Drawing;
 using System.Linq;
-using System.Threading;
 using System.IO;
 using Kontur.Selone.Extensions;
 using NUnit.Framework;
@@ -90,24 +89,11 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
                 options.AddAdditionalCapability("tunnel-identifier", this.tunnelIdentifier, true);
                 options.AddAdditionalCapability("maxDuration", 10800, true);
 
-                // get session fails while sauce tunnel is not ready
-                var attempts = 5;
-                while (true)
-                {
-                    var hasAttempts = --attempts > 0;
-                    try
-                    {
-                        webDriver = new RemoteWebDriver(new Uri("http://ondemand.saucelabs.com:80/wd/hub"),
-                                                        options.ToCapabilities(),
-                                                        TimeSpan.FromSeconds(180));
-                        webDriver.Manage().Window.Size = new Size(1280, 1024);
-                        return webDriver;
-                    }
-                    catch (WebDriverException) when (hasAttempts)
-                    {
-                        Thread.Sleep(2000);
-                    }
-                }
+                webDriver = new RemoteWebDriver(new Uri("http://ondemand.saucelabs.com:80/wd/hub"),
+                    options.ToCapabilities(),
+                    TimeSpan.FromSeconds(180));
+                webDriver.Manage().Window.Size = new Size(1280, 1024);
+                return webDriver;
             }
         }
 

--- a/packages/react-ui-testing/Tests/TestEnvironmentFixture.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironmentFixture.cs
@@ -21,7 +21,10 @@ namespace SKBKontur.SeleniumTesting.Tests
             var tunnelIdentifier = Environment.GetEnvironmentVariable("TRAVIS_JOB_NUMBER", EnvironmentVariableTarget.Process) ?? $"{Environment.MachineName}-{Guid.NewGuid()}";
             sauceConnectProcess = CreateSauceConnectProcess(tunnelIdentifier);
             sauceConnectProcess.Start();
-
+            if (sauceConnectProcess.StandardOutput.ReadLine() != "Sauce Connect ready")
+            {
+                throw new Exception("Unable to start sauce connect");
+            }
             BrowserSetUp.SetUp(tunnelIdentifier);
         }
 
@@ -87,6 +90,7 @@ namespace SKBKontur.SeleniumTesting.Tests
                 {
                     UseShellExecute = false,
                     RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
                     FileName = "node",
                     WorkingDirectory = PathUtils.FindProjectRootFolder(),
                     Arguments = $"sauce.js {tunnelIdentifier}"

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -40,7 +40,4 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="dotenv.net" Version="1.0.3" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Изменения для 2 тикетов.

Fix #891  
Убрал dotenv.net из зависимостей.  
Казалось сначала, что нативней всего использовать App.config, но это xml и будет не так удобно, как .env. Да и не встраивается это легко (https://github.com/dotnet/corefx/issues/22101).
Еще один вариант - это хранить логин/пароль в json-файле, который отлично встраивается в sauce.js, а в .net воспользоваться JsonConvert, но опять же json - это не так удобно.
В итоге решил просто попарсить файл в .net.

Fix #873
Убрал цикл с попытками поднять туннель. Теперь просто жду, что sauce.js после запуска выводит сообщение об успехе в stdout.

Структуру не стал переделывать, потому что в будущем тесты надо будет распараллеливать, а Саус не даст этого сделать из-за ограничения по браузерам. Это значит, придется искать альтернативные решения и выпиливать Саус.