### PR TITLE
 fix(DropdownContainer): align dropdown in disablePortal mode

### DIFF
--- a/packages/react-ui-screenshot-tests/gemini/dropdownContainer.js
+++ b/packages/react-ui-screenshot-tests/gemini/dropdownContainer.js
@@ -1,0 +1,78 @@
+/* global gemini */
+var pathTo = require('./utils').pathTo;
+
+var TEST_CONTAINER = 'html';
+var BUTTONS = '#buttons';
+
+var initTest = (suite, showLongItems) =>
+  suite
+    .setUrl(pathTo('DropdownContainer', 'various aligns, portals, items and scrolls'))
+    .setCaptureElements(TEST_CONTAINER)
+    .ignoreElements(BUTTONS)
+    .before((actions, find) => {
+      if (showLongItems) {
+        actions
+          .click(find(BUTTONS + ' button'));
+      }
+    });
+
+var pageScrollTest = (suite) =>
+  suite
+    .capture('shot', (actions) => {
+      actions.executeJS(function(window) {
+        var doc = window.document.documentElement;
+        doc.scrollTop = doc.scrollHeight - doc.offsetHeight;
+        doc.scrollLeft = doc.scrollWidth - doc.offsetWidth;
+      });
+    });
+
+var innerScrollTest = (suite) =>
+  suite
+    .capture('shot', (actions) => {
+      actions
+        .executeJS(function(window) {
+          var innerScroll = window.document.querySelector('#inner-scroll');
+          innerScroll.scrollTop = innerScroll.scrollHeight - innerScroll.offsetHeight;
+          innerScroll.scrollLeft = innerScroll.scrollWidth - innerScroll.offsetWidth;
+        })
+    })
+    .skip.in(
+      "ie11",
+      "ie иногда не до конца скролит элемент (разница в пару px)"
+    );
+
+gemini.suite('DropdownContainer', () => {
+  gemini.suite('short Items', () => {
+    gemini.suite('items', suite => {
+      initTest(suite)
+        .capture('shot');
+    });
+
+    gemini.suite('page scroll', suite => {
+      pageScrollTest(initTest(suite));
+    });
+
+    gemini.suite('inner scroll', suite => {
+      innerScrollTest(initTest(suite));
+    });
+  });
+
+  gemini.suite('long Items', () => {
+    gemini.suite('items', suite => {
+      initTest(suite, true)
+        .capture('shot');
+    });
+
+    gemini.suite('page scroll', suite => {
+      pageScrollTest(
+        initTest(suite, true)
+      );
+    });
+
+    gemini.suite('inner scroll', suite => {
+      innerScrollTest(
+        initTest(suite, true)
+      );
+    });
+  });
+});

--- a/packages/react-ui-screenshot-tests/gemini/dropdownContainer.js
+++ b/packages/react-ui-screenshot-tests/gemini/dropdownContainer.js
@@ -1,78 +1,73 @@
 /* global gemini */
-var pathTo = require('./utils').pathTo;
+var pathTo = require("./utils").pathTo;
 
-var TEST_CONTAINER = 'html';
-var BUTTONS = '#buttons';
+var TEST_CONTAINER = "html";
+var BUTTONS = "#buttons";
 
 var initTest = (suite, showLongItems) =>
   suite
-    .setUrl(pathTo('DropdownContainer', 'various aligns, portals, items and scrolls'))
+    .setUrl(
+      pathTo("DropdownContainer", "various aligns, portals, items and scrolls")
+    )
     .setCaptureElements(TEST_CONTAINER)
     .ignoreElements(BUTTONS)
     .before((actions, find) => {
       if (showLongItems) {
-        actions
-          .click(find(BUTTONS + ' button'));
+        actions.click(find(BUTTONS + " button"));
       }
     });
 
