### PR TITLE
fix(Paging): changed detecting of pressed key

### DIFF
--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -236,21 +236,21 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
       return;
     }
 
-    if (NavigationHelper.checkKeyPressed(event) && event.key === 'ArrowLeft') {
+    if (NavigationHelper.checkKeyPressed(event) && event.keyCode === 37) { // ArrowLeft
       this.setState({ focusedItem: null }, this.goBackward);
       return;
     }
-    if (NavigationHelper.checkKeyPressed(event) && event.key === 'ArrowRight') {
+    if (NavigationHelper.checkKeyPressed(event) && event.keyCode === 39) { // ArrowRight
       this.setState({ focusedItem: null }, this.goForward);
       return;
     }
 
     if (this.container && this.container === event.target) {
-      if (event.key === 'ArrowLeft') {
+      if (event.keyCode === 37) { // ArrowLeft
         this.setState({ focusedByTab: true }, this.moveFocusLeft);
         return;
       }
-      if (event.key === 'ArrowRight') {
+      if (event.keyCode === 39) { // ArrowRight
         this.setState({ focusedByTab: true }, this.moveFocusRight);
         return;
       }

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -228,6 +228,10 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     }
 
     const target = event.target;
+    const key = event.key;
+
+    const isArrowLeft = key === 'ArrowLeft' || key === 'Left';
+    const isArrowRight = key === 'ArrowRight' || key === 'Right';
 
     if (
       target instanceof Element &&
@@ -236,21 +240,21 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
       return;
     }
 
-    if (NavigationHelper.checkKeyPressed(event) && event.keyCode === 37) { // ArrowLeft
+    if (NavigationHelper.checkKeyPressed(event) && isArrowLeft) {
       this.setState({ focusedItem: null }, this.goBackward);
       return;
     }
-    if (NavigationHelper.checkKeyPressed(event) && event.keyCode === 39) { // ArrowRight
+    if (NavigationHelper.checkKeyPressed(event) && isArrowRight) {
       this.setState({ focusedItem: null }, this.goForward);
       return;
     }
 
     if (this.container && this.container === event.target) {
-      if (event.keyCode === 37) { // ArrowLeft
+      if (isArrowLeft) {
         this.setState({ focusedByTab: true }, this.moveFocusLeft);
         return;
       }
-      if (event.keyCode === 39) { // ArrowRight
+      if (isArrowRight) {
         this.setState({ focusedByTab: true }, this.moveFocusRight);
         return;
       }


### PR DESCRIPTION
Исправляет https://github.com/skbkontur/retail-ui/issues/1351
По какой-то причине, в ie11 при нажатии клавиш влево/вправо у event.key лежит не "ArrowLeft"/"ArrowRight", а просто "Left"/"Right". Заменил на использование event.key, кажется, это более правильно.