### PR TITLE
refactor(Table): deleted table width = 100%

### DIFF
--- a/packages/retail-ui/components/internal/ComponentStatesTable.tsx
+++ b/packages/retail-ui/components/internal/ComponentStatesTable.tsx
@@ -37,7 +37,7 @@ export interface TableProps<T extends {}> {
 export default function ComponentStatesTable<T extends {}>(props: TableProps<T>) {
   const { rows = [], cols = [], presetState, component: Component } = props;
   return (
-    <table style={{ width: '100%', borderSpacing: 10, marginBottom: 20 }}>
+    <table style={{ borderSpacing: 10, marginBottom: 20 }}>
       <caption style={{ captionSide: 'bottom' }}>{renderStateDesc(presetState)}</caption>
       <thead>
         <tr>


### PR DESCRIPTION
- удален стиль Таблицы width: 100%.
При ```width: 100%``` содержимое таблицы растягивалось по всему экрану, между элементами в таблице оставалось много места, что создавало неудобства при просмотре сториса.
