### PR TITLE
 fix(Logotype): keep the widget working after props update

### DIFF
--- a/packages/react-ui-screenshot-tests/gemini/logotype.js
+++ b/packages/react-ui-screenshot-tests/gemini/logotype.js
@@ -1,0 +1,18 @@
+/* global gemini */
+
+var pathTo = require("./utils").pathTo;
+var TOGGLE_WIDGET = "#toggle-widget";
+
+gemini.suite("Logotype", suite => {
+  suite
+    .setUrl(pathTo("Logotype", "with widget"))
+    .setCaptureElements("#test-element")
+    .ignoreElements(TOGGLE_WIDGET)
+    .capture("without widget")
+    .before((actions, find) => {
+      this.toggleWidget = find(TOGGLE_WIDGET);
+    })
+    .capture("with widget", actions => {
+      actions.click(this.toggleWidget);
+    });
+});

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/with widget/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/with widget/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2e77528c9aeac85da7d37dc2b6c83777abcec8bf256e7b76d39224d5ab429ec
+size 2146

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/with widget/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/with widget/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:798565a8ec81ca44346e47201807a401e20df5ed2e8c335f519773b722b4a0dc
+size 2018

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/with widget/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/with widget/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:153537b1be9cfe30c875ae91c3395eb95088e2df43011021546033366dfce14c
+size 2116

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cd0b2d7c38801c5d56f3c1feaac0a1a292f8a61f63a5786071104960661d7ba
+size 1948

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cd0b2d7c38801c5d56f3c1feaac0a1a292f8a61f63a5786071104960661d7ba
-size 1948
+oid sha256:4f61d76c5b2df68dda7195ace827c18498e27569264856eea4e6cd748b4209fb
+size 1885

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75b40c6fa685efce6535247f6dda2b6843eed683545743472efa7e1e83aa7681
+size 1718

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75b40c6fa685efce6535247f6dda2b6843eed683545743472efa7e1e83aa7681
-size 1718
+oid sha256:c56b821a15bd7ae9280ca337e983ec456d09e8c2e03b930bb1f3a3e9d4c38bf7
+size 1654

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7dc72ccb03537c1f5d6f6cb8f0ce1ef5ce6ed8c45a5ffe39b200c9504f8dd04a
-size 1929
+oid sha256:ee1aa10c0684c602999d5df18a0e93bd1031dde5e6ae91eb97af6ef8052794dd
+size 1866

--- a/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Logotype/without widget/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dc72ccb03537c1f5d6f6cb8f0ce1ef5ce6ed8c45a5ffe39b200c9504f8dd04a
+size 1929

--- a/packages/retail-ui/components/Logotype/Logotype.less
+++ b/packages/retail-ui/components/Logotype/Logotype.less
@@ -36,6 +36,10 @@
     height: 100%;
     display: flex;
     flex-wrap: nowrap;
