### PR TITLE
fix(Popup): call `onOpen` prop in right moment for react@15

### DIFF
--- a/packages/retail-ui/components/Popup/Popup.tsx
+++ b/packages/retail-ui/components/Popup/Popup.tsx
@@ -16,6 +16,7 @@ import { Nullable } from '../../typings/utility-types';
 import warning from 'warning';
 import { FocusEventType, MouseEventType } from '../../typings/event-types';
 import { isFunction } from '../../lib/utils';
+import LifeCycleProxy from '../internal/LifeCycleProxy';
 
 const POPUP_BORDER_DEFAULT_COLOR = 'transparent';
 const TRANSITION_TIMEOUT = { enter: 0, exit: 200 };
@@ -206,14 +207,6 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
     }
   }
 
-  public componentDidUpdate(prevProps: PopupProps, prevState: PopupState) {
-    const hadNoLocation = prevState.location === null;
-    const hasLocation = this.state.location !== null;
-    if (hadNoLocation && hasLocation && this.props.onOpen) {
-      this.props.onOpen();
-    }
-  }
-
   public componentWillUnmount() {
     this.cancelDelayedUpdateLocation();
     this.removeEventListeners(this.anchorElement);
@@ -247,7 +240,11 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
         active={Boolean(onCloseRequest) && opened}
       >
         <RenderContainer anchor={child} ref={child ? this.refAnchorElement : undefined}>
-          {this.renderContent()}
+          {/* This need to correct handle order of lifecycle hooks with portal and react@15 */}
+          {/* For more details see issue #1257*/}
+          <LifeCycleProxy onDidUpdate={this.handleDidUpdate} props={this.state}>
+            {this.renderContent()}
+          </LifeCycleProxy>
         </RenderContainer>
       </RenderLayer>
     );
@@ -424,6 +421,14 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
     }
     if (this.state.location) {
       this.updateLocation();
+    }
+  };
+
+  private handleDidUpdate = (prevProps: PopupState, props: PopupState) => {
+    const hadNoLocation = prevProps.location === null;
+    const hasLocation = props.location !== null;
+    if (hadNoLocation && hasLocation && this.props.onOpen) {
+      this.props.onOpen();
     }
   };
 

--- a/packages/retail-ui/components/Popup/__tests__/__snapshots__/Popup-test.tsx.snap
+++ b/packages/retail-ui/components/Popup/__tests__/__snapshots__/Popup-test.tsx.snap
@@ -36,26 +36,35 @@ exports[`Popup snapshots:  open and close popup: closed popup 1`] = `
     <RenderContainer
       anchor={null}
     >
-      <Transition
-        appear={true}
-        enter={true}
-        exit={true}
-        in={false}
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={
+      <LifeCycleProxy
+        onDidUpdate={[Function]}
+        props={
           Object {
-            "enter": 0,
-            "exit": 200,
+            "location": null,
           }
         }
-        unmountOnExit={true}
-      />
+      >
+        <Transition
+          appear={true}
+          enter={true}
+          exit={true}
+          in={false}
+          mountOnEnter={true}
+          onEnter={[Function]}
+          onEntered={[Function]}
+          onEntering={[Function]}
+          onExit={[Function]}
+          onExited={[Function]}
+          onExiting={[Function]}
+          timeout={
+            Object {
+              "enter": 0,
+              "exit": 200,
+            }
+          }
+          unmountOnExit={true}
+        />
+      </LifeCycleProxy>
       <Portal
         key="portal-ref"
         rt_rootID={1}
@@ -105,26 +114,35 @@ exports[`Popup snapshots:  open and close popup: closed popup again 1`] = `
     <RenderContainer
       anchor={null}
     >
