### PR TITLE
fix(RenderLayer) не отключает обработку событий

### DIFF
--- a/packages/retail-ui/components/Popup/Popup.tsx
+++ b/packages/retail-ui/components/Popup/Popup.tsx
@@ -238,7 +238,7 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
          * If onCloseRequest is not specified handleClickOutside and handleFocusOutside
          * are doing nothing. So there is no need in RenderLayer at all.
          */
-        active={this.props.onCloseRequest && this.props.opened}
+        active={Boolean(this.props.onCloseRequest) && this.props.opened}
       >
         <RenderContainer
           anchor={child}

--- a/packages/retail-ui/components/Popup/__tests__/__snapshots__/Popup-test.tsx.snap
+++ b/packages/retail-ui/components/Popup/__tests__/__snapshots__/Popup-test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Popup snapshots:  open and close popup: closed popup 1`] = `
   }
 >
   <RenderLayer
-    active={true}
+    active={false}
     onClickOutside={[Function]}
     onFocusOutside={[Function]}
   >
@@ -96,7 +96,7 @@ exports[`Popup snapshots:  open and close popup: closed popup again 1`] = `
   }
 >
   <RenderLayer
-    active={true}
+    active={false}
     onClickOutside={[Function]}
     onFocusOutside={[Function]}
   >
@@ -164,7 +164,7 @@ exports[`Popup snapshots:  open and close popup: opened popup 1`] = `
   }
 >
   <RenderLayer
-    active={true}
+    active={false}
     onClickOutside={[Function]}
     onFocusOutside={[Function]}
   >

--- a/packages/retail-ui/components/RenderLayer/RenderLayer.tsx
+++ b/packages/retail-ui/components/RenderLayer/RenderLayer.tsx
@@ -22,11 +22,24 @@ class RenderLayer extends React.Component<RenderLayerProps> {
   } | null = null;
 
   public componentDidMount() {
-    this.attachListeners();
+    if (this.props.active) {
+      this.attachListeners();
+    }
+  }
+
+  public componentWillReceiveProps(nextProps: RenderLayerProps) {
+    if (!this.props.active && nextProps.active) {
+      this.attachListeners();
+    }
+    if (this.props.active && !nextProps.active) {
+      this.detachListeners();
+    }
   }
 
   public componentWillUnmount() {
-    this.detachListeners();
+    if (this.props.active) {
+      this.detachListeners();
+    }
   }
 
   public render(): JSX.Element {
@@ -64,18 +77,12 @@ class RenderLayer extends React.Component<RenderLayerProps> {
   }
 
   private handleFocusOutside = (event: Event) => {
-    if (!this.props.active) {
-      return;
-    }
     if (this.props.onFocusOutside) {
       this.props.onFocusOutside(event);
     }
   };
 
   private handleNativeDocClick = (event: Event) => {
-    if (!this.props.active) {
-      return;
-    }
     const target = (event.target || event.srcElement) as HTMLElement;
     const node = this.getDomNode();
 

--- a/packages/retail-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/retail-ui/components/Tooltip/Tooltip.tsx
@@ -309,7 +309,9 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
 
       case 'closed':
         return {
-          layerProps: {},
+          layerProps: {
+            active: false
+          },
           wrapperProps: {},
           popupProps: {
             opened: false
@@ -319,7 +321,9 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
       case 'hoverAnchor':
       case 'hover':
         return {
-          layerProps: {},
+          layerProps: {
+            active: false
+          },
           wrapperProps: {
             onMouseEnter: this.handleMouseEnter,
             onMouseLeave: this.handleMouseLeave
@@ -346,7 +350,9 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
 
       case 'focus':
         return {
-          layerProps: {},
+          layerProps: {
+            active: false
+          },
           wrapperProps: {
             onFocus: this.handleFocus,
             onBlur: this.handleBlur


### PR DESCRIPTION
Сломалась отключение обработки событий для Tootip и Hint.
В RenderLayer prop active по умолчанию был равен true.
Tooltip при "close" не передавал active=false, из-за чего события продолжали обрабатываться.
В Popup active={this.props.onCloseRequest && this.props.opened}, если onCloseRequest не передавался, то был равен undefined и active брался из defaultProps и был равен true.