### PR TITLE
fix(retail-ui-testing): change config jest and .gitignore

### DIFF
--- a/packages/retail-ui/.gitignore
+++ b/packages/retail-ui/.gitignore
@@ -19,6 +19,7 @@ gemini-report
 /components/**/*.d.ts
 /components/**/*.js
 /components/**/*.map
+/components/**/*.snap
 
 
 yarn-debug.log

--- a/packages/retail-ui/package.json
+++ b/packages/retail-ui/package.json
@@ -169,14 +169,6 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
     "setupFiles": [
       "<rootDir>/test-setup.js"
     ]


### PR DESCRIPTION
Поправил конфиг для запуска тестов локально

Было:
```powershell
Test Suites: 39 failed, 84 passed, 123 total
Tests:       1356 passed, 1356 total
Snapshots:   6 passed, 6 total
Time:        31.173s
```
Стало:
```powershell
Test Suites: 38 passed, 38 total
Tests:       392 passed, 392 total
Snapshots:   3 passed, 3 total
Time:        18.682s
```