### PR TITLE
refactor(DropdownContainer): render warning fix

### DIFF
--- a/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
+++ b/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
@@ -28,6 +28,7 @@ export interface DropdownContainerProps {
 
 export interface DropdownContainerState {
   position: Nullable<DropdownContainerPosition>;
+  minWidth: number;
   hasStaticRoot?: boolean;
 }
 
@@ -44,6 +45,7 @@ export default class DropdownContainer extends React.Component<
 
   public state: DropdownContainerState = {
     position: null,
+    minWidth: 0,
     hasStaticRoot: true
   };
 
@@ -84,7 +86,7 @@ export default class DropdownContainer extends React.Component<
         bottom: bottom !== null ? bottom : undefined,
         left: left !== null ? left : undefined,
         right: right !== null ? right : undefined,
-        minWidth: this.getMinWidth()
+        minWidth: this.state.minWidth
       };
     }
 
@@ -178,6 +180,7 @@ export default class DropdownContainer extends React.Component<
       };
 
       this.setState({
+        minWidth: this.getMinWidth(),
         position: this.props.disablePortal
           ? this.convertToRelativePosition(position)
           : position

--- a/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
+++ b/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
@@ -8,6 +8,8 @@ import ZIndex from '../ZIndex';
 import { createPropsGetter } from '../internal/createPropsGetter';
 import { Nullable } from '../../typings/utility-types';
 
+type DOMNode = Element | Text | null;
+
 export interface DropdownContainerPosition {
   top: Nullable<number>;
   bottom: Nullable<number>;
@@ -17,7 +19,7 @@ export interface DropdownContainerPosition {
 
 export interface DropdownContainerProps {
   align?: 'left' | 'right';
-  getParent: () => null | Element | Text;
+  getParent: () => DOMNode;
   children?: React.ReactNode;
   disablePortal?: boolean;
   offsetY?: number;
@@ -47,7 +49,7 @@ export default class DropdownContainer extends React.Component<
 
   private getProps = createPropsGetter(DropdownContainer.defaultProps);
 
-  private dom: Nullable<HTMLElement>;
+  private dom: DOMNode = null;
   private layoutSub: Nullable<ReturnType<typeof LayoutEvents.addListener>>;
 
   public componentDidMount() {
@@ -100,10 +102,10 @@ export default class DropdownContainer extends React.Component<
   }
 
   private ref = (e: ZIndex | null) => {
-    this.dom = e && (findDOMNode(e) as HTMLElement);
+    this.dom = e && findDOMNode(e);
   };
 
-  private isElement = (node: Element | Text | null): node is Element => {
+  private isElement = (node: DOMNode): node is Element => {
     return node instanceof Element;
   };
 
@@ -184,7 +186,7 @@ export default class DropdownContainer extends React.Component<
   };
 
   private getHeight = () => {
-    if (!this.dom) {
+    if (!this.isElement(this.dom)) {
       return 0;
     }
     const child = this.dom.children.item(0);


### PR DESCRIPTION
После моих последних изменений стал сыпаться warning по открытию выпадашек:
> Warning: DropdownContainer is accessing findDOMNode inside its render().

Из-за вызова `this.props.getParent()` в процессе рендера, в который пользователи обычно передают `() => findDOMNode(this)`. 

Перенес `minWidth` в state, а её вычисление в `position()`.