-var pageScrollTest = (suite) =>
-  suite
-    .capture('shot', (actions) => {
-      actions.executeJS(function(window) {
-        var doc = window.document.documentElement;
-        doc.scrollTop = doc.scrollHeight - doc.offsetHeight;
-        doc.scrollLeft = doc.scrollWidth - doc.offsetWidth;
-      });
+var pageScrollTest = suite =>
+  suite.capture("shot", actions => {
+    actions.executeJS(function(window) {
+      var doc = window.document.documentElement;
+      doc.scrollTop = doc.scrollHeight - doc.offsetHeight;
+      doc.scrollLeft = doc.scrollWidth - doc.offsetWidth;
     });
+  });
 
-var innerScrollTest = (suite) =>
+var innerScrollTest = suite =>
   suite
-    .capture('shot', (actions) => {
-      actions
-        .executeJS(function(window) {
-          var innerScroll = window.document.querySelector('#inner-scroll');
-          innerScroll.scrollTop = innerScroll.scrollHeight - innerScroll.offsetHeight;
-          innerScroll.scrollLeft = innerScroll.scrollWidth - innerScroll.offsetWidth;
-        })
+    .capture("shot", actions => {
+      actions.executeJS(function(window) {
+        var innerScroll = window.document.querySelector("#inner-scroll");
+        innerScroll.scrollTop =
+          innerScroll.scrollHeight - innerScroll.offsetHeight;
+        innerScroll.scrollLeft =
+          innerScroll.scrollWidth - innerScroll.offsetWidth;
+      });
     })
     .skip.in(
       "ie11",
       "ie иногда не до конца скролит элемент (разница в пару px)"
     );
 
-gemini.suite('DropdownContainer', () => {
-  gemini.suite('short Items', () => {
-    gemini.suite('items', suite => {
-      initTest(suite)
-        .capture('shot');
+gemini.suite("DropdownContainer", () => {
+  gemini.suite("short Items", () => {
+    gemini.suite("items", suite => {
+      initTest(suite).capture("shot");
     });
 
-    gemini.suite('page scroll', suite => {
+    gemini.suite("page scroll", suite => {
       pageScrollTest(initTest(suite));
     });
 
-    gemini.suite('inner scroll', suite => {
+    gemini.suite("inner scroll", suite => {
       innerScrollTest(initTest(suite));
     });
   });
 
-  gemini.suite('long Items', () => {
-    gemini.suite('items', suite => {
-      initTest(suite, true)
-        .capture('shot');
+  gemini.suite("long Items", () => {
+    gemini.suite("items", suite => {
+      initTest(suite, true).capture("shot");
     });
 
-    gemini.suite('page scroll', suite => {
-      pageScrollTest(
-        initTest(suite, true)
-      );
+    gemini.suite("page scroll", suite => {
+      pageScrollTest(initTest(suite, true));
     });
 
-    gemini.suite('inner scroll', suite => {
-      innerScrollTest(
-        initTest(suite, true)
-      );
+    gemini.suite("inner scroll", suite => {
+      innerScrollTest(initTest(suite, true));
     });
   });
 });

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef3cb2232f2e86a2aef163aa765eadc7b8fd1e9c909c265e1f846acda8152441
-size 81297
+oid sha256:9b0aeea34ed264172a9c09d273a73ac923ea08efb840c067ba888b53fe312e5f
+size 81307

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef3cb2232f2e86a2aef163aa765eadc7b8fd1e9c909c265e1f846acda8152441
+size 81297

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6da5f1cc96a4bbdcb5a7387575ccfcbfe45f31c5dd2f42804674557ea6ce2f0c
-size 45972
+oid sha256:64876c491ec235bf9375c5c00a399ba3875f603508c043b4e41cb23634d74b3f
+size 44648

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/inner scroll/shot/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6da5f1cc96a4bbdcb5a7387575ccfcbfe45f31c5dd2f42804674557ea6ce2f0c
+size 45972

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6a9b6cac2def998c38f3cb48694710432eeffba3da2a881a52c9a41c442c44d
+size 63733

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6a9b6cac2def998c38f3cb48694710432eeffba3da2a881a52c9a41c442c44d
-size 63733
+oid sha256:ba9324447fc6534b74bf4211296e923ed4df0e2407a31b3e9ef50c1f38c22bf3
+size 63738

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b93485fdd907700b272bca0f19f217e4df19c43236b71c4d35223f570bee538
+size 38104

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b93485fdd907700b272bca0f19f217e4df19c43236b71c4d35223f570bee538
-size 38104
+oid sha256:bb985aafd49579adebde368c1b6eedf749f5a1e33d8d08c1788e531925bae161
+size 38110

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d620fe8ae67f194bbefc7443e296e0e7f2b9fde62a993d11dc5cbb975937df7f
-size 41517
+oid sha256:23527fd091d888c5fd3553ff9e539f2097a9e73fa8159595e02db74352fde770
+size 36539

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/items/shot/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d620fe8ae67f194bbefc7443e296e0e7f2b9fde62a993d11dc5cbb975937df7f
+size 41517

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6a9b6cac2def998c38f3cb48694710432eeffba3da2a881a52c9a41c442c44d
+size 63733

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6a9b6cac2def998c38f3cb48694710432eeffba3da2a881a52c9a41c442c44d
-size 63733
+oid sha256:ba9324447fc6534b74bf4211296e923ed4df0e2407a31b3e9ef50c1f38c22bf3
+size 63738

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bd05bdacea5dc203351b873d6661e2433f043235442175e31f482e6aee5a83
+size 38195

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3bd05bdacea5dc203351b873d6661e2433f043235442175e31f482e6aee5a83
-size 38195
+oid sha256:e59593fea0ca064efb27be16b2ecc88a8955e4469663cb3214ceb6be1941398f
+size 38201

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d620fe8ae67f194bbefc7443e296e0e7f2b9fde62a993d11dc5cbb975937df7f
-size 41517
+oid sha256:23527fd091d888c5fd3553ff9e539f2097a9e73fa8159595e02db74352fde770
+size 36539

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/long Items/page scroll/shot/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d620fe8ae67f194bbefc7443e296e0e7f2b9fde62a993d11dc5cbb975937df7f
+size 41517

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f4517fc6721d67c48022944885874566b7dbb861719ed0377b5382c78f1b1a3
+size 57018

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f4517fc6721d67c48022944885874566b7dbb861719ed0377b5382c78f1b1a3
-size 57018
+oid sha256:3ed9b48d00fc37bb4cf7231dc32b9e04b039158deec3cca098c3d6c4a0563ca8
+size 57025

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79533d9f0fb1abfde62d7883b32f88ef35de2f3a9fbe1f9bfbbb87bf9fe43ad6
+size 37621

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/inner scroll/shot/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79533d9f0fb1abfde62d7883b32f88ef35de2f3a9fbe1f9bfbbb87bf9fe43ad6
-size 37621
+oid sha256:699a1a3c91d1544fda3fdf08dc218449a8ca4e5a1e48c5a63ce23291602c1893
+size 37637

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b36e9c85f4ed78ef39b872801a99aa1c8ec40afd03daf3d45328846ce730f5d4
+size 46684

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b36e9c85f4ed78ef39b872801a99aa1c8ec40afd03daf3d45328846ce730f5d4
-size 46684
+oid sha256:26ce4ee5eb1b6b58edd5a410d86841fa3a9f5f37e0262c56ee0ef658b92e219d
+size 46690

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00df9195ee199107aa9db8bbb1058a376e1674f6617a01f7ea63533067b12f7c
-size 29947
+oid sha256:d996da3f05eb89aa686fc0535bc1bff395c17e1e21bf8e4dfc2350d458044ba7
+size 29953

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00df9195ee199107aa9db8bbb1058a376e1674f6617a01f7ea63533067b12f7c
+size 29947

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc15df8da742a39ef61c0a12fac3b5b5a2c4dd0d6aa2136c9eaf5bd3ad476efa
-size 36123
+oid sha256:c8288a9bbafcedd073e230c99dc2f7b70152a5926456959e6244db5869ff9baf
+size 29142

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/items/shot/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc15df8da742a39ef61c0a12fac3b5b5a2c4dd0d6aa2136c9eaf5bd3ad476efa
+size 36123

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b36e9c85f4ed78ef39b872801a99aa1c8ec40afd03daf3d45328846ce730f5d4
+size 46684

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b36e9c85f4ed78ef39b872801a99aa1c8ec40afd03daf3d45328846ce730f5d4
-size 46684
+oid sha256:26ce4ee5eb1b6b58edd5a410d86841fa3a9f5f37e0262c56ee0ef658b92e219d
+size 46690

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:021ec137823c5fc64b7fb7bd46196451c245089c92acea210666e49c6e158cc0
-size 30451
+oid sha256:31483c6fa1bf3ba162c6828212493dbd599205eeaa4b9c350634b6ba3b051ca1
+size 30457

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:021ec137823c5fc64b7fb7bd46196451c245089c92acea210666e49c6e158cc0
+size 30451

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc15df8da742a39ef61c0a12fac3b5b5a2c4dd0d6aa2136c9eaf5bd3ad476efa
-size 36123
+oid sha256:cfce347f376ca1775dc2eb8b1f40c08ef889183975c3fef4af0600975bc33ee4
+size 29067

--- a/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DropdownContainer/short Items/page scroll/shot/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc15df8da742a39ef61c0a12fac3b5b5a2c4dd0d6aa2136c9eaf5bd3ad476efa
+size 36123

--- a/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
+++ b/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
@@ -191,8 +191,7 @@ export default class DropdownContainer extends React.Component<
     if (!child) {
       return 0;
     }
-    const rect = child.getBoundingClientRect();
-    return rect.height ? rect.height : rect.bottom - rect.top;
+    return child.getBoundingClientRect().height;
   };
 
   private getMinWidth = () => {
@@ -200,8 +199,7 @@ export default class DropdownContainer extends React.Component<
     if (!this.isElement(target)) {
       return 0;
     }
-    const rect = target.getBoundingClientRect();
-    return rect.width ? rect.width : rect.right - rect.left;
+    return target.getBoundingClientRect().width;
   };
 
   private convertToRelativePosition = (

--- a/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
+++ b/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
@@ -103,11 +103,15 @@ export default class DropdownContainer extends React.Component<
     this.dom = e && (findDOMNode(e) as HTMLElement);
   };
 
+  private isElement = (node: Element | Text | null): node is Element => {
+    return node instanceof Element;
+  };
+
   private position = () => {
-    const target = this.props.getParent() as Nullable<Element>;
+    const target = this.props.getParent();
     const dom = this.dom;
 
-    if (target && dom) {
+    if (this.isElement(target) && dom) {
       const targetRect = target.getBoundingClientRect();
       const docEl = document.documentElement;
 
@@ -192,26 +196,28 @@ export default class DropdownContainer extends React.Component<
   };
 
   private getMinWidth = () => {
-    const target = this.props.getParent() as Nullable<Element>;
-    if (!target) {
+    const target = this.props.getParent();
+    if (!this.isElement(target)) {
       return 0;
     }
     const rect = target.getBoundingClientRect();
     return rect.width ? rect.width : rect.right - rect.left;
   };
 
-  private convertToRelativePosition = (position: DropdownContainerPosition): DropdownContainerPosition => {
-    const target = this.props.getParent() as Nullable<Element>;
+  private convertToRelativePosition = (
+    position: DropdownContainerPosition
+  ): DropdownContainerPosition => {
+    const target = this.props.getParent();
     const { offsetX = 0, offsetY = 0 } = this.props;
     const { top, bottom, left, right } = position;
-    if (target) {
+    if (this.isElement(target)) {
       const targetHeight = target.getBoundingClientRect().height;
       return {
         top: top !== null ? targetHeight + offsetY : null,
         bottom: bottom !== null ? targetHeight + offsetY : null,
         left: left !== null ? offsetX : null,
         right: right !== null ? offsetX : null
-      }
+      };
     }
     return {
       top: offsetY,

--- a/packages/retail-ui/components/DropdownContainer/__stories__/DropdownContainer.stories.tsx
+++ b/packages/retail-ui/components/DropdownContainer/__stories__/DropdownContainer.stories.tsx
@@ -3,165 +3,271 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import MenuItem from '../../MenuItem';
 import Toggle from '../../Toggle';
-import DropdownContainer from '../DropdownContainer';
+import DropdownContainer, {
+  DropdownContainerProps
+} from '../DropdownContainer';
 import { findDOMNode } from 'react-dom';
 import Menu from '../../Menu/Menu';
 import Button from '../../Button/Button';
 
-storiesOf('DropdownContainer', module)
-  .add('various aligns, portals, items and scrolls', () => (
-    <VariousAlignsPortalsItemsAndScrolls/>
-  ));
+storiesOf('DropdownContainer', module).add(
+  'various aligns, portals, items and scrolls',
+  () => <VariousAlignsPortalsItemsAndScrolls />
+);
 
-class  VariousAlignsPortalsItemsAndScrolls extends React.Component {
+class VariousAlignsPortalsItemsAndScrolls extends React.Component {
   public aligns: Array<'left' | 'right'> = ['left', 'right'];
-  public portals = [true, false];
+  public portals = [false, true];
   public rows = ['top', 'middle', 'bottom'];
   public cols = ['left', 'center', 'right'];
-  public LONG_ITEM = 'LongItemLongItemLongItemLongItemLong LongItem LongItemLongItemLongItemLongItemLongItemLongItem';
+  public LONG_ITEM =
+    'LongItemLongItemLongItemLongItemLong LongItem LongItemLongItemLongItemLongItemLongItemLongItem';
   public SHORT_ITEM = 'ShortShortShort Short';
-  public toggles: {
-    [id: string]: Toggle | null
+  public dropdowns: {
+    [id: string]: DropdownWithToggle | null;
   } = {};
 
-  public state : {
-    show: { [id: string]: boolean },
-    long: boolean
+  public state: {
+    shown: { [id: string]: boolean };
+    long: boolean;
   } = {
-    show: {},
-    long: false,
+    shown: {},
+    long: false
   };
 
   public componentDidMount(): void {
-    Object.keys(this.toggles).forEach(id =>
-      this.toggle(id, true)
+    Object.keys(this.dropdowns).forEach(dropdown =>
+      this.toggle(dropdown, true)
     );
   }
 
   public get isAllShown() {
-    const { show } = this.state;
-    const all = Object.keys(show);
-    return all.length > 0 && all.every(key => show[key]);
+    const { shown } = this.state;
+    const all = Object.keys(shown);
+    return all.length > 0 && all.every(id => shown[id]);
   }
 
   public toggle = (id: string, value: boolean) => {
-    this.setState((state: {
-      show: { [id: string]: boolean },
-      long: boolean
-    }) => ({
-      show: {
-        ...state.show,
-        [id]: value
-      }
-    }));
+    this.setState(
+      (state: { shown: { [id: string]: boolean }; long: boolean }) => ({
+        shown: {
+          ...state.shown,
+          [id]: value
+        }
+      })
+    );
   };
 
   public toggleAll = (value: boolean) => {
-    const { show } = this.state;
-    Object.keys(show).forEach(key => {
+    const { shown } = this.state;
+    Object.keys(shown).forEach(key => {
       this.toggle(key, value);
     });
   };
 
   public render() {
-    const { show, long } = this.state;
     return (
-      // makes window scroll
+      <ScrollMaker>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            borderStyle: 'solid',
+            borderColor: 'transparent',
+            borderWidth: '50px 150px 150px 50px',
+            height: '100%',
+            boxSizing: 'border-box'
+          }}
+        >
+          {this.renderControls()}
+          <ScrollableContainer id="inner-scroll">
+            <ScrollMaker>{this.renderDropdowns()}</ScrollMaker>
+          </ScrollableContainer>
+        </div>
+      </ScrollMaker>
+    );
+  }
+
+  private renderControls = () => (
+    <div style={{ marginBottom: 16 }}>
+      <div id="buttons" style={{ display: 'inline-block' }}>
+        <Button onClick={() => this.setState({ long: !this.state.long })}>
+          {this.state.long ? 'Short' : 'Long'} Items
+        </Button>
+        &nbsp;
+        <Button onClick={() => this.toggleAll(!this.isAllShown)}>
+          {this.isAllShown ? 'Hide' : 'Show'} All
+        </Button>
+      </div>
+    </div>
+  );
+
+  private renderDropdowns = () => {
+    const { rows, cols, aligns, portals, LONG_ITEM, SHORT_ITEM } = this;
+    const { long, shown } = this.state;
+    return (
+      <Grid rows={rows} cols={cols}>
+        {(row, col) =>
+          aligns.map(align =>
+            portals.map(disablePortal => {
+              const dropdownId = `${row}-${col}-${align}-${disablePortal}`;
+              return (
+                <div key={`${disablePortal}`}>
+                  <DropdownWithToggle
+                    ref={this.createDropdownRef(dropdownId)}
+                    show={shown[dropdownId]}
+                    onToggle={value => this.toggle(dropdownId, value)}
+                    dropdownProps={{ align, disablePortal }}
+                  >
+                    <Menu>
+                      <MenuItem>{long ? LONG_ITEM : SHORT_ITEM}</MenuItem>
+                    </Menu>
+                  </DropdownWithToggle>
+                  &nbsp;
+                  {`${align}, portal: ${!disablePortal}`}
+                </div>
+              );
+            })
+          )
+        }
+      </Grid>
+    );
+  };
+
+  private createDropdownRef = (id: string) => (
+    element: DropdownWithToggle | null
+  ) => {
+    if (element) {
+      this.dropdowns[id] = element;
+    }
+  };
+}
+
+class ScrollableContainer extends React.Component<{
+  id?: string;
+}> {
+  public render() {
+    return (
+      <div
+        id={this.props.id}
+        style={{
+          overflow: 'auto',
+          border: '1px dashed #ccc',
+          position: 'relative',
+          height: '100%'
+        }}
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+class ScrollMaker extends React.Component<{
+  xScroll: number;
+  yScroll: number;
+}> {
+  public static defaultProps = {
+    xScroll: 100,
+    yScroll: 100
+  };
+
+  public render() {
+    const { xScroll, yScroll } = this.props;
+    return (
       <div
         style={{
           position: 'absolute',
           top: 0,
-          right: -50,
-          bottom: -50,
-          left: 0,
-          border: '50px solid transparent'
-        }}>
-        <div id="buttons">
-          <Button onClick={() => this.setState({ long: !long })}>
-            { long ? 'Short' : 'Long' } Items
-          </Button>
-          &nbsp;
-          <Button onClick={() => this.toggleAll(!this.isAllShown)}>
-            { this.isAllShown ? 'Hide' : 'Show' } All
-          </Button>
-        </div>
+          right: -xScroll,
+          bottom: -yScroll,
+          left: 0
+        }}
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+class Grid extends React.Component<{
+  rows: string[];
+  cols: string[];
+  children: (row: string, col: string) => React.ReactNode;
+}> {
+  public static Row = class Row extends React.Component {
+    public render() {
+      return (
         <div
-          id="inner-scroll"
           style={{
-            position: 'absolute',
-            top: 50,
-            right: 50,
-            bottom: 50,
-            left: 0,
-            overflow: 'auto',
-            border: '1px dashed #ccc',
+            display: 'flex',
+            justifyContent: 'space-between'
           }}
         >
-          {/* makes inner scroll */}
-          <div style={{
-            position: 'absolute',
-            display: 'flex',
-            justifyContent: 'space-between',
-            top: 0,
-            right: -100,
-            bottom: -100,
-            left: 0,
-            padding: 10
-          }}>
-            {this.rows.map((row) => (
-              <div
-                key={row}
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'space-between',
-                }}
-              >
-                {this.cols.map((col) => (
-                  <div key={col} style={{ padding: 10 }}>
-                    {this.aligns.map(align => {
-                      return this.portals.map(portal => {
-                        const id = `${row}-${col}-${align}-${portal}`;
-                        if (this.toggles[id] === undefined) {
-                          this.toggles[id] = null;
-                        }
-                        return (
-                          <div key={`${portal}`}>
-                            <span style={{ display: 'inline-block', position: 'relative' }}>
-                              <Toggle
-                                checked={show[id] === true}
-                                onChange={(value) => this.toggle(id, value)}
-                                ref={el => this.toggles[id] = el}
-                              />
-                              {show[id] && (
-                                <DropdownContainer
-                                  align={align}
-                                  disablePortal={!portal}
-                                  getParent={() => this.toggles[id] && findDOMNode(this.toggles[id]!) || null}
-                                >
-                                  <Menu>
-                                    <MenuItem>
-                                      {this.state.long
-                                        ? this.LONG_ITEM
-                                        : this.SHORT_ITEM}
-                                    </MenuItem>
-                                  </Menu>
-                                </DropdownContainer>
-                              )}
-                            </span>
-                            &nbsp;
-                            {`${align}, portal: ${portal}`}
-                          </div>
-                        );
-                      });
-                    })}
-                  </div>
-                ))}
-              </div>
-            ))}
-          </div>
+          {this.props.children}
         </div>
+      );
+    }
+  };
+
+  public static Cell = class Cell extends React.Component {
+    public render() {
+      return <div style={{ padding: 20 }}>{this.props.children}</div>;
+    }
+  };
+
+  public render() {
+    const { rows, cols } = this.props;
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          height: '100%'
+        }}
+      >
+        {rows.map(row => (
+          <Grid.Row key={row}>
+            {cols.map(col => (
+              <Grid.Cell key={col}>{this.props.children(row, col)}</Grid.Cell>
+            ))}
+          </Grid.Row>
+        ))}
       </div>
+    );
+  }
+}
+
+class DropdownWithToggle extends React.Component<{
+  show: boolean;
+  onToggle: (value: boolean) => void;
+  dropdownProps: {
+    align: DropdownContainerProps['align'];
+    disablePortal: DropdownContainerProps['disablePortal'];
+  };
+}> {
+  private DOMNode: Element | Text | null = null;
+
+  public componentDidMount(): void {
+    this.DOMNode = findDOMNode(this);
+  }
+
+  public render() {
+    const { show, onToggle, dropdownProps } = this.props;
+    return (
+      <span style={{ display: 'inline-block', position: 'relative' }}>
+        <Toggle checked={show === true} onChange={onToggle} />
+        {show && (
+          <DropdownContainer
+            align={dropdownProps.align}
+            disablePortal={dropdownProps.disablePortal}
+            getParent={() => this.DOMNode}
+          >
+            {this.props.children}
+          </DropdownContainer>
+        )}
+      </span>
     );
   }
 }

--- a/packages/retail-ui/components/DropdownContainer/__stories__/DropdownContainer.stories.tsx
+++ b/packages/retail-ui/components/DropdownContainer/__stories__/DropdownContainer.stories.tsx
@@ -1,0 +1,167 @@
+// tslint:disable:jsx-no-lambda
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import MenuItem from '../../MenuItem';
+import Toggle from '../../Toggle';
+import DropdownContainer from '../DropdownContainer';
+import { findDOMNode } from 'react-dom';
+import Menu from '../../Menu/Menu';
+import Button from '../../Button/Button';
+
+storiesOf('DropdownContainer', module)
+  .add('various aligns, portals, items and scrolls', () => (
+    <VariousAlignsPortalsItemsAndScrolls/>
+  ));
+
+class  VariousAlignsPortalsItemsAndScrolls extends React.Component {
+  public aligns: Array<'left' | 'right'> = ['left', 'right'];
+  public portals = [true, false];
+  public rows = ['top', 'middle', 'bottom'];
+  public cols = ['left', 'center', 'right'];
+  public LONG_ITEM = 'LongItemLongItemLongItemLongItemLong LongItem LongItemLongItemLongItemLongItemLongItemLongItem';
+  public SHORT_ITEM = 'ShortShortShort Short';
+  public toggles: {
+    [id: string]: Toggle | null
+  } = {};
+
+  public state : {
+    show: { [id: string]: boolean },
+    long: boolean
+  } = {
+    show: {},
+    long: false,
+  };
+
+  public componentDidMount(): void {
+    Object.keys(this.toggles).forEach(id =>
+      this.toggle(id, true)
+    );
+  }
+
+  public get isAllShown() {
+    const { show } = this.state;
+    const all = Object.keys(show);
+    return all.length > 0 && all.every(key => show[key]);
+  }
+
+  public toggle = (id: string, value: boolean) => {
+    this.setState((state: {
+      show: { [id: string]: boolean },
+      long: boolean
+    }) => ({
+      show: {
+        ...state.show,
+        [id]: value
+      }
+    }));
+  };
+
+  public toggleAll = (value: boolean) => {
+    const { show } = this.state;
+    Object.keys(show).forEach(key => {
+      this.toggle(key, value);
+    });
+  };
+
+  public render() {
+    const { show, long } = this.state;
+    return (
+      // makes window scroll
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: -50,
+          bottom: -50,
+          left: 0,
+          border: '50px solid transparent'
+        }}>
+        <div id="buttons">
+          <Button onClick={() => this.setState({ long: !long })}>
+            { long ? 'Short' : 'Long' } Items
+          </Button>
+          &nbsp;
+          <Button onClick={() => this.toggleAll(!this.isAllShown)}>
+            { this.isAllShown ? 'Hide' : 'Show' } All
+          </Button>
+        </div>
+        <div
+          id="inner-scroll"
+          style={{
+            position: 'absolute',
+            top: 50,
+            right: 50,
+            bottom: 50,
+            left: 0,
+            overflow: 'auto',
+            border: '1px dashed #ccc',
+          }}
+        >
+          {/* makes inner scroll */}
+          <div style={{
+            position: 'absolute',
+            display: 'flex',
+            justifyContent: 'space-between',
+            top: 0,
+            right: -100,
+            bottom: -100,
+            left: 0,
+            padding: 10
+          }}>
+            {this.rows.map((row) => (
+              <div
+                key={row}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'space-between',
+                }}
+              >
+                {this.cols.map((col) => (
+                  <div key={col} style={{ padding: 10 }}>
+                    {this.aligns.map(align => {
+                      return this.portals.map(portal => {
+                        const id = `${row}-${col}-${align}-${portal}`;
+                        if (this.toggles[id] === undefined) {
+                          this.toggles[id] = null;
+                        }
+                        return (
+                          <div key={`${portal}`}>
+                            <span style={{ display: 'inline-block', position: 'relative' }}>
+                              <Toggle
+                                checked={show[id] === true}
+                                onChange={(value) => this.toggle(id, value)}
+                                ref={el => this.toggles[id] = el}
+                              />
+                              {show[id] && (
+                                <DropdownContainer
+                                  align={align}
+                                  disablePortal={!portal}
+                                  getParent={() => this.toggles[id] && findDOMNode(this.toggles[id]!) || null}
+                                >
+                                  <Menu>
+                                    <MenuItem>
+                                      {this.state.long
+                                        ? this.LONG_ITEM
+                                        : this.SHORT_ITEM}
+                                    </MenuItem>
+                                  </Menu>
+                                </DropdownContainer>
+                              )}
+                            </span>
+                            &nbsp;
+                            {`${align}, portal: ${portal}`}
+                          </div>
+                        );
+                      });
+                    })}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Дополнение к #1001. fix #590 
 
DropdownContainer в режиме `disablePortal: true` никак не учитывает prop `align?: 'left' | 'right'`.  Это не позволяет полностью покрыть кейс #590 (второй скрин), где выпадашку следует вытащить из портала и выровнять по правому краю.

Добавил story для тестирования всех положений выпадахи:

![storybook](https://user-images.githubusercontent.com/4607770/50069643-d0e3a400-01ec-11e9-89c2-26178bccab19.png)

-  было:
![default](https://user-images.githubusercontent.com/4607770/50069831-99c1c280-01ed-11e9-8b6c-a76ef618251c.png)

- стало:
![default](https://user-images.githubusercontent.com/4607770/50069843-a80fde80-01ed-11e9-80b0-7acfdc371c71.png)

- разница:
![default](https://user-images.githubusercontent.com/4607770/50069855-b231dd00-01ed-11e9-8e1b-25411fe0303b.png)
