### PR TITLE
chore: add workaround to fix console autoimport issue

### DIFF
--- a/packages/react-ui-validations/typings/console.d.ts
+++ b/packages/react-ui-validations/typings/console.d.ts
@@ -1,0 +1,3 @@
+declare module 'console' {
+  export = typeof import('console');
+}

--- a/packages/retail-ui/typings/console.d.ts
+++ b/packages/retail-ui/typings/console.d.ts
@@ -1,0 +1,3 @@
+declare module 'console' {
+  export = typeof import('console');
+}


### PR DESCRIPTION
Some `@types/*` depend on `@types/node`, that has declared `console` module and vscode try autoimport not existed `console` module.
For more info see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015