### PR TITLE
fix(retail-ui): add optional for some props and default for generic

### DIFF
--- a/packages/retail-ui/components/Autocomplete/Autocomplete.js.flow
+++ b/packages/retail-ui/components/Autocomplete/Autocomplete.js.flow
@@ -3,14 +3,14 @@ import type { InputProps } from '../Input';
 
 export type AutocompleteProps = {
   ...$Exact<InputProps>,
-  renderItem: (item: string) => React$Node,
+  renderItem?: (item: string) => React$Node,
   source?: string[] | ((patter: string) => Promise<string[]>),
-  disablePortal: boolean,
-  hasShadow: boolean,
-  menuAlign: 'left' | 'right',
-  menuMaxHeight: number | string,
+  disablePortal?: boolean,
+  hasShadow?: boolean,
+  menuAlign?: 'left' | 'right',
+  menuMaxHeight?: number | string,
   menuWidth?: number | string,
-  preventWindowScroll: boolean,
+  preventWindowScroll?: boolean,
   onChange: (
     event: {
       target: {
@@ -20,7 +20,7 @@ export type AutocompleteProps = {
     value: string,
   ) => void,
   onBlur?: () => void,
-  size: $PropertyType<InputProps, 'size'>,
+  size?: $PropertyType<InputProps, 'size'>,
   value: string,
 };
 

--- a/packages/retail-ui/components/ComboBox/ComboBox.js.flow
+++ b/packages/retail-ui/components/ComboBox/ComboBox.js.flow
@@ -1,7 +1,12 @@
 /* @flow */
 import type { MenuItemState } from '../MenuItem';
 
-export type ComboBoxProps<T> = {|
+export type ComboBoxItem = {
+  value: string | number;
+  label: string;
+};
+
+export type ComboBoxProps<T = ComboBoxItem> = {|
   align?: 'left' | 'center' | 'right',
   autocomplete?: boolean,
   autoFocus?: boolean,
@@ -40,7 +45,7 @@ export type ComboBoxProps<T> = {|
   maxMenuHeight?: number | string,
 |};
 
-declare class ComboBox<T> extends React$Component<ComboBoxProps<T>> {
+declare class ComboBox<T = ComboBoxItem> extends React$Component<ComboBoxProps<T>> {
   focus(): void;
   search(query?: string): void;
   open(): void;

--- a/packages/retail-ui/components/ComboBox/index.js.flow
+++ b/packages/retail-ui/components/ComboBox/index.js.flow
@@ -1,2 +1,2 @@
 /* @flow */
-export { default, ComboBoxProps } from './ComboBox';
+export { default, ComboBoxProps, ComboBoxItem } from './ComboBox';

--- a/packages/retail-ui/components/DropdownMenu/DropdownMenu.js.flow
+++ b/packages/retail-ui/components/DropdownMenu/DropdownMenu.js.flow
@@ -7,7 +7,8 @@ export type DropdownMenuProps = {|
   caption: $PropertyType<PopupMenuProps, 'caption'>,
   onOpen?: () => void,
   onClose?: () => void,
-  disableAnimations: boolean,
+  disableAnimations?: boolean,
+  children: React$Node
 |};
 
 class DropdownMenu extends React$Component<DropdownMenuProps> {}

--- a/packages/retail-ui/components/Hint/Hint.js.flow
+++ b/packages/retail-ui/components/Hint/Hint.js.flow
@@ -4,7 +4,7 @@ export type HintProps = {|
   manual?: boolean,
   maxWidth?: string | number,
   opened?: boolean,
-  pos:
+  pos?:
     | 'top'
     | 'right'
     | 'bottom'
@@ -22,8 +22,8 @@ export type HintProps = {|
     | 'right middle'
     | 'right bottom',
   text: React$Node,
-  disableAnimations: boolean,
-  useWrapper: boolean,
+  disableAnimations?: boolean,
+  useWrapper?: boolean,
   onMouseEnter?: (event: SyntheticMouseEvent<HTMLElement> | MouseEvent) => void,
   onMouseLeave?: (event: SyntheticMouseEvent<HTMLElement> | MouseEvent) => void,
 |};

--- a/packages/retail-ui/components/Kebab/Kebab.js.flow
+++ b/packages/retail-ui/components/Kebab/Kebab.js.flow
@@ -5,10 +5,11 @@ export type KebabProps = {|
   disabled?: boolean,
   onClose: () => void,
   onOpen: () => void,
-  size: 'small' | 'medium' | 'large',
-  positions: PopupPosition[],
+  size?: 'small' | 'medium' | 'large',
+  positions?: PopupPosition[],
   menuMaxHeight?: number | string,
-  disableAnimations: boolean,
+  disableAnimations?: boolean,
+  children: React$Node
 |};
 
 export type KebabState = {|

--- a/packages/retail-ui/components/Tooltip/Tooltip.js.flow
+++ b/packages/retail-ui/components/Tooltip/Tooltip.js.flow
@@ -14,9 +14,9 @@ export type TooltipProps = {|
   trigger: TooltipTrigger,
   onCloseClick?: MouseEventHandler<HTMLElement>,
   onCloseRequest?: () => void,
-  allowedPositions: PopupPosition[],
-  disableAnimations: boolean,
-  useWrapper: boolean,
+  allowedPositions?: PopupPosition[],
+  disableAnimations?: boolean,
+  useWrapper?: boolean,
 |};
 
 export type TooltipState = {|


### PR DESCRIPTION
Эти props необязательные, так как у компонентов есть дефолтные значения. 
А Flow ругается.

У комбобокса есть дефолтное определение типа item'а, почему бы его не указать в дефолтном типе дженерика.
