### PR TITLE
build(retail-ui): use eslint for only old js components

### DIFF
--- a/packages/retail-ui/.eslintignore
+++ b/packages/retail-ui/.eslintignore
@@ -9,3 +9,9 @@ flow
 styleguide
 storybook-static
 build
+lib/**/*.js
+components/**/*.js
+!components/ComboBoxOld/**/*.js
+!components/DatePickerOld/**/*.js
+!components/PhoneInput/**/*.js
+!components/SearchSelect/**/*.js


### PR DESCRIPTION
Теперь можно не делать `clean` перед запуском eslint'а