+
+    &.inline {
+      display: inline-flex;
+    }
   }
 
   .divider {

--- a/packages/retail-ui/components/Logotype/Logotype.tsx
+++ b/packages/retail-ui/components/Logotype/Logotype.tsx
@@ -61,8 +61,8 @@ class Logotype extends React.Component<LogotypeProps> {
     href: '/'
   };
 
-  private _logoWrapper: Nullable<HTMLElement> = null;
-  private _isWidgetInited: boolean = false;
+  private logoWrapper: Nullable<HTMLElement> = null;
+  private isWidgetInited: boolean = false;
 
   public componentDidMount() {
     if (this.props.withWidget) {
@@ -88,7 +88,7 @@ class Logotype extends React.Component<LogotypeProps> {
 
     return (
       <div id="spwDropdown" className={styles.dropdown}>
-        <span ref={this._refLogoWrapper} className={styles.widgetWrapper}>
+        <span ref={this.refLogoWrapper} className={styles.widgetWrapper}>
           <Component href={href} tabIndex="-1" className={styles.root}>
             <span style={{ color: textColor }}>к</span>
             <span style={{ color }}>{createCloud(color)}</span>
@@ -109,30 +109,30 @@ class Logotype extends React.Component<LogotypeProps> {
     );
   }
 
-  private _refLogoWrapper = (el: Nullable<HTMLElement>) => {
-    if (this._logoWrapper) {
+  private refLogoWrapper = (el: Nullable<HTMLElement>) => {
+    if (this.logoWrapper) {
       events.removeEventListener(
-        this._logoWrapper,
+        this.logoWrapper,
         'click',
-        this._handleNativeLogoClick
+        this.handleNativeLogoClick
       );
     }
 
     if (el) {
-      events.addEventListener(el, 'click', this._handleNativeLogoClick);
+      events.addEventListener(el, 'click', this.handleNativeLogoClick);
     }
 
-    this._logoWrapper = el;
+    this.logoWrapper = el;
   };
 
-  private _handleNativeLogoClick = (event: Event) => {
+  private handleNativeLogoClick = (event: Event) => {
     stopPropagation(event);
   };
 
   private initWidget = () => {
-    if (!this._isWidgetInited) {
+    if (!this.isWidgetInited) {
       ProductWidget.init();
-      this._isWidgetInited = true;
+      this.isWidgetInited = true;
     }
   };
 }

--- a/packages/retail-ui/components/Logotype/Logotype.tsx
+++ b/packages/retail-ui/components/Logotype/Logotype.tsx
@@ -62,10 +62,17 @@ class Logotype extends React.Component<LogotypeProps> {
   };
 
   private _logoWrapper: Nullable<HTMLElement> = null;
+  private _isWidgetInited: boolean = false;
 
   public componentDidMount() {
     if (this.props.withWidget) {
-      ProductWidget.init();
+      this.initWidget();
+    }
+  }
+
+  public componentDidUpdate() {
+    if (this.props.withWidget) {
+      this.initWidget();
     }
   }
 
@@ -120,6 +127,13 @@ class Logotype extends React.Component<LogotypeProps> {
 
   private _handleNativeLogoClick = (event: Event) => {
     stopPropagation(event);
+  };
+
+  private initWidget = () => {
+    if (!this._isWidgetInited) {
+      ProductWidget.init();
+      this._isWidgetInited = true;
+    }
   };
 }
 

--- a/packages/retail-ui/components/Logotype/Logotype.tsx
+++ b/packages/retail-ui/components/Logotype/Logotype.tsx
@@ -79,38 +79,26 @@ class Logotype extends React.Component<LogotypeProps> {
       withWidget
     } = this.props;
 
-    if (withWidget) {
-      return (
-        <div id="spwDropdown" className={styles.dropdown}>
-          <span ref={this._refLogoWrapper} className={styles.widgetWrapper}>
-            <Component href={href} tabIndex="-1" className={styles.root}>
-              <span style={{ color: textColor }}>к</span>
-              <span style={{ color }}>{createCloud(color)}</span>
-              <span style={{ color: textColor }}>
-                нтур
-                {suffix && '.'}
-              </span>
-              {suffix && <span style={{ color }}>{suffix}</span>}
-            </Component>
-            <span className={styles.divider} />
-          </span>
+    return (
+      <div id="spwDropdown" className={styles.dropdown}>
+        <span ref={this._refLogoWrapper} className={styles.widgetWrapper}>
+          <Component href={href} tabIndex="-1" className={styles.root}>
+            <span style={{ color: textColor }}>к</span>
+            <span style={{ color }}>{createCloud(color)}</span>
+            <span style={{ color: textColor }}>
+              нтур
+              {suffix && '.'}
+            </span>
+            {suffix && <span style={{ color }}>{suffix}</span>}
+          </Component>
+          {withWidget && <span className={styles.divider} />}
+        </span>
+        {withWidget && (
           <button className={styles.button}>
             <ArrowChevronDownIcon color="#aaa" size={20} />
           </button>
-        </div>
-      );
-    }
-
-    return (
-      <Component href={href} tabIndex="-1" className={styles.root}>
-        <span style={{ color: textColor }}>к</span>
-        <span style={{ color }}>{createCloud(color)}</span>
-        <span style={{ color: textColor }}>
-          нтур
-          {suffix && '.'}
-        </span>
-        {suffix && <span style={{ color }}>{suffix}</span>}
-      </Component>
+        )}
+      </div>
     );
   }
 

--- a/packages/retail-ui/components/Logotype/Logotype.tsx
+++ b/packages/retail-ui/components/Logotype/Logotype.tsx
@@ -7,6 +7,7 @@ import stopPropagation from '../../lib/events/stopPropagation';
 import { Nullable } from '../../typings/utility-types';
 import ProductWidget from './ProductWidget';
 import styles from './Logotype.less';
+import classnames from 'classnames';
 
 const createCloud = (color: string) => (
   <svg width="24" height="17" viewBox="0 0 24 17" className={styles.cloud}>
@@ -85,9 +86,12 @@ class Logotype extends React.Component<LogotypeProps> {
       href = Logotype.defaultProps.href,
       withWidget
     } = this.props;
+    const dropdownClassName = classnames(styles.dropdown, {
+      [styles.inline]: !withWidget
+    });
 
     return (
-      <div id="spwDropdown" className={styles.dropdown}>
+      <div id="spwDropdown" className={dropdownClassName}>
         <span ref={this.refLogoWrapper} className={styles.widgetWrapper}>
           <Component href={href} tabIndex="-1" className={styles.root}>
             <span style={{ color: textColor }}>к</span>

--- a/packages/retail-ui/components/Logotype/__stories__/Logotype.stories.tsx
+++ b/packages/retail-ui/components/Logotype/__stories__/Logotype.stories.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+import Logotype from '../../Logotype';
+
+storiesOf('Logotype', module).add('with widget', () => <WithWidgetToggler />);
+
+class WithWidgetToggler extends React.Component {
+  public state = {
+    widget: false
+  };
+
+  public toggle = () => {
+    this.setState({ widget: !this.state.widget });
+  };
+
+  public render() {
+    return (
+      <div>
+        <Logotype suffix="ui" withWidget={this.state.widget} />
+        <br />
+        <button id="toggle-widget" onClick={this.toggle}>
+          toggle widget
+        </button>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Раньше компонент рендерил блочный или строчный элемент взависимости от флага `withWidget`, и это странным образом никому ничего не ломало. По этому можно предположить, что будет безопасно оставить только один из них (блочный).

Поломки возможны у тех, кто использует Logotype отдельно от TopBar и без виджета (т.е. строчный вариант). Но их будет легко исправить.

Что думаете?

fix #631 