### PR TITLE
fix(Logotype): async load products widget script

### DIFF
--- a/packages/retail-ui/components/Logotype/ProductWidget.tsx
+++ b/packages/retail-ui/components/Logotype/ProductWidget.tsx
@@ -10,7 +10,7 @@ export default {
 
       const script = document.createElement('script');
       script.src = 'https://widget-product.kontur.ru/widget/loader?' + 'product=&type=service';
-      document.getElementsByTagName('head')[0].appendChild(script);
+      setTimeout(() => document.getElementsByTagName('head')[0].appendChild(script));
     };
 
     if (window.jQuery) {


### PR DESCRIPTION
В некоторых случаях скрипт может загружаться очень долго. Из-за этого появляется проблема когда страница находится в состоянии загрузки пока не загрузится скрипт виджета.