### PR TITLE
fix(InputLikeText): fix overflow inside flex container

### DIFF
--- a/packages/react-ui-screenshot-tests/gemini/ComboBox.js
+++ b/packages/react-ui-screenshot-tests/gemini/ComboBox.js
@@ -34,6 +34,13 @@ gemini.suite("ComboBox", () => {
         .setCaptureElements("#test-element")
         .capture("plain");
     });
+
+    gemini.suite("Inside flex container", suite => {
+      suite
+        .before(renderStory("ComboBoxView", "in flex modal"))
+        .setCaptureElements("html")
+        .capture("plain");
+    });
   });
 
   gemini.suite("Component", () => {

--- a/packages/react-ui-screenshot-tests/gemini/DateInput.js
+++ b/packages/react-ui-screenshot-tests/gemini/DateInput.js
@@ -1,0 +1,27 @@
+var renderStory = require("./utils").renderStory;
+
+gemini.suite("DateInput", () => {
+  gemini.suite("simple", suite => {
+    suite
+      .before(renderStory("DateInput", "simple"))
+      .setCaptureElements("#test-element")
+      .capture("idle")
+      .capture("focus", actions => actions.click("[class^='Input-input']"));
+  });
+
+  gemini.suite("disabled", suite => {
+    suite
+      .before(renderStory("DateInput", "disabled"))
+      .setCaptureElements("#test-element")
+      .capture("idle")
+      .capture("focus", actions => actions.click("[class^='Input-input']"));
+  });
+
+  gemini.suite("with width", suite => {
+    suite
+      .before(renderStory("DateInput", "with width"))
+      .setCaptureElements("#test-element")
+      .capture("idle")
+      .capture("focus", actions => actions.click("[class^='Input-input']"));
+  });
+});

--- a/packages/react-ui-screenshot-tests/gemini/screens/ComboBox/View/Inside flex container/plain/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/ComboBox/View/Inside flex container/plain/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58109e8081aa19d617137e0c2ceacc603780b20cf7c8a5b95920e99f5e8a1a5e
+size 6792

--- a/packages/react-ui-screenshot-tests/gemini/screens/ComboBox/View/Inside flex container/plain/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/ComboBox/View/Inside flex container/plain/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6255e3f5111d47d7f77e76196c8dd8781cefea0d03a4d27d1bed5f4e9d1e0d95
+size 6300

--- a/packages/react-ui-screenshot-tests/gemini/screens/ComboBox/View/Inside flex container/plain/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/ComboBox/View/Inside flex container/plain/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5cf9ca7abeece150f463e92202ed896c6f72ba7e2522a70d99e939808ed8f34
+size 6447

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/focus/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/focus/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:806a54a706265a547c10c3d3d708293711f5f667c2ccd4259c8bb338098d8c3e
+size 899

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/focus/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/focus/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:827e6d2f80a4d5983b7d67677a558146a4723444b6632a64c0306478af3fa7e9
+size 675

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/focus/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/focus/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d0fc6c71893ca9944d7a8fa9ec3f157cbc4b1d708d9972b3c353c9fedd33c2c
+size 932

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/idle/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/idle/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:806a54a706265a547c10c3d3d708293711f5f667c2ccd4259c8bb338098d8c3e
+size 899

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/idle/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/idle/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:827e6d2f80a4d5983b7d67677a558146a4723444b6632a64c0306478af3fa7e9
+size 675

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/idle/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/disabled/idle/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d0fc6c71893ca9944d7a8fa9ec3f157cbc4b1d708d9972b3c353c9fedd33c2c
+size 932

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/focus/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/focus/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb44a918e5a3f835be74358dacad4928245fc355cef5d95d0b2e3c8cde4fc96b
+size 1002

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/focus/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/focus/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b0c10efdb1d7a6b0550c8d12ede7ac5326c5f70938b3d78123a0e2d23fd9f6a
+size 939

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/focus/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/focus/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bcb344439e95db328ac36b43988186727f5dfc1f68c36954c243bdccca4de2d
+size 1034

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/idle/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/idle/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ca2f7bb0ecdb928417829d19f910f8f0123252350c7ec1c3b01963d666ff6c7
+size 814

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/idle/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/idle/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee26021cf2d7da25cf2b0d1c7ecaf44715c3e21b392a99140e35dec26a527fe0
+size 670

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/idle/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/simple/idle/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1ee07fba7e0df1b97a8a95e743e574c2d0b5a7de5aab0cbf51e098d8b13cec0
+size 893

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/focus/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/focus/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42a0371f100fce434b21c8f36f4b28bc0069cd8b0dd85dc6a532a9fd7cb6f026
+size 593

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/focus/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/focus/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3821f6299b6cc1c22da644108f832b916a58483c3baa2f74d7c47062ef54b42
+size 580

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/focus/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/focus/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc439a859bf74d4be77d8ae36589046720a8cad71ecb9f0d742e23a5e76654ff
+size 630

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/idle/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/idle/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf47bc22f4392a469fabdde53a8e493cdaa5adb1f83f1e566f6444681f826ecb
+size 472

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/idle/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/idle/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb117f8f0554aa3efc753899da8e86e31d5248f7bd3d0303bb24e05f432810ff
+size 412

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/idle/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateInput/with width/idle/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df8897643d79412003b7791c991630834c44b89d807f1d2db26d918bc413f18f
+size 544

--- a/packages/react-ui-screenshot-tests/gemini/screens/DatePicker/opened/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DatePicker/opened/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2ef7377223fc31664fb2108967e306903fe99af2c36f43bc6a6ebb7e717e9de
-size 9595
+oid sha256:2fe0ee57cf9850ab5bca00804e660468d79c920677d0b66a874c5913f97bd3ef
+size 9576

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateSelect in DatePicker/DateSelect year/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateSelect in DatePicker/DateSelect year/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d6be0e880a275f837562b2bdd27747da58f1b21db9db0006cc6445f9b1e5ddbf
-size 11703
+oid sha256:53dde44032a7a5af2d15575cd04ac989f599f62d1f15d779733e5b54f2927bcf
+size 11685

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateSelect with disabled items/DateSelect months/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateSelect with disabled items/DateSelect months/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:122ede79be7cb2fd37a238eae7fbc77b3c8732e5d886d47e62b3ec8351cb4011
-size 13863
+oid sha256:1f8ee810610386c1527e977c2822972b35ad399c6686366cc68d7fdf033b71aa
+size 13890

--- a/packages/react-ui-screenshot-tests/gemini/screens/DateSelect with disabled items/DateSelect years/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/DateSelect with disabled items/DateSelect years/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbce8cc907de689261b5036b03a0b78699cac9be4895b88192e16c1a136d1e2f
-size 11392
+oid sha256:5c83670f5050a69feae01a69742ca2c405de66b708ba82816d407b2cfc32f7f4
+size 11442

--- a/packages/retail-ui/components/CustomComboBox/__stories__/View.stories.tsx
+++ b/packages/retail-ui/components/CustomComboBox/__stories__/View.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react';
 
 import View from '../ComboBoxView';
 import Gapped from '../../Gapped';
+import Modal from '../../Modal';
 
 storiesOf('ComboBoxView', module)
   .add('input like text', () => (
@@ -126,6 +127,17 @@ storiesOf('ComboBoxView', module)
         renderItem={complexRenderValue}
       />
     </div>
+  ))
+  .add('in flex modal', () => (
+    <Modal width="250px">
+      <Modal.Body>
+        <div style={{ display: 'flex' }}>
+          <div style={{ flexGrow: 2 }}>
+            <View value={'Hello world! '.repeat(5)} width="100%" />
+          </div>
+        </div>
+      </Modal.Body>
+    </Modal>
   ));
 
 function simpleRenderValue(value: { value: number; label: string }) {

--- a/packages/retail-ui/components/DateInput/DateInput.less
+++ b/packages/retail-ui/components/DateInput/DateInput.less
@@ -9,25 +9,9 @@
 }
 
 :local {
-  .wrapper,
   .root {
     font-family: kontur-mask-char, Segoe UI, Helevetica Neue, sans-serif;
-  }
-
-  .wrapper {
-    display: inline-block;
-    position: relative;
-  }
-
-  .root {
     cursor: text;
-  }
-
-  .disabled {
-    background: @bg-disabled;
-    border-color: @border-color-gray-light;
-    color: @text-color-disabled;
-    pointer-events: none;
   }
 
   .mask {
@@ -44,5 +28,9 @@
 
   .icon {
     color: @date_input-icon-color;
+
+    &.disabled {
+      color: @text-color-disabled;
+    }
   }
 }

--- a/packages/retail-ui/components/DateInput/DateInput.tsx
+++ b/packages/retail-ui/components/DateInput/DateInput.tsx
@@ -181,25 +181,15 @@ class DateInput extends React.Component<DateInputProps, DateInputState> {
   }
 
   public render() {
-    return (
-      <div
-        className={classNames(
-          styles.wrapper,
-          this.props.disabled && styles.disabled
-        )}
-        style={{ width: this.props.width }}
-      >
-        {DateInputConfig.polyfillInput
-          ? /**
-             * Internet Explorer looses focus on element, if its containing node
-             * would be selected with selectNodeContents
-             *
-             * Rendering input with mask
-             */
-            this.renderInputLikeText()
-          : this.renderInput()}
-      </div>
-    );
+    return DateInputConfig.polyfillInput
+      ? /**
+         * Internet Explorer looses focus on element, if its containing node
+         * would be selected with selectNodeContents
+         *
+         * Rendering input with mask
+         */
+        this.renderInputLikeText()
+      : this.renderInput();
   }
 
   private renderInput() {
@@ -207,7 +197,7 @@ class DateInput extends React.Component<DateInputProps, DateInputState> {
 
     return (
       <Input
-        width="100%"
+        width={this.props.width}
         ref={el => (this._input = el)}
         size={this.props.size}
         disabled={this.props.disabled}
@@ -230,7 +220,7 @@ class DateInput extends React.Component<DateInputProps, DateInputState> {
     const isMaskHidden = this.checkIfMaskHidden();
     return (
       <InputLikeText
-        width="100%"
+        width={this.props.width}
         ref={el => (this._inputlikeText = el)}
         size={this.props.size}
         disabled={this.props.disabled}
@@ -294,6 +284,9 @@ class DateInput extends React.Component<DateInputProps, DateInputState> {
   };
 
   private handleMouseDown = (event: React.MouseEvent<HTMLInputElement>) => {
+    if (this.props.disabled) {
+      return;
+    }
     event.preventDefault();
     this.selectDatePart(DateParts.Date);
 
@@ -519,9 +512,14 @@ class DateInput extends React.Component<DateInputProps, DateInputState> {
   }
 
   private renderIcon = () => {
+    const iconStyles = classNames({
+      [styles.icon]: true,
+      [styles.disabled]: this.props.disabled
+    });
+
     if (this.props.withIcon) {
       return () => (
-        <span className={styles.icon}>
+        <span className={iconStyles}>
           <CalendarIcon size={this._getIconSize()} />
         </span>
       );

--- a/packages/retail-ui/components/DateInput/__stories__/DateInput.stories.tsx
+++ b/packages/retail-ui/components/DateInput/__stories__/DateInput.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import DateInput from '../DateInput';
+
+storiesOf('DateInput', module)
+  .add('simple', () => <DateInput value="01.02.2017" />)
+  .add('disabled', () => <DateInput disabled value="01.02.2017" />)
+  .add('with width', () => <DateInput width="50px" value="01.02.2017" />);

--- a/packages/retail-ui/components/internal/InputLikeText/InputLikeText.less
+++ b/packages/retail-ui/components/internal/InputLikeText/InputLikeText.less
@@ -1,0 +1,6 @@
+:local {
+  .input {
+    position: absolute;
+    top: 0;
+  }
+}

--- a/packages/retail-ui/components/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/retail-ui/components/internal/InputLikeText/InputLikeText.tsx
@@ -7,6 +7,8 @@ import { Nullable, TimeoutID } from '../../../typings/utility-types';
 import { InputVisibilityState, IconType } from '../../Input/Input';
 import { InputProps } from '../../Input';
 
+import styles from './InputLikeText.less';
+
 const isFlatDesign = Upgrades.isFlatDesignEnabled();
 
 const inputStyles = isFlatDesign
@@ -119,7 +121,9 @@ export default class InputLikeText extends React.Component<
           {prefix && <span className={inputStyles.prefix}>{prefix}</span>}
         </span>
         <span className={inputStyles.wrapper}>
-          <span className={classNames(inputStyles.input)}>{children}</span>
+          <span className={classNames(inputStyles.input, styles.input)}>
+            {children}
+          </span>
           {this.renderPlaceholder()}
         </span>
         <span

--- a/packages/retail-ui/components/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/retail-ui/components/internal/InputLikeText/InputLikeText.tsx
@@ -9,7 +9,7 @@ import { InputProps } from '../../Input';
 
 const isFlatDesign = Upgrades.isFlatDesignEnabled();
 
-const styles = isFlatDesign
+const inputStyles = isFlatDesign
   ? require('../../Input/Input.flat.less')
   : require('../../Input/Input.less');
 
@@ -95,13 +95,13 @@ export default class InputLikeText extends React.Component<
       ...rest
     } = this.props;
 
-    const className = classNames(styles.root, this._getSizeClassName(), {
-      [styles.disabled]: this.props.disabled,
-      [styles.error]: error,
-      [styles.warning]: warning,
-      [styles.borderless]: borderless,
-      [styles.blink]: this.state.blinking,
-      [styles.focus]: this.state.focused
+    const className = classNames(inputStyles.root, this._getSizeClassName(), {
+      [inputStyles.disabled]: this.props.disabled,
+      [inputStyles.error]: error,
+      [inputStyles.warning]: warning,
+      [inputStyles.borderless]: borderless,
+      [inputStyles.blink]: this.state.blinking,
+      [inputStyles.focus]: this.state.focused
     });
 
     return (
@@ -114,18 +114,21 @@ export default class InputLikeText extends React.Component<
         onBlur={this.handleBlur}
         ref={this._ref}
       >
-        <span className={styles.sideContainer}>
+        <span className={inputStyles.sideContainer}>
           {this.renderLeftIcon()}
-          {prefix && <span className={styles.prefix}>{prefix}</span>}
+          {prefix && <span className={inputStyles.prefix}>{prefix}</span>}
         </span>
-        <span className={styles.wrapper}>
-          <span className={styles.input}>{children}</span>
+        <span className={inputStyles.wrapper}>
+          <span className={classNames(inputStyles.input)}>{children}</span>
           {this.renderPlaceholder()}
         </span>
         <span
-          className={classNames(styles.sideContainer, styles.rightContainer)}
+          className={classNames(
+            inputStyles.sideContainer,
+            inputStyles.rightContainer
+          )}
         >
-          {suffix && <span className={styles.suffix}>{suffix}</span>}
+          {suffix && <span className={inputStyles.suffix}>{suffix}</span>}
           {this.renderRightIcon()}
         </span>
       </span>
@@ -143,18 +146,18 @@ export default class InputLikeText extends React.Component<
     const { children, placeholder } = this.props;
 
     if (!children && placeholder) {
-      return <span className={styles.placeholder}>{placeholder}</span>;
+      return <span className={inputStyles.placeholder}>{placeholder}</span>;
     }
     return null;
   }
 
   private _getSizeClassName() {
     const SIZE_CLASS_NAMES = {
-      small: styles.sizeSmall,
+      small: inputStyles.sizeSmall,
       medium: Upgrades.isSizeMedium16pxEnabled()
-        ? styles.sizeMedium
-        : styles.DEPRECATED_sizeMedium,
-      large: styles.sizeLarge
+        ? inputStyles.sizeMedium
+        : inputStyles.DEPRECATED_sizeMedium,
+      large: inputStyles.sizeLarge
     };
 
     return SIZE_CLASS_NAMES[this.props.size!];
@@ -176,11 +179,11 @@ export default class InputLikeText extends React.Component<
   };
 
   private renderLeftIcon() {
-    return this.renderIcon(this.props.leftIcon, styles.leftIcon);
+    return this.renderIcon(this.props.leftIcon, inputStyles.leftIcon);
   }
 
   private renderRightIcon() {
-    return this.renderIcon(this.props.rightIcon, styles.rightIcon);
+    return this.renderIcon(this.props.rightIcon, inputStyles.rightIcon);
   }
 
   private renderIcon(icon: IconType, className: string) {
@@ -193,7 +196,7 @@ export default class InputLikeText extends React.Component<
     }
 
     return (
-      <span className={classNames(className, styles.useDefaultColor)}>
+      <span className={classNames(className, inputStyles.useDefaultColor)}>
         {icon}
       </span>
     );


### PR DESCRIPTION
fix #1116
fix #1119 

- Вернул обратно `position: absolute` для корректного вычисления ширины `InputLikeText` внутри флекс контейнеров
- `top: 0` нужен для правильного отображения текста в ИЕ11 и старых версиях FF
- По каким-то причинам `top: 0` привел к тому что в chrome для `DateInput` текст стал на 1 px ниже
  - Починил тем что убрал обертку в `DateInput`
- В качестве побочных эффектов:
  - Было исправлено выделение текста в задизейбленом состоянии
  - Курсор мыши в `DatePicker` выглядит однообразно с `Input`
  - Вероятно будет исправлен мигающий тест в ИЕ на `DatePicker`