### PR TITLE
При фокусе на дату в DatePicker-е нельзя нажимать F клавиши

### DIFF
--- a/packages/retail-ui/components/DateInput/DateInputKeyboardActions.tsx
+++ b/packages/retail-ui/components/DateInput/DateInputKeyboardActions.tsx
@@ -1,9 +1,8 @@
 // @ts-ignore noUnusedVar
 import * as React from 'react';
-import { KeyboardActionExctracterBuilder, isSeparator, isModified } from '../internal/extractKeyboardAction';
+import { KeyboardActionExctracterBuilder, isSeparator } from '../internal/extractKeyboardAction';
 
 export const Actions = {
-  Unknown: 0,
   Ignore: 1,
   MoveSelectionLeft: 11,
   MoveSelectionRight: 12,
@@ -25,8 +24,7 @@ const extractAction = new KeyboardActionExctracterBuilder()
   .add(Actions.FullSelection, e => (e.ctrlKey || e.metaKey) && e.key === 'a')
   .add(Actions.ClearSelection, e => e.key === 'Backspace' || e.key === 'Delete')
   .add(Actions.Digit, e => /^\d$/.test(e.key))
-  .add(Actions.Ignore, e => isModified(e) || e.key === 'Tab')
   .add(Actions.WrongInput, e => e.key === ' ' || /^[A-Za-zА-Яа-я]$/.test(e.key))
-  .build(Actions.Unknown);
+  .build(Actions.Ignore);
 
 export { extractAction };


### PR DESCRIPTION
## Проблема 

Данный PR каким-то образом решает следующей баг в DatePicker-е:
1. Кликаем на DatePicker
2. Нажимаем F5/F12/F8 и понимаем, что ничего не происходит
![image](https://user-images.githubusercontent.com/1395040/58032028-270d9800-7b3b-11e9-9d5a-57a553f99fe4.png)

DatePicker почему-то маскирует поведение всех клавиш, за исключением тех, которые являются `isModified`. Однако F клавиши не являются мета-клавишами и вообще никак не отличимы от обычных "букв", поэтому они также маскируются и дефолтный хэндлер браузера для них не вызывается.

## Решение

В данном PR изменен подход к обработке пользовательских событий, а именно - теперь DatePicke маскирует дефолтные обработчики кнопок только в том случае, когда у него есть кастомная замена для них.