-      <Transition
-        appear={true}
-        enter={true}
-        exit={true}
-        in={false}
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={
+      <LifeCycleProxy
+        onDidUpdate={[Function]}
+        props={
           Object {
-            "enter": 0,
-            "exit": 200,
+            "location": null,
           }
         }
-        unmountOnExit={true}
-      />
+      >
+        <Transition
+          appear={true}
+          enter={true}
+          exit={true}
+          in={false}
+          mountOnEnter={true}
+          onEnter={[Function]}
+          onEntered={[Function]}
+          onEntering={[Function]}
+          onExit={[Function]}
+          onExited={[Function]}
+          onExiting={[Function]}
+          timeout={
+            Object {
+              "enter": 0,
+              "exit": 200,
+            }
+          }
+          unmountOnExit={true}
+        />
+      </LifeCycleProxy>
       <Portal
         key="portal-ref"
         rt_rootID={1}
@@ -174,71 +192,80 @@ exports[`Popup snapshots:  open and close popup: opened popup 1`] = `
     <RenderContainer
       anchor={null}
     >
-      <Transition
-        appear={true}
-        enter={true}
-        exit={true}
-        in={true}
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={
+      <LifeCycleProxy
+        onDidUpdate={[Function]}
+        props={
           Object {
-            "enter": 0,
-            "exit": 200,
+            "location": null,
           }
         }
-        unmountOnExit={true}
       >
-        <ZIndex
-          className="popup transition-enter-top"
-          delta={1000}
-          key="dummy"
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          render={true}
-          style={
+        <Transition
+          appear={true}
+          enter={true}
+          exit={true}
+          in={true}
+          mountOnEnter={true}
+          onEnter={[Function]}
+          onEntered={[Function]}
+          onEntering={[Function]}
+          onExit={[Function]}
+          onExited={[Function]}
+          onExiting={[Function]}
+          timeout={
             Object {
-              "left": -9999,
-              "maxWidth": 500,
-              "top": -9999,
+              "enter": 0,
+              "exit": 200,
             }
           }
+          unmountOnExit={true}
         >
-          <div
+          <ZIndex
             className="popup transition-enter-top"
+            delta={1000}
+            key="dummy"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
+            render={true}
             style={
               Object {
                 "left": -9999,
                 "maxWidth": 500,
                 "top": -9999,
-                "zIndex": 26000,
               }
             }
           >
             <div
-              className="content"
+              className="popup transition-enter-top"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "left": -9999,
+                  "maxWidth": 500,
+                  "top": -9999,
+                  "zIndex": 26000,
+                }
+              }
             >
               <div
-                className="contentInner"
-                style={
-                  Object {
-                    "backgroundColor": undefined,
-                  }
-                }
+                className="content"
               >
-                Test content
+                <div
+                  className="contentInner"
+                  style={
+                    Object {
+                      "backgroundColor": undefined,
+                    }
+                  }
+                >
+                  Test content
+                </div>
               </div>
             </div>
-          </div>
-        </ZIndex>
-      </Transition>
+          </ZIndex>
+        </Transition>
+      </LifeCycleProxy>
       <Portal
         key="portal-ref"
         rt_rootID={1}

--- a/packages/retail-ui/components/internal/LifeCycleProxy.ts
+++ b/packages/retail-ui/components/internal/LifeCycleProxy.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface LifeCycleProxyProps<T> {
+  onDidMount?: (props: T) => void;
+  onDidUpdate?: (prevProps: T, props: T) => void;
+  onWillUnmount?: (props: T) => void;
+  props: T;
+}
+
+// NOTE You can extends props and arguments if necessary
+export default class LifeCycleProxy<T> extends React.Component<LifeCycleProxyProps<T>> {
+  public componentDidMount() {
+    if (this.props.onDidMount) {
+      this.props.onDidMount(this.props.props);
+    }
+  }
+  public componentDidUpdate(prevProps: LifeCycleProxyProps<T>) {
+    if (this.props.onDidUpdate) {
+      this.props.onDidUpdate(prevProps.props, this.props.props);
+    }
+  }
+  public componentWillUnmount() {
+    if (this.props.onWillUnmount) {
+      this.props.onWillUnmount(this.props.props);
+    }
+  }
+  public render() {
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
Добавил компонент `LifeCycleProxy` у которого можно подписаться на вызовы lifecycle методов. Сам компонент рендерится внутри портала, что обеспечивает правильный порядок вызовов `popup render -> portal render -> did update`

fix #1257