### PR TITLE
 feat(ComboBox): add search method

### DIFF
--- a/packages/retail-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/retail-ui/components/ComboBox/ComboBox.tsx
@@ -151,10 +151,12 @@ class ComboBox<T> extends React.Component<ComboBoxProps<T>> {
 
   /**
    * @public Открывает выпадающий список
+   * @param {boolean} [emptySearch] - Если передан, запускает поиск
+   * по пустому (true) или текущему значению (false)
    */
-  public open() {
+  public open(emptySearch?: boolean) {
     if (this.comboboxElement) {
-      this.comboboxElement.open();
+      this.comboboxElement.open(emptySearch);
     }
   }
 

--- a/packages/retail-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/retail-ui/components/ComboBox/ComboBox.tsx
@@ -150,13 +150,22 @@ class ComboBox<T> extends React.Component<ComboBoxProps<T>> {
   }
 
   /**
-   * @public Открывает выпадающий список
-   * @param {boolean} [emptySearch] - Если передан, запускает поиск
-   * по пустому (true) или текущему значению (false)
+   * @public Открывает выпадающий список и запускает поиск элементов
+   * @param {string} [query] - Текст поиска. По умолчанию берется
+   * текст из инпута или результат `valueToString(value)`
    */
-  public open(emptySearch?: boolean) {
+  public search(query?: string) {
     if (this.comboboxElement) {
-      this.comboboxElement.open(emptySearch);
+      this.comboboxElement.search(query);
+    }
+  }
+
+  /**
+   * @public Открывает выпадающий список
+   */
+  public open() {
+    if (this.comboboxElement) {
+      this.comboboxElement.open();
     }
   }
 

--- a/packages/retail-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/retail-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -140,9 +140,18 @@ storiesOf('ComboBox', module)
     let combobox: Nullable<ComboBox<any>> = null;
     return (
       <div>
-        <ComboBox ref={e => combobox = e}/>
+        <ComboBox
+          ref={e => combobox = e}
+          value={items[0]}
+          getItems={search}
+          renderItem={i => i.name}
+          valueToString={v => v.name}
+          renderValue={v => v.name}
+        />
         <span className="control-buttons">
           <button onClick={() => combobox && combobox.open()}>open</button>
+          <button onClick={() => combobox && combobox.open(true)}>open with empty search</button>
+          <button onClick={() => combobox && combobox.open(false)}>open with value search</button>
           <button onClick={() => combobox && combobox.close()}>close</button>
         </span>
       </div>

--- a/packages/retail-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/retail-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -136,7 +136,7 @@ storiesOf('ComboBox', module)
   .add('with renderItem state', () => (
     <SimpleCombobox renderItem={(_, state) => String(state)} />
   ))
-  .add('open and close methods', () => {
+  .add('open, close, search methods', () => {
     let combobox: Nullable<ComboBox<any>> = null;
     return (
       <div>
@@ -147,11 +147,12 @@ storiesOf('ComboBox', module)
           renderItem={i => i.name}
           valueToString={v => v.name}
           renderValue={v => v.name}
-        />
+        />{' '}
         <span className="control-buttons">
-          <button onClick={() => combobox && combobox.open()}>open</button>
-          <button onClick={() => combobox && combobox.open(true)}>open with empty search</button>
-          <button onClick={() => combobox && combobox.open(false)}>open with value search</button>
+          <button onClick={() => combobox && combobox.open()}>open</button>{' '}
+          <button onClick={() => combobox && combobox.search('')}>empty search</button>{' '}
+          <button onClick={() => combobox && combobox.search()}>search current value</button>{' '}
+          <button onClick={() => combobox && combobox.search('two')}>search "two"</button>{' '}
           <button onClick={() => combobox && combobox.close()}>close</button>
         </span>
       </div>

--- a/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -478,6 +478,58 @@ describe('ComboBox', () => {
     expect(wrapper.find(Menu)).toHaveLength(0);
   });
 
+  it('opens by method with search', async () => {
+    const ITEMS = [
+      { value: 1, label: 'One' },
+      { value: 2, label: 'Two' },
+      { value: 3, label: 'Three' }
+    ];
+    const promise = Promise.resolve(ITEMS);
+    const search = (text: string) =>
+      promise.then(items =>
+        items.filter(
+          item => item.label.indexOf(text) > -1
+        )
+      );
+    const wrapper = mount<ComboBox<string>>(
+      <ComboBox getItems={search} value={ITEMS[0]}/>
+    );
+
+    expect(wrapper.find(Menu)).toHaveLength(0);
+
+    // open without search
+    wrapper.instance().open();
+    wrapper.update();
+    expect(wrapper.find(Menu)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(MenuItem)
+        .filterWhere(item => !item.prop('disabled'))
+    ).toHaveLength(0);
+
+    // open with empty search
+    wrapper.instance().open(true);
+    await promise;
+    wrapper.update();
+    expect(wrapper.find(Menu)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(MenuItem)
+        .filterWhere(item => !item.prop('disabled'))
+    ).toHaveLength(3);
+
+    // open with value search
+    wrapper.instance().open(false);
+    await promise;
+    wrapper.update();
+    expect(wrapper.find(Menu)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(MenuItem)
+        .filterWhere(item => !item.prop('disabled'))
+    ).toHaveLength(1);
+  });
+
   it('keep focus in input after click on item', async () => {
     const ITEMS = ['one', 'two', 'three'];
     const promise = Promise.resolve(ITEMS);

--- a/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -478,56 +478,42 @@ describe('ComboBox', () => {
     expect(wrapper.find(Menu)).toHaveLength(0);
   });
 
-  it('opens by method with search', async () => {
+  describe('search by method', async () => {
     const ITEMS = [
-      { value: 1, label: 'One' },
-      { value: 2, label: 'Two' },
-      { value: 3, label: 'Three' }
+      { value: 1, label: 'one' },
+      { value: 2, label: 'two' },
+      { value: 3, label: 'three' }
     ];
+    const VALUE = ITEMS[0];
     const promise = Promise.resolve(ITEMS);
-    const search = (text: string) =>
-      promise.then(items =>
-        items.filter(
-          item => item.label.indexOf(text) > -1
-        )
-      );
+    const getItems = jest.fn();
     const wrapper = mount<ComboBox<string>>(
-      <ComboBox getItems={search} value={ITEMS[0]}/>
+      <ComboBox getItems={getItems} value={VALUE}/>
     );
 
-    expect(wrapper.find(Menu)).toHaveLength(0);
+    beforeEach(() => {
+      getItems.mockClear();
+    });
 
-    // open without search
-    wrapper.instance().open();
-    wrapper.update();
-    expect(wrapper.find(Menu)).toHaveLength(1);
-    expect(
-      wrapper
-        .find(MenuItem)
-        .filterWhere(item => !item.prop('disabled'))
-    ).toHaveLength(0);
+    it('opens menu', async () => {
+      wrapper.instance().search();
+      await promise;
+      wrapper.update();
+      expect(wrapper.find(Menu)).toHaveLength(1);
+    });
 
-    // open with empty search
-    wrapper.instance().open(true);
-    await promise;
-    wrapper.update();
-    expect(wrapper.find(Menu)).toHaveLength(1);
-    expect(
-      wrapper
-        .find(MenuItem)
-        .filterWhere(item => !item.prop('disabled'))
-    ).toHaveLength(3);
+    it('searches current value by default', async () => {
+      wrapper.instance().search();
+      expect(getItems).toHaveBeenCalledTimes(1);
+      expect(getItems).toHaveBeenCalledWith(VALUE.label);
+    });
 
-    // open with value search
-    wrapper.instance().open(false);
-    await promise;
-    wrapper.update();
-    expect(wrapper.find(Menu)).toHaveLength(1);
-    expect(
-      wrapper
-        .find(MenuItem)
-        .filterWhere(item => !item.prop('disabled'))
-    ).toHaveLength(1);
+    it('searches given query', async () => {
+      const QUERY = 'SEARCH_ME';
+      wrapper.instance().search(QUERY);
+      expect(getItems).toHaveBeenCalledTimes(1);
+      expect(getItems).toHaveBeenCalledWith(QUERY);
+    });
   });
 
   it('keep focus in input after click on item', async () => {

--- a/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/retail-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -1,7 +1,7 @@
 // tslint:disable:jsx-no-lambda
 import * as React from 'react';
 import ComboBox from '../ComboBox';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import InputLikeText from '../../internal/InputLikeText';
 import MenuItem from '../../MenuItem/MenuItem';
 import Menu from '../../Menu/Menu';
@@ -478,37 +478,31 @@ describe('ComboBox', () => {
     expect(wrapper.find(Menu)).toHaveLength(0);
   });
 
-  describe('search by method', async () => {
-    const ITEMS = [
-      { value: 1, label: 'one' },
-      { value: 2, label: 'two' },
-      { value: 3, label: 'three' }
-    ];
-    const VALUE = ITEMS[0];
-    const promise = Promise.resolve(ITEMS);
-    const getItems = jest.fn();
-    const wrapper = mount<ComboBox<string>>(
-      <ComboBox getItems={getItems} value={VALUE}/>
-    );
+  describe('search by method', () => {
+    const VALUE = { value: 1, label: 'one' };
+    let getItems: jest.Mock;
+    let wrapper: ReactWrapper<{}, {}, ComboBox<typeof VALUE>>;
 
     beforeEach(() => {
-      getItems.mockClear();
+      getItems = jest.fn();
+      wrapper = mount<ComboBox<typeof VALUE>>(
+        <ComboBox getItems={getItems} value={VALUE} />
+      );
     });
 
-    it('opens menu', async () => {
+    it('opens menu', () => {
       wrapper.instance().search();
-      await promise;
       wrapper.update();
       expect(wrapper.find(Menu)).toHaveLength(1);
     });
 
-    it('searches current value by default', async () => {
+    it('searches current value by default', () => {
       wrapper.instance().search();
       expect(getItems).toHaveBeenCalledTimes(1);
       expect(getItems).toHaveBeenCalledWith(VALUE.label);
     });
 
-    it('searches given query', async () => {
+    it('searches given query', () => {
       const QUERY = 'SEARCH_ME';
       wrapper.instance().search(QUERY);
       expect(getItems).toHaveBeenCalledTimes(1);

--- a/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
+++ b/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
@@ -23,8 +23,9 @@ export type Action<T> =
   | { type: 'InputClick' }
   | { type: 'Blur' }
   | { type: 'Reset' }
-  | { type: 'Open'; emptySearch?: boolean }
-  | { type: 'Close' };
+  | { type: 'Open' }
+  | { type: 'Close' }
+  | { type: 'Search'; query: string };
 
 export interface CustomComboBoxProps<T> {
   align?: 'left' | 'center' | 'right';
@@ -134,8 +135,15 @@ class CustomComboBox extends React.Component<
   /**
    * @public
    */
-  public open(emptySearch?: boolean) {
-    this.dispatch({ type: 'Open', emptySearch });
+  public search(query: string = this.state.textValue) {
+    this.dispatch({ type: 'Search', query });
+  }
+
+  /**
+   * @public
+   */
+  public open() {
+    this.dispatch({ type: 'Open' });
   }
 
   /**

--- a/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
+++ b/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
@@ -46,11 +46,12 @@ export interface CustomComboBoxProps<T> {
   warning?: boolean;
   width?: string | number;
   maxMenuHeight?: number | string;
-  renderItem?: (item: T, state?: MenuItemState) => React.ReactNode;
   renderNotFound?: () => React.ReactNode;
-  renderValue?: (value: T) => React.ReactNode;
   renderTotalCount?: (found: number, total: number) => React.ReactNode;
-  valueToString?: (value: T) => string;
+  renderItem: (item: T, state?: MenuItemState) => React.ReactNode;
+  renderValue: (value: T) => React.ReactNode;
+  valueToString: (value: T) => string;
+  itemToValue: (item: T) => string | number;
 }
 
 export interface CustomComboBoxState<T> {

--- a/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
+++ b/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
@@ -23,7 +23,7 @@ export type Action<T> =
   | { type: 'InputClick' }
   | { type: 'Blur' }
   | { type: 'Reset' }
-  | { type: 'Open' }
+  | { type: 'Open'; emptySearch?: boolean }
   | { type: 'Close' };
 
 export interface CustomComboBoxProps<T> {
@@ -133,8 +133,8 @@ class CustomComboBox extends React.Component<
   /**
    * @public
    */
-  public open() {
-    this.dispatch({ type: 'Open' });
+  public open(emptySearch?: boolean) {
+    this.dispatch({ type: 'Open', emptySearch });
   }
 
   /**

--- a/packages/retail-ui/components/CustomComboBox/reducer/autocomplete.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/autocomplete.tsx
@@ -1,22 +1,9 @@
 import {
   reducers as defaultReducers,
-  Effect as DefaultEffect,
-  EffectType,
+  Effect,
   Reducer,
   getValueString
 } from './default';
-
-import debounce from 'lodash.debounce';
-
-const Effect = {
-  ...DefaultEffect,
-  Search: ((dispatch, getState, getProps, getInstance) => {
-    DefaultEffect.Search(false)(dispatch, getState, getProps, getInstance);
-    dispatch({ type: 'Open' });
-  }) as EffectType
-};
-
-Effect.DebouncedSearch = debounce(Effect.Search, 300);
 
 const reducers: { [key: string]: Reducer } = {
   ...defaultReducers,

--- a/packages/retail-ui/components/CustomComboBox/reducer/autocomplete.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/autocomplete.tsx
@@ -2,7 +2,8 @@ import {
   reducers as defaultReducers,
   Effect as DefaultEffect,
   EffectType,
-  Reducer
+  Reducer,
+  getValueString
 } from './default';
 
 import debounce from 'lodash.debounce';
@@ -19,10 +20,10 @@ Effect.DebouncedSearch = debounce(Effect.Search, 300);
 
 const reducers: { [key: string]: Reducer } = {
   ...defaultReducers,
-  Focus: (state, props, action) => {
+  Focus: (state, { value, valueToString }, action) => {
     const textValue = state.editing
       ? state.textValue
-      : props.value ? props.valueToString!(props.value) : '';
+      : getValueString(value, valueToString);
     return [
       {
         textValue,

--- a/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
@@ -81,7 +81,7 @@ const getValueString = (value: any, valueToString: Props['valueToString']) => {
   if (!value) {
     return '';
   }
-  return valueToString ? valueToString(value) : value;
+  return valueToString ? valueToString(value) : value.label;
 };
 
 const Effect = {

--- a/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
@@ -25,13 +25,11 @@ interface Action extends BaseAction {
 
 export type Props = CustomComboBoxProps<any> & {
   getItems: (query: string) => Promise<any[]>;
-  itemToValue?: (x0: any) => string;
   onBlur?: () => {};
   onChange?: (x0: { target: { value: any } }, value: any) => {};
   onFocus?: () => {};
   onInputChange?: (textValue: string) => any;
   onUnexpectedInput?: (query: string) => Nullable<boolean>;
-  valueToString?: (x0: any) => string;
 };
 
 export type State = {
@@ -81,7 +79,7 @@ const getValueString = (value: any, valueToString: Props['valueToString']) => {
   if (!value) {
     return '';
   }
-  return valueToString ? valueToString(value) : value.label;
+  return valueToString(value);
 };
 
 const Effect = {
@@ -175,7 +173,7 @@ const Effect = {
     }
 
     let index = -1;
-    if (items && items.length && value && itemToValue) {
+    if (items && items.length && value) {
       index = items.findIndex(x => itemToValue(x) === itemToValue(value));
     }
     // FIXME: accessing private props
@@ -405,4 +403,4 @@ const reducers: { [type: string]: Reducer } = {
   }
 };
 
-export { reducers, Effect };
+export { reducers, Effect, getValueString };

--- a/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
@@ -390,10 +390,13 @@ const reducers: { [type: string]: Reducer } = {
   Reset() {
     return DefaultState;
   },
-  Open: () => {
-    return {
-      opened: true
-    };
+  Open: (state, props, { emptySearch }) => {
+    return [
+      {
+        opened: true
+      },
+      emptySearch !== undefined ? [Effect.Search(emptySearch)] : []
+    ];
   },
   Close: () => {
     return {

--- a/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
+++ b/packages/retail-ui/components/CustomComboBox/reducer/default.tsx
@@ -219,14 +219,19 @@ const Effect = {
 };
 
 const reducers: { [type: string]: Reducer } = {
-  Mount: () => ({ ...DefaultState, inputChanged: false }),
+  Mount: (state, props) => ({
+    ...DefaultState,
+    inputChanged: false,
+    textValue: getValueString(props.value, props.valueToString)
+  }),
   DidUpdate(state, props, action) {
     if (isEqual(props.value, action.prevProps.value)) {
       return state;
     }
 
     return {
-      opened: false
+      opened: false,
+      textValue: state.editing ? state.textValue : getValueString(props.value, props.valueToString)
     } as State;
   },
   Blur(state, props, action) {
@@ -252,9 +257,6 @@ const reducers: { [type: string]: Reducer } = {
     ];
   },
   Focus(state, props, action) {
-    const { value, valueToString } = props;
-    const textValue = getValueString(value, valueToString);
-
     if (state.editing) {
       return [
         {
@@ -264,13 +266,11 @@ const reducers: { [type: string]: Reducer } = {
         [Effect.Search(false), Effect.Focus]
       ];
     }
-
     return [
       {
         focused: true,
         opened: true,
-        editing: true,
-        textValue
+        editing: true
       },
       [Effect.Search(true), Effect.Focus, Effect.SelectInputText]
     ];
@@ -290,8 +290,8 @@ const reducers: { [type: string]: Reducer } = {
     };
   },
   ValueChange(state, props, { value, keepFocus }) {
+    const textValue = getValueString(value, props.valueToString);
     if (keepFocus) {
-      const textValue = getValueString(value, props.valueToString);
       return [
         {
           opened: false,
@@ -307,7 +307,8 @@ const reducers: { [type: string]: Reducer } = {
       {
         opened: false,
         inputChanged: false,
-        editing: false
+        editing: false,
+        textValue
       },
       [Effect.Change(value)]
     ];


### PR DESCRIPTION
В #967 был добавлен метод `open`. Оказалось, что он довольно бесполезен, т.к. всегда открывает пустой список, без запуска поиска (получения списка элементов). 

Здесь я предлагаю дополнить его возможностью попутно запустить поиск по пустому (получить все элементы) или текущему значению инпута. Как происходит на onFocus в режиме не-автокомплита.

Пришлось ввести постоянную синхронизацию между `textValue` и `value`, что вроде бы и так логично.

Напомню, все это я затеял после того, как ComboBox в режиме autocomplete перестал открываться на фокус. Но иногда, хочется это делать руками (#957 ).

Close #991 