### PR TITLE
fix(Tooltip): correct render invalid react element

### DIFF
--- a/packages/retail-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/retail-ui/components/Tooltip/Tooltip.tsx
@@ -193,7 +193,11 @@ class Tooltip extends React.Component<TooltipProps, TooltipState> {
       return <RenderLayer {...layerProps}>{popup}</RenderLayer>;
     }
 
-    return children;
+    if (React.isValidElement(children)) {
+      return children;
+    }
+
+    return <span>{children}</span>;
   }
 
   public renderContent = () => {


### PR DESCRIPTION
fix problem where children is plain string, that render without popup on react@15