### PR TITLE
fix: fix props typings

### DIFF
--- a/packages/retail-ui/components/Kebab/Kebab.tsx
+++ b/packages/retail-ui/components/Kebab/Kebab.tsx
@@ -22,7 +22,7 @@ export interface KebabProps {
   /**
    * Не показывать анимацию
    */
-  disableAnimations: boolean;
+  disableAnimations?: boolean;
 }
 
 export interface KebabState {

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -21,11 +21,11 @@ interface ItemComponentProps {
 
 export interface PagingProps {
   activePage: number;
-  component: React.ComponentType<ItemComponentProps>;
+  component?: React.ComponentType<ItemComponentProps>;
   onPageChange: (pageNumber: number) => void;
   pagesCount: number;
   disabled?: boolean;
-  strings: { forward: string };
+  strings?: { forward: string };
   /**
    * Отключает навигационные подсказки.
    * По-умолчанию подсказки появляются, когда доступно управление с клавиатуры
@@ -39,7 +39,7 @@ export interface PagingProps {
    * **Paging** с withoutNavigationHint === true, то обработчик keyDown будет вызываться
    * на каждом из них. Такие случаи лучше обрабатывать отдельно.
    */
-  useGlobalListener: boolean;
+  useGlobalListener?: boolean;
 }
 
 export interface PagingState {

--- a/packages/retail-ui/components/Textarea/Textarea.tsx
+++ b/packages/retail-ui/components/Textarea/Textarea.tsx
@@ -41,12 +41,12 @@ export type TextareaProps = Override<
     /**
      * Число строк
      */
-    rows: number;
+    rows?: number;
     /**
      * Максимальное число строк при
      * автоматическом ресайзе
      */
-    maxRows: string | number;
+    maxRows?: string | number;
 
     /**
      * Стандартный ресайз


### PR DESCRIPTION
Обновил я такой 0.19.1 -> 0.28.0 и что вы думаете. За это время добавилось несколько пропсов в некоторые компоненты, которые используются в проекте. У всех этих пропрсов дефолтное значение в `defaultProps`, но типизация на них сделана обязательно. Теперь нужно весь проект перередачить, а потом обратно. Не надо так :(