### PR TITLE
build(retail-ui): add public url for styleguide dev-server

### DIFF
--- a/packages/retail-ui/styleguide.config.js
+++ b/packages/retail-ui/styleguide.config.js
@@ -193,6 +193,9 @@ const webpackConfig = {
         use: ['file-loader']
       }
     ]
+  },
+  devServer: {
+    public: 'localhost.dev.kontur'
   }
 };
 


### PR DESCRIPTION
Styleguidist должен заработать на хосте `localhost.dev.kontur`, чтобы компоненты могли ходить с него на `api.dev.kontur` .