### PR TITLE
Date picker range

### DIFF
--- a/packages/retail-ui/components/DatePickerRange/DatePickerRange.tsx
+++ b/packages/retail-ui/components/DatePickerRange/DatePickerRange.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import {CSSProperties, HTMLProps} from 'react';
 import DatePicker from "../DatePicker/DatePicker";
 
-export interface PeriodValues {
+export interface DatePickerRangeValues {
   startValue: string;
   endValue: string;
 }
 
-interface PeriodUIProps {
-  separator?: string | JSX.Element;
+interface DatePickerRangeUIProps {
+  separator?: string | React.ReactNode;
   vertical?: boolean;
   horizontalMargin?: number;
   verticalMargin?: number;
@@ -23,7 +23,7 @@ interface DatePickerRangeValidationProps {
   useFocusOnStartDatePicker?: boolean;
 }
 
-interface HandleEvents {
+interface DatePickerRangeHandleEvents {
   onBlur?: (...args: any[]) => any;
   onChange?: (...args: any[]) => any;
   onFocus?: (...args: any[]) => any;
@@ -33,14 +33,15 @@ interface HandleEvents {
   onMouseOver?: (...args: any[]) => any;
 }
 
-export interface DatePickerRangeProps extends PeriodValues, PeriodUIProps, DatePickerRangeValidationProps, HandleEvents {
+export interface DatePickerRangeProps
+  extends DatePickerRangeValues, DatePickerRangeUIProps, DatePickerRangeValidationProps, DatePickerRangeHandleEvents {
   onStartChange: (e: { target: { value: string } }, v: string) => void;
   onEndChange: (e: { target: { value: string } }, v: string) => void;
   disableRange?: boolean;
 }
 
 export class DatePickerRange extends React.Component<DatePickerRangeProps> {
-  private readonly defaultSeparatorStyles: CSSProperties = {
+  private readonly _defaultSeparatorStyles: CSSProperties = {
     display: 'flex',
     width: 30,
     height: 34,
@@ -49,22 +50,22 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
     lineHeight: 0
   };
 
-  private DatePickerRange: React.RefObject<HTMLDivElement> = React.createRef();
-  private StartDatePicker: React.RefObject<DatePicker> = React.createRef();
-  private EndDatePicker: React.RefObject<DatePicker> = React.createRef();
+  private _datePickerRange: React.RefObject<HTMLDivElement> = React.createRef();
+  private _startDatePicker: React.RefObject<DatePicker> = React.createRef();
+  private _endDatePicker: React.RefObject<DatePicker> = React.createRef();
 
-  private readonly defaultSeparator = <span style={this.defaultSeparatorStyles}>—</span>;
+  private readonly _defaultSeparator = <span style={this._defaultSeparatorStyles}>—</span>;
 
   focus = () => {
     this.props.useFocusOnStartDatePicker
-      ? this.StartDatePicker && this.StartDatePicker.current && this.StartDatePicker.current.focus()
-      : this.EndDatePicker && this.EndDatePicker.current && this.EndDatePicker.current.focus();
+      ? this._startDatePicker && this._startDatePicker.current && this._startDatePicker.current.focus()
+      : this._endDatePicker && this._endDatePicker.current && this._endDatePicker.current.focus();
   };
 
   blur = () => {
     this.props.useFocusOnStartDatePicker
-      ? this.StartDatePicker && this.StartDatePicker.current && this.StartDatePicker.current.blur()
-      : this.EndDatePicker && this.EndDatePicker.current && this.EndDatePicker.current.blur();
+      ? this._startDatePicker && this._startDatePicker.current && this._startDatePicker.current.blur()
+      : this._endDatePicker && this._endDatePicker.current && this._endDatePicker.current.blur();
   };
 
   render(): JSX.Element {
@@ -109,11 +110,11 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
     }
 
     return (
-      <div ref={this.DatePickerRange} style={wrapperStyle}>
+      <div ref={this._datePickerRange} style={wrapperStyle}>
         <span style={startWrapperStyles}
               onFocus={this._onStartWrapperFocus}
               onBlur={this._onStartWrapperBlur}>
-          <DatePicker ref={this.StartDatePicker}
+          <DatePicker ref={this._startDatePicker}
                       value={startValue}
                       onChange={this._onStartChange}
                       maxDate={!disableRange ? this.props.endValue : ''}
@@ -124,13 +125,13 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
 
         {!disableDefaultSeparator && (
           <span {...separatorProps}>
-            {separator || (vertical ? null : this.defaultSeparator)}
+            {separator || (vertical ? null : this._defaultSeparator)}
           </span>
         )}
 
         <span onFocus={this._onEndWrapperFocus}
               onBlur={this._onEndWrapperBlur}>
-          <DatePicker ref={this.EndDatePicker}
+          <DatePicker ref={this._endDatePicker}
                       error={error}
                       value={endValue}
                       onChange={this._onEndChange}
@@ -158,26 +159,26 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
   }
 
   private _onStartWrapperFocus = () => {
-    if (this.StartDatePicker && this.StartDatePicker.current && this.props.error) {
-      this.StartDatePicker.current.focus();
+    if (this._startDatePicker && this._startDatePicker.current && this.props.error) {
+      this._startDatePicker.current.focus();
     }
   }
 
   private _onStartWrapperBlur = () => {
-    if (this.StartDatePicker && this.StartDatePicker.current && this.props.error) {
-      this.StartDatePicker.current.blur();
+    if (this._startDatePicker && this._startDatePicker.current && this.props.error) {
+      this._startDatePicker.current.blur();
     }
   }
 
   private _onEndWrapperFocus = () => {
-    if (this.EndDatePicker && this.EndDatePicker.current) {
-      this.EndDatePicker.current.focus();
+    if (this._endDatePicker && this._endDatePicker.current) {
+      this._endDatePicker.current.focus();
     }
   }
 
   private _onEndWrapperBlur = () => {
-    if (this.EndDatePicker && this.EndDatePicker.current) {
-      this.EndDatePicker.current.blur();
+    if (this._endDatePicker && this._endDatePicker.current) {
+      this._endDatePicker.current.blur();
     }
   }
 }

--- a/packages/retail-ui/components/DatePickerRange/DatePickerRange.tsx
+++ b/packages/retail-ui/components/DatePickerRange/DatePickerRange.tsx
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import {CSSProperties, HTMLProps} from 'react';
+import DatePicker from "../DatePicker/DatePicker";
+
+export interface PeriodValues {
+  startValue: string;
+  endValue: string;
+}
+
+interface PeriodUIProps {
+  separator?: string | JSX.Element;
+  vertical?: boolean;
+  horizontalMargin?: number;
+  verticalMargin?: number;
+  startWidth?: number;
+  endWidth?: number;
+  disableDefaultSeparator?: boolean;
+}
+
+interface DatePickerRangeValidationProps {
+  error?: boolean;
+  warning?: boolean;
+  useFocusOnStartDatePicker?: boolean;
+}
+
+interface HandleEvents {
+  onBlur?: (...args: any[]) => any;
+  onChange?: (...args: any[]) => any;
+  onFocus?: (...args: any[]) => any;
+  onKeyDown?: (...args: any[]) => any;
+  onMouseEnter?: (...args: any[]) => any;
+  onMouseLeave?: (...args: any[]) => any;
+  onMouseOver?: (...args: any[]) => any;
+}
+
+export interface DatePickerRangeProps extends PeriodValues, PeriodUIProps, DatePickerRangeValidationProps, HandleEvents {
+  onStartChange: (e: { target: { value: string } }, v: string) => void;
+  onEndChange: (e: { target: { value: string } }, v: string) => void;
+  disableRange?: boolean;
+}
+
+export class DatePickerRange extends React.Component<DatePickerRangeProps> {
+  private readonly defaultSeparatorStyles: CSSProperties = {
+    display: 'flex',
+    width: 30,
+    height: 34,
+    alignItems: 'center',
+    justifyContent: 'center',
+    lineHeight: 0
+  };
+
+  private DatePickerRange: React.RefObject<HTMLDivElement> = React.createRef();
+  private StartDatePicker: React.RefObject<DatePicker> = React.createRef();
+  private EndDatePicker: React.RefObject<DatePicker> = React.createRef();
+
+  private readonly defaultSeparator = <span style={this.defaultSeparatorStyles}>—</span>;
+
+  focus = () => {
+    this.props.useFocusOnStartDatePicker
+      ? this.StartDatePicker && this.StartDatePicker.current && this.StartDatePicker.current.focus()
+      : this.EndDatePicker && this.EndDatePicker.current && this.EndDatePicker.current.focus();
+  };
+
+  blur = () => {
+    this.props.useFocusOnStartDatePicker
+      ? this.StartDatePicker && this.StartDatePicker.current && this.StartDatePicker.current.blur()
+      : this.EndDatePicker && this.EndDatePicker.current && this.EndDatePicker.current.blur();
+  };
+
+  render(): JSX.Element {
+    const {
+      startValue,
+      endValue,
+      separator,
+      disableDefaultSeparator,
+      startWidth,
+      endWidth,
+      disableRange,
+      vertical,
+      error,
+      warning,
+      onBlur,
+      onChange,
+      onFocus,
+      onKeyDown,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseOver
+    } = this.props;
+
+    const commonDatePickerProps = {
+      error, warning, onBlur, onFocus, onKeyDown, onMouseEnter, onMouseLeave, onMouseOver
+    };
+
+    const separatorProps: HTMLProps<HTMLSpanElement> = {
+      style: {display: 'flex', alignItems: 'center'},
+      onMouseEnter,
+      onMouseLeave,
+      onMouseOver
+    };
+
+    const wrapperStyle: CSSProperties = {
+      display: 'flex',
+      flexDirection: vertical ? 'column' : 'row'
+    }
+
+    return (
+      <div ref={this.DatePickerRange} style={wrapperStyle}>
+        <span style={this.getStartWrapperStyles()}
+              onFocus={this.onStartWrapperFocus}
+              onBlur={this.onStartWrapperBlur}>
+          <DatePicker ref={this.StartDatePicker}
+                      value={startValue}
+                      onChange={(e, v) => {
+                        this.onStartChange(e, v);
+                        onChange && onChange(e, v)
+                      }}
+                      maxDate={!disableRange ? this.props.endValue : ''}
+                      width={startWidth}
+                      {...commonDatePickerProps}
+          />
+        </span>
+
+        {!disableDefaultSeparator && (
+          <span {...separatorProps}>
+            {separator || (vertical ? null : this.defaultSeparator)}
+          </span>
+        )}
+
+        <span style={this.getEndWrapperStyles()}
+              onFocus={this.onEndWrapperFocus}
+              onBlur={this.onEndWrapperBlur}>
+          <DatePicker ref={this.EndDatePicker}
+                      error={error}
+                      value={endValue}
+                      onChange={(e, v) => {
+                        this.onEndChange(e, v);
+                        onChange && onChange(e, v);
+                      }}
+                      minDate={!disableRange ? this.props.startValue : ''}
+                      width={endWidth}
+                      {...commonDatePickerProps}
+          />
+         </span>
+      </div>
+    );
+  }
+
+  private onStartChange = (e: { target: { value: string } }, v: string) => {
+    !this.props.disableRange && this.setState({minDate: v});
+    this.props.onStartChange && this.props.onStartChange(e, v);
+  }
+
+  private onEndChange = (e: { target: { value: string } }, v: string) => {
+    !this.props.disableRange && this.setState({maxDate: v});
+    this.props.onEndChange && this.props.onEndChange(e, v);
+  }
+
+  private onStartWrapperFocus = () => {
+    if (this.StartDatePicker && this.StartDatePicker.current && this.props.error) {
+      this.StartDatePicker.current.focus();
+    }
+  }
+
+  private onStartWrapperBlur = () => {
+    if (this.StartDatePicker && this.StartDatePicker.current && this.props.error) {
+      this.StartDatePicker.current.blur();
+    }
+  }
+
+  private onEndWrapperFocus = () => {
+    if (this.EndDatePicker && this.EndDatePicker.current) {
+      this.EndDatePicker.current.focus();
+    }
+  }
+
+  private onEndWrapperBlur = () => {
+    if (this.EndDatePicker && this.EndDatePicker.current) {
+      this.EndDatePicker.current.blur();
+    }
+  }
+
+  private getStartWrapperStyles = (): CSSProperties => {
+    const {separator, vertical, horizontalMargin, verticalMargin, disableDefaultSeparator} = this.props;
+
+    return {
+      marginBottom: (!separator && vertical && verticalMargin) || 'unset',
+      marginRight: (!separator && !vertical && disableDefaultSeparator && horizontalMargin) || 'unset'
+    }
+  }
+
+  private getEndWrapperStyles = (): CSSProperties => {
+    return {};
+  }
+}

--- a/packages/retail-ui/components/DatePickerRange/DatePickerRange.tsx
+++ b/packages/retail-ui/components/DatePickerRange/DatePickerRange.tsx
@@ -77,10 +77,11 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
       endWidth,
       disableRange,
       vertical,
+      verticalMargin,
+      horizontalMargin,
       error,
       warning,
       onBlur,
-      onChange,
       onFocus,
       onKeyDown,
       onMouseEnter,
@@ -88,9 +89,7 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
       onMouseOver
     } = this.props;
 
-    const commonDatePickerProps = {
-      error, warning, onBlur, onFocus, onKeyDown, onMouseEnter, onMouseLeave, onMouseOver
-    };
+    const commonDatePickerProps = {error, warning, onBlur, onFocus, onKeyDown, onMouseEnter, onMouseLeave, onMouseOver};
 
     const separatorProps: HTMLProps<HTMLSpanElement> = {
       style: {display: 'flex', alignItems: 'center'},
@@ -104,17 +103,19 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
       flexDirection: vertical ? 'column' : 'row'
     }
 
+    const startWrapperStyles: CSSProperties = {
+      marginBottom: (!separator && vertical && verticalMargin) || 'unset',
+      marginRight: (!separator && !vertical && disableDefaultSeparator && horizontalMargin) || 'unset'
+    }
+
     return (
       <div ref={this.DatePickerRange} style={wrapperStyle}>
-        <span style={this.getStartWrapperStyles()}
-              onFocus={this.onStartWrapperFocus}
-              onBlur={this.onStartWrapperBlur}>
+        <span style={startWrapperStyles}
+              onFocus={this._onStartWrapperFocus}
+              onBlur={this._onStartWrapperBlur}>
           <DatePicker ref={this.StartDatePicker}
                       value={startValue}
-                      onChange={(e, v) => {
-                        this.onStartChange(e, v);
-                        onChange && onChange(e, v)
-                      }}
+                      onChange={this._onStartChange}
                       maxDate={!disableRange ? this.props.endValue : ''}
                       width={startWidth}
                       {...commonDatePickerProps}
@@ -127,16 +128,12 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
           </span>
         )}
 
-        <span style={this.getEndWrapperStyles()}
-              onFocus={this.onEndWrapperFocus}
-              onBlur={this.onEndWrapperBlur}>
+        <span onFocus={this._onEndWrapperFocus}
+              onBlur={this._onEndWrapperBlur}>
           <DatePicker ref={this.EndDatePicker}
                       error={error}
                       value={endValue}
-                      onChange={(e, v) => {
-                        this.onEndChange(e, v);
-                        onChange && onChange(e, v);
-                      }}
+                      onChange={this._onEndChange}
                       minDate={!disableRange ? this.props.startValue : ''}
                       width={endWidth}
                       {...commonDatePickerProps}
@@ -146,50 +143,41 @@ export class DatePickerRange extends React.Component<DatePickerRangeProps> {
     );
   }
 
-  private onStartChange = (e: { target: { value: string } }, v: string) => {
-    !this.props.disableRange && this.setState({minDate: v});
-    this.props.onStartChange && this.props.onStartChange(e, v);
+  private _onStartChange = (e: { target: { value: string } }, v: string) => {
+    const {disableRange, onStartChange, onChange} = this.props;
+    !disableRange && this.setState({minDate: v});
+    onStartChange(e, v);
+    onChange && onChange(e, v);
   }
 
-  private onEndChange = (e: { target: { value: string } }, v: string) => {
-    !this.props.disableRange && this.setState({maxDate: v});
-    this.props.onEndChange && this.props.onEndChange(e, v);
+  private _onEndChange = (e: { target: { value: string } }, v: string) => {
+    const {disableRange, onEndChange, onChange} = this.props;
+    !disableRange && this.setState({maxDate: v});
+    onEndChange(e, v);
+    onChange && onChange(e, v);
   }
 
-  private onStartWrapperFocus = () => {
+  private _onStartWrapperFocus = () => {
     if (this.StartDatePicker && this.StartDatePicker.current && this.props.error) {
       this.StartDatePicker.current.focus();
     }
   }
 
-  private onStartWrapperBlur = () => {
+  private _onStartWrapperBlur = () => {
     if (this.StartDatePicker && this.StartDatePicker.current && this.props.error) {
       this.StartDatePicker.current.blur();
     }
   }
 
-  private onEndWrapperFocus = () => {
+  private _onEndWrapperFocus = () => {
     if (this.EndDatePicker && this.EndDatePicker.current) {
       this.EndDatePicker.current.focus();
     }
   }
 
-  private onEndWrapperBlur = () => {
+  private _onEndWrapperBlur = () => {
     if (this.EndDatePicker && this.EndDatePicker.current) {
       this.EndDatePicker.current.blur();
     }
-  }
-
-  private getStartWrapperStyles = (): CSSProperties => {
-    const {separator, vertical, horizontalMargin, verticalMargin, disableDefaultSeparator} = this.props;
-
-    return {
-      marginBottom: (!separator && vertical && verticalMargin) || 'unset',
-      marginRight: (!separator && !vertical && disableDefaultSeparator && horizontalMargin) || 'unset'
-    }
-  }
-
-  private getEndWrapperStyles = (): CSSProperties => {
-    return {};
   }
 }

--- a/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRange.stories.tsx
+++ b/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRange.stories.tsx
@@ -1,0 +1,7 @@
+import {storiesOf} from "@storybook/react";
+import {DatePickerRangeSimpleStory} from "./DatePickerRangeSimpleStory";
+import {DatePickerRangeWithErrorsStory} from "./DatePickerRangeWithErrorsStory";
+
+storiesOf('DatePickerRange', module).add('Simple using', DatePickerRangeSimpleStory);
+
+storiesOf('DatePickerRange', module).add('With errors', DatePickerRangeWithErrorsStory);

--- a/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRangeSimpleStory.tsx
+++ b/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRangeSimpleStory.tsx
@@ -1,0 +1,93 @@
+import {DatePickerRange, DatePickerRangeProps} from "../DatePickerRange";
+import * as React from "react";
+import {CSSProperties} from "react";
+
+interface WrapperProps {
+  rangeProps?: Partial<DatePickerRangeProps>;
+  name?: string
+  disableWrapperStyles?: boolean;
+}
+
+class Wrapper extends React.Component<WrapperProps, {startValue?: string, endValue?: string}> {
+  state = {startValue: '', endValue: ''};
+
+  render(): JSX.Element {
+    const styles: CSSProperties = {
+      display: 'inline-block',
+      border: '1px solid #f1f1f1',
+      margin: 20,
+      padding: 10
+    }
+
+    const datePickerRangeProps: DatePickerRangeProps = {
+      startValue: this.state.startValue,
+      endValue: this.state.endValue,
+      onStartChange: (e, v) => this.setState({startValue: v}),
+      onEndChange: (e, v) => this.setState({endValue: v}),
+      ...this.props.rangeProps
+    }
+
+    return (
+      <div style={this.props.disableWrapperStyles ? {} : styles}>
+        {this.props.name && <div style={{marginBottom: 5}}>{this.props.name}</div>}
+        <DatePickerRange {...datePickerRangeProps}/>
+      </div>
+    );
+  }
+}
+
+export const DatePickerRangeSimpleStory = () => {
+  const renderHorizontalWithCustomSeparator = (): JSX.Element => {
+    const separator = <div style={{marginLeft: 10}}>to:&nbsp;</div>;
+
+    return (
+      <div style={{margin: 20, border: '1px solid #f1f1f1', padding: 10, display: 'inline-block'}}>
+        <div style={{marginBottom: 5}}>With custom separator</div>
+        <span>from:&nbsp;</span>
+        <div style={{display: 'inline-block'}}>
+          <Wrapper disableWrapperStyles
+                   rangeProps={{separator}}/>
+        </div>
+      </div>
+    )
+  }
+
+  const renderVerticalWithCustomSeparator = (): JSX.Element => {
+    const separator = <div style={{marginTop: 10}}>to:</div>;
+
+    return (
+      <div style={{margin: 20, border: '1px solid #f1f1f1', padding: 10, display: 'inline-block'}}>
+        <div style={{marginBottom: 5}}>Vertical with custom separator</div>
+        <div>from:&nbsp;</div>
+        <div style={{display: 'inline-block'}}>
+          <Wrapper disableWrapperStyles
+                   rangeProps={{separator, vertical: true}}/>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <Wrapper name='Simple with default separator'/>
+
+      <Wrapper name='Without range (min / max) and with custom width'
+               rangeProps={{disableRange: true, startWidth: 180, endWidth: 110}}/>
+
+      <Wrapper name='With custom horizontal margin' rangeProps={{horizontalMargin: 10, disableDefaultSeparator: true}}/>
+
+      <Wrapper name='Without separator'
+               rangeProps={{disableDefaultSeparator: true}}/>
+
+      {renderHorizontalWithCustomSeparator()}
+
+      <Wrapper name='Vertical simple'
+               rangeProps={{vertical: true}}/>
+
+      <Wrapper name='Vertical with margin'
+               rangeProps={{vertical: true, verticalMargin: 10}}/>
+
+      {renderVerticalWithCustomSeparator()}
+    </div>
+  );
+}

--- a/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRangeWithErrorsStory.tsx
+++ b/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRangeWithErrorsStory.tsx
@@ -30,10 +30,12 @@ class Wrapper extends React.Component<WrapperProps, {startValue?: string, endVal
 
     return (
       <div style={styles}>
+        {this.props.name && <div style={{marginBottom: 5}}>{this.props.name}</div>}
         <DatePickerRange {...datePickerRangeProps}/>
       </div>
     )
 
+    //TODO: заготовка для истории с валидациями
     /*return (
       <ValidationContainer>
         <ValidationWrapperV1 validationInfo={this.getValidationInfo()}>
@@ -43,21 +45,20 @@ class Wrapper extends React.Component<WrapperProps, {startValue?: string, endVal
     )*/
   }
 
-  private getValidationInfo(){
+  /*private _getValidationInfo(){
     return {
       level: this.props.errorLevel,
-      message: 'ololo',
-      type: 'immediate'
+      message: 'error message'
     }
-  }
+  }*/
 }
 
 export const DatePickerRangeWithErrorsStory = () => {
   return (
     <div>
-      <Wrapper rangeProps={{warning: true}}/>
+      <Wrapper rangeProps={{warning: true}} name="With warning"/>
 
-      <Wrapper rangeProps={{error: true}}/>
+      <Wrapper rangeProps={{error: true}} name="With error"/>
     </div>
   );
 }

--- a/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRangeWithErrorsStory.tsx
+++ b/packages/retail-ui/components/DatePickerRange/__stories__/DatePickerRangeWithErrorsStory.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import {DatePickerRange, DatePickerRangeProps} from "../DatePickerRange";
+import {CSSProperties} from "react";
+
+interface WrapperProps {
+  rangeProps?: Partial<DatePickerRangeProps>;
+  name?: string
+  disableWrapperStyles?: boolean;
+  errorLevel?: "error" | "warning";
+}
+
+class Wrapper extends React.Component<WrapperProps, {startValue?: string, endValue?: string}> {
+  state = {startValue: '', endValue: ''};
+
+  render(): JSX.Element {
+    const styles: CSSProperties = {
+      display: 'inline-block',
+      border: '1px solid #f1f1f1',
+      margin: 20,
+      padding: 10
+    }
+
+    const datePickerRangeProps: DatePickerRangeProps = {
+      startValue: this.state.startValue,
+      endValue: this.state.endValue,
+      onStartChange: (e, v) => this.setState({startValue: v}),
+      onEndChange: (e, v) => this.setState({endValue: v}),
+      ...this.props.rangeProps
+    }
+
+    return (
+      <div style={styles}>
+        <DatePickerRange {...datePickerRangeProps}/>
+      </div>
+    )
+
+    /*return (
+      <ValidationContainer>
+        <ValidationWrapperV1 validationInfo={this.getValidationInfo()}>
+          <DatePickerRange {...datePickerRangeProps}/>
+        </ValidationWrapperV1>
+      </ValidationContainer>
+    )*/
+  }
+
+  private getValidationInfo(){
+    return {
+      level: this.props.errorLevel,
+      message: 'ololo',
+      type: 'immediate'
+    }
+  }
+}
+
+export const DatePickerRangeWithErrorsStory = () => {
+  return (
+    <div>
+      <Wrapper rangeProps={{warning: true}}/>
+
+      <Wrapper rangeProps={{error: true}}/>
+    </div>
+  );
+}


### PR DESCRIPTION
Создал контрол периода для нашего проекта (он уже на проде), доделал его для всеобщего использования. 
Первая история с разными вариантами использования.
Во второй хотел сделать использование с ValidationWrapperV1, но пока он не умеет имортироваться в retail-ui, так что пока там два примера с подсветкой warning и error.
Кажется, что в гайды можно вынести только самый простой вариант использования с дефолтным разделителем (—), остальные варианты - вкусовщина.

![default](https://user-images.githubusercontent.com/30799122/53085197-63693200-3513-11e9-842b-4178d3ad4093.png)
