### PR TITLE
fix(Popup): remove ambient types

### DIFF
--- a/packages/retail-ui/components/Hint/Hint.tsx
+++ b/packages/retail-ui/components/Hint/Hint.tsx
@@ -5,6 +5,7 @@ import Popup, { PopupPosition, PopupProps } from '../Popup';
 
 import styles = require('./HintBox.less');
 import { Nullable, TimeoutID } from '../../typings/utility-types';
+import { MouseEventType } from '../../typings/event-types';
 
 const HINT_BACKGROUND_COLOR = 'rgba(51, 51, 51, 0.8)';
 const HINT_BORDER_COLOR = 'transparent';
@@ -14,8 +15,8 @@ export interface HintProps {
   children?: React.ReactNode;
   manual?: boolean;
   maxWidth?: React.CSSProperties['maxWidth'];
-  onMouseEnter?: (event: IMouseEvent) => void;
-  onMouseLeave?: (event: IMouseEvent) => void;
+  onMouseEnter?: (event: MouseEventType) => void;
+  onMouseLeave?: (event: MouseEventType) => void;
   opened?: boolean;
   pos:
     | 'top'
@@ -141,7 +142,7 @@ class Hint extends React.Component<HintProps, HintState> {
     return Positions.filter(x => x.startsWith(this.props.pos));
   };
 
-  private handleMouseEnter = (e: IMouseEvent) => {
+  private handleMouseEnter = (e: MouseEventType) => {
     if (!this.props.manual && !this.timer) {
       this.timer = window.setTimeout(this.open, 400);
     }
@@ -151,7 +152,7 @@ class Hint extends React.Component<HintProps, HintState> {
     }
   };
 
-  private handleMouseLeave = (e: IMouseEvent) => {
+  private handleMouseLeave = (e: MouseEventType) => {
     if (!this.props.manual && this.timer) {
       clearTimeout(this.timer);
       this.timer = null;

--- a/packages/retail-ui/components/Popup/Popup.tsx
+++ b/packages/retail-ui/components/Popup/Popup.tsx
@@ -17,6 +17,7 @@ import styles from './Popup.less';
 import { isIE } from '../ensureOldIEClassName';
 import { Nullable } from '../../typings/utility-types';
 import warning from 'warning';
+import { FocusEventType, MouseEventType } from '../../typings/event-types';
 
 const POPUP_BORDER_DEFAULT_COLOR = 'transparent';
 const TRANSITION_TIMEOUT = { enter: 0, exit: 200 };
@@ -51,11 +52,11 @@ export const PopupPositions: PopupPosition[] = [
 ];
 
 export interface PopupHandlerProps {
-  onMouseEnter?: (event: IMouseEvent) => void;
-  onMouseLeave?: (event: IMouseEvent) => void;
-  onClick?: (event: IMouseEvent) => void;
-  onFocus?: (event: IFocusEvent) => void;
-  onBlur?: (event: IBlurEvent) => void;
+  onMouseEnter?: (event: MouseEventType) => void;
+  onMouseLeave?: (event: MouseEventType) => void;
+  onClick?: (event: MouseEventType) => void;
+  onFocus?: (event: FocusEventType) => void;
+  onBlur?: (event: FocusEventType) => void;
   onOpen?: () => void;
 }
 
@@ -284,7 +285,7 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
       element.addEventListener('mouseleave', this.handleMouseLeave);
       element.addEventListener('click', this.handleClick);
       element.addEventListener('focusin', this.handleFocus as EventListener);
-      element.addEventListener('focusout', this.handleBlur);
+      element.addEventListener('focusout', this.handleBlur as EventListener);
     }
   }
 
@@ -294,31 +295,31 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
       element.removeEventListener('mouseleave', this.handleMouseLeave);
       element.removeEventListener('click', this.handleClick);
       element.removeEventListener('focusin', this.handleFocus as EventListener);
-      element.removeEventListener('focusout', this.handleBlur);
+      element.removeEventListener('focusout', this.handleBlur as EventListener);
     }
   }
 
-  private handleMouseEnter = (event: IMouseEvent) => {
+  private handleMouseEnter = (event: MouseEventType) => {
     if (this.props.onMouseEnter) {
       this.props.onMouseEnter(event);
     }
   };
-  private handleMouseLeave = (event: IMouseEvent) => {
+  private handleMouseLeave = (event: MouseEventType) => {
     if (this.props.onMouseLeave) {
       this.props.onMouseLeave(event);
     }
   };
-  private handleClick = (event: IMouseEvent) => {
+  private handleClick = (event: MouseEventType) => {
     if (this.props.onClick) {
       this.props.onClick(event);
     }
   };
-  private handleFocus = (event: IFocusEvent) => {
+  private handleFocus = (event: FocusEventType) => {
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
   };
-  private handleBlur = (event: IBlurEvent) => {
+  private handleBlur = (event: FocusEventType) => {
     if (this.props.onBlur) {
       this.props.onBlur(event);
     }

--- a/packages/retail-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/retail-ui/components/Tooltip/Tooltip.tsx
@@ -6,6 +6,7 @@ import CROSS from '../internal/cross';
 import { Nullable } from '../../typings/utility-types';
 import styles from './Tooltip.less';
 import warning from 'warning';
+import { MouseEventType } from '../../typings/event-types';
 
 const POPUP_MARGIN = 15;
 const POPUP_PIN_OFFSET = 17;
@@ -349,7 +350,7 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
     this.setState({ opened: false });
   }
 
-  private handleMouseEnter = (event: IMouseEvent) => {
+  private handleMouseEnter = (event: MouseEventType) => {
     const isHoverAnchor = this.props.trigger === 'hoverAnchor';
     if (isHoverAnchor && event.target === this.contentElement) {
       return;
@@ -362,7 +363,7 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
     this.open();
   };
 
-  private handleMouseLeave = (event: IMouseEvent) => {
+  private handleMouseLeave = (event: MouseEventType) => {
     const isHover = this.props.trigger === 'hover';
     if (isHover && event.relatedTarget === this.contentElement) {
       return;

--- a/packages/retail-ui/typings/event-types.d.ts
+++ b/packages/retail-ui/typings/event-types.d.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+
+export type MouseEventType<T extends HTMLElement = HTMLElement> = React.MouseEvent<T> | MouseEvent;
+export type FocusEventType<T extends HTMLElement = HTMLElement> = React.FocusEvent<T> | FocusEvent;

--- a/packages/retail-ui/typings/opaque-helper-types.d.ts
+++ b/packages/retail-ui/typings/opaque-helper-types.d.ts
@@ -1,4 +1,0 @@
-declare type IMouseEvent<T extends HTMLElement = HTMLElement> = import('react').MouseEvent<T> | MouseEvent;
-declare type IFocusEvent<T extends HTMLElement = HTMLElement> = import('react').FocusEvent<T> | FocusEvent;
-declare type IFocusInEvent<T extends HTMLElement = HTMLElement> = import('react').FocusEvent<T> | FocusEvent;
-declare type IBlurEvent<T extends HTMLElement = HTMLElement> = import('react').BlurEvent<T> | BlurEvent;


### PR DESCRIPTION
When consumer does not skipLibCheck, typescript compiler has no way to find ambient types of
dependant @skbkontur/react-ui package, so one must specify path to those types in 'include' section
of his tsconfig. To overcome this complexity, we replace ambient types (IMosueEvent/IFocusEvent)
with concrete ones and import them explicitly.