### PR TITLE
docs(retail-ui): fix export components for styleguidist

### DIFF
--- a/packages/retail-ui/components/CurrencyLabel/CurrencyLabel.tsx
+++ b/packages/retail-ui/components/CurrencyLabel/CurrencyLabel.tsx
@@ -8,7 +8,7 @@ export interface CurrencyLabelProps {
   currencySymbol?: React.ReactNode | null;
 }
 
-const CurrencyLabel: React.SFC<CurrencyLabelProps> = ({
+export const CurrencyLabel: React.SFC<CurrencyLabelProps> = ({
   value,
   fractionDigits = 2,
   currencySymbol = null,

--- a/packages/retail-ui/components/Token/Token.tsx
+++ b/packages/retail-ui/components/Token/Token.tsx
@@ -44,7 +44,7 @@ export interface TokenProps {
   warning?: boolean;
 }
 
-const Token: React.SFC<TokenProps & TokenActions> = ({
+export const Token: React.SFC<TokenProps & TokenActions> = ({
   children,
   isActive,
   colors,


### PR DESCRIPTION
По каким-то причинам в 0.44.2 в документации сломались CurrencyLabel и Token