### PR TITLE
fix(PasswordInput): remove not DOM prop `detectCapsLock`

### DIFF
--- a/packages/retail-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/retail-ui/components/PasswordInput/PasswordInput.tsx
@@ -173,8 +173,9 @@ export default class PasswordInput extends React.Component<
   };
 
   private renderInput() {
+    const { detectCapsLock, ...props } = this.props;
     const inputProps = {
-      ...this.props,
+      ...props,
       onKeyDown: this.handleKeydown,
       onKeyPress: this.handleKeyPress,
       rightIcon: this.renderEye()


### PR DESCRIPTION
```javascript
warning.js:33 Warning: React does not recognize the `detectCapsLock` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `detectcapslock` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in input (created by Input)
    in span (created by Input)
    in label (created by Input)
    in Input (created by PasswordInput)
    in div (created by PasswordInput)
    in PasswordInput (created by Component)
    in div (created by Component)
    in Component
    in div
```