### PR TITLE
fix(Tooltip): fixed closing for `hoverAnchor` 

### DIFF
--- a/packages/retail-ui/components/Popup/Popup.less
+++ b/packages/retail-ui/components/Popup/Popup.less
@@ -13,6 +13,10 @@
     min-width: 18px;
     border-radius: @popup-border-radius;
     border: @popup-border @popup-border-color;
+
+    &-ignore-hover {
+      pointer-events: none;
+    }
   }
 
   .content {

--- a/packages/retail-ui/components/Popup/Popup.tsx
+++ b/packages/retail-ui/components/Popup/Popup.tsx
@@ -74,6 +74,7 @@ export interface PopupProps extends PopupHandlerProps {
   popupOffset: number;
   positions: string[];
   onCloseRequest?: () => void;
+  ignoreHover?: boolean;
 }
 
 interface PopupLocation {
@@ -146,7 +147,12 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
      * С какой стороны показывать попап и край попапа,
      * на котором будет отображаться пин
      */
-    positions: PropTypes.array
+    positions: PropTypes.array,
+
+    /**
+     * Игнорировать ли события hover/click
+     */
+    ignoreHover: PropTypes.bool,
   };
 
   public static defaultProps = {
@@ -340,6 +346,7 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
             ref={this.refPopupElement}
             className={cn({
               [styles.popup]: true,
+              [styles['popup-ignore-hover']]: this.props.ignoreHover,
               [styles.shadow]: this.props.hasShadow,
               [styles['transition-enter']]: state === 'entering',
               [styles['transition-enter-active']]: state === 'entered',

--- a/packages/retail-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/retail-ui/components/Tooltip/Tooltip.tsx
@@ -259,6 +259,7 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
         pinOffset={POPUP_PIN_OFFSET}
         disableAnimations={this.props.disableAnimations}
         positions={this.getPositions()}
+        ignoreHover={this.props.trigger === 'hoverAnchor'}
         {...popupProps}
       >
         {content}
@@ -394,9 +395,13 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
       clearTimeout(this.hoverTimeout);
       this.hoverTimeout = null;
     }
-    this.hoverTimeout = window.setTimeout(() => {
+    if (this.props.trigger === 'hoverAnchor') {
       this.close();
-    }, Tooltip.closeDelay);
+    } else {
+      this.hoverTimeout = window.setTimeout(() => {
+        this.close();
+      }, Tooltip.closeDelay);
+    }
   };
 
   private handleClick = () => {


### PR DESCRIPTION
fix #973

Добавил новый флаг для Popup - `ignoreHover: boolean`.
Использую этот флаг в тултипе при условии `props.trigger === 'hoverAnchor'`