### PR TITLE
build(retail-ui): remove unused resolutions for gemini/wd deps

### DIFF
--- a/packages/retail-ui/package.json
+++ b/packages/retail-ui/package.json
@@ -142,7 +142,6 @@
     "tslint-react": "^3.6.0",
     "typescript": "^3.3.3333",
     "url-loader": "^1.0.1",
-    "wd": "^1.10.1",
     "webpack": "^3.11.0",
     "webpack-watch-files-plugin": "^1.0.2"
   },
@@ -150,9 +149,6 @@
     "@skbkontur/react-icons": "^3.0.0",
     "react": ">=0.14.9",
     "react-dom": ">=0.14.9"
-  },
-  "resolutions": {
-    "gemini/wd": "1.6.2"
   },
   "jest": {
     "testResultsProcessor": "jest-teamcity-reporter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15670,11 +15670,6 @@ semver@~5.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
   integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
-semver@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
 send@0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
@@ -17850,7 +17845,7 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-wd@^1.10.1, wd@^1.6.2:
+wd@^1.6.2:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/wd/-/wd-1.10.3.tgz#395ac7eb58a98e556369f8f8e5f845d91fb152a3"
   integrity sha512-ffqqZDtFFLeg5u/4pw2vYKECW+z+vW6vc+7rcqF15uu1/rmw3BydV84BONNc9DIcQ5Z7gQFS/hAuMvj53eVtSg==


### PR DESCRIPTION
В общем эта херня (свойство `resolutions`) триггерит переустановку зависимости `wd` при добавлении/удалении пакетов в retail-ui, в результате генерируется некорректный yarn.lock.

semver зацепился, потому что ключ `semver@^5.6.0` уже корректно резолвится в нужный пакет чуть выше, поэтому это просто удаление дубля.