### PR TITLE
fix(Select): public focus 

### DIFF
--- a/packages/retail-ui/components/Select/Select.tsx
+++ b/packages/retail-ui/components/Select/Select.tsx
@@ -256,6 +256,13 @@ class Select<TValue = {}, TItem = {}> extends React.Component<
     this._close();
   }
 
+  /**
+   * @public
+   */
+  public focus() {
+    this._focus();
+  }
+
   private renderLabel() {
     const value = this._getValue();
     const item = this._getItemByValue(value);
@@ -507,6 +514,7 @@ class Select<TValue = {}, TItem = {}> extends React.Component<
   private _focus = () => {
     const node = ReactDOM.findDOMNode(this);
     if (node && node instanceof HTMLElement) {
+      node.tabIndex = 0;
       node.focus();
     }
   };


### PR DESCRIPTION
Проблема: у Select не было публичного focus() метода - соответственно он не отображал тултип с валидацией react-ui-validations, которая дергает публичный фокус метод компонента.

Решение: прокинул фокус наружу и добавил tabIndex=0 для span, который не умеет фокуситься из коробки.