### PR TITLE
 refactor(Tab): use global tabListener

### DIFF
--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus backward/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus backward/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a35ddbec20e0a831bff1547fc2116dbce275b20003998d603760456a35f3e1e6
+size 1242

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus backward/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus backward/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f69e9a781e2f759ed802537cf3ca7b450b49e3d934b80052d931c88e79bbe239
+size 1028

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus backward/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus backward/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a509049a2a5600651fce70f3f5722f07d6d6ff252ce69fc77ab3aed93f30802b
+size 1296

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus forward/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus forward/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2825473710780a46b93b84a399699819f4db3fe7042f8e162d220e6fc025d44
+size 1237

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus forward/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus forward/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed33d4174ec9edb632142412618951a0f4138409c59de061d359b49d1516667b
+size 1023

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus forward/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/move focus forward/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:466b89a4f8b1206145dfce1d5f70a5fd9c8c52b6b6696bc5b0ecc9e668616c0f
+size 1293

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/reset focus after click/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/reset focus after click/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:989783325664012af6f1a44008570d3bd8ddfc5d1f99f6ac92908626264ef19e
+size 1208

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/reset focus after click/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/reset focus after click/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b34d95c12c77e50d2933f96bb361b4164e7256aa9afefe5139f068e97f4a855b
+size 994

--- a/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/reset focus after click/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/Tabs keyboard control/reset focus after click/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5f09081dfb58528d7559bed98787a38d050c88f5e22e266757f3203f65c9f83
+size 1259

--- a/packages/react-ui-screenshot-tests/gemini/tabs.js
+++ b/packages/react-ui-screenshot-tests/gemini/tabs.js
@@ -38,3 +38,21 @@ gemini.suite('tabs vertical', suite => {
   suite.before(renderStory('Tabs', 'vertical'));
   applyTest(suite);
 });
+
+gemini.suite('Tabs keyboard control', suite => {
+  suite
+    .before(renderStory('Tabs', 'simple'))
+    .setCaptureElements('#test-element')
+    .capture('move focus forward', (actions, find) => {
+      actions.focus(find(tabAtIndex(1)));
+      actions.sendKeys(gemini.ARROW_RIGHT);
+      actions.sendKeys(gemini.ARROW_DOWN);
+    })
+    .capture('move focus backward', (actions, find) => {
+      actions.sendKeys(gemini.ARROW_LEFT);
+      actions.sendKeys(gemini.ARROW_UP);
+    })
+    .capture('reset focus after click', (actions, find) => {
+      actions.click(find(tabAtIndex(3)));
+    })
+});

--- a/packages/retail-ui/components/Button/Button.tsx
+++ b/packages/retail-ui/components/Button/Button.tsx
@@ -293,7 +293,6 @@ export default class Button extends React.Component<ButtonProps, ButtonState> {
       process.nextTick(() => {
         if (tabListener.isTabPressed) {
           this.setState({ focusedByTab: true });
-          tabListener.isTabPressed = false;
         }
       });
       if (this.props.onFocus) {

--- a/packages/retail-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/retail-ui/components/Checkbox/Checkbox.tsx
@@ -190,7 +190,6 @@ class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
       process.nextTick(() => {
         if (tabListener.isTabPressed) {
           this.setState({ focusedByTab: true });
-          tabListener.isTabPressed = false;
         }
       });
     }

--- a/packages/retail-ui/components/Kebab/Kebab.tsx
+++ b/packages/retail-ui/components/Kebab/Kebab.tsx
@@ -172,7 +172,6 @@ export default class Kebab extends React.Component<KebabProps, KebabState> {
       process.nextTick(() => {
         if (tabListener.isTabPressed) {
           this.setState({ focusedByTab: true });
-          tabListener.isTabPressed = false;
         }
       });
     }

--- a/packages/retail-ui/components/Link/Link.tsx
+++ b/packages/retail-ui/components/Link/Link.tsx
@@ -125,7 +125,6 @@ class Link extends React.Component<LinkProps, LinkState> {
       process.nextTick(() => {
         if (tabListener.isTabPressed) {
           this.setState({ focusedByTab: true });
-          tabListener.isTabPressed = false;
         }
       });
     }

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -286,7 +286,6 @@ export default class Paging extends React.Component<PagingProps, PagingState> {
     process.nextTick(() => {
       if (tabListener.isTabPressed) {
         this.setState({ focusedByTab: true });
-        tabListener.isTabPressed = false;
       }
     });
   };

--- a/packages/retail-ui/components/Tabs/Tab.tsx
+++ b/packages/retail-ui/components/Tabs/Tab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import invariant from 'invariant';
 import cn from 'classnames';
+import tabListener from '../../lib/events/tabListener';
 import { Nullable } from '../../typings/utility-types';
 import { isFunctionalComponent, withContext } from '../../lib/utils';
 
@@ -84,29 +85,10 @@ export interface TabState {
   focusedByKeyboard: boolean;
 }
 
-const KEYCODE_TAB = 9;
 const KEYCODE_ARROW_LEFT = 37;
 const KEYCODE_ARROW_UP = 38;
 const KEYCODE_ARROW_RIGHT = 39;
 const KEYCODE_ARROW_DOWN = 40;
-
-let isListening: boolean;
-let focusKeyPressed: boolean;
-
-function listenTabPresses() {
-  if (!isListening) {
-    window.addEventListener('keydown', (event: KeyboardEvent) => {
-      focusKeyPressed = [
-        KEYCODE_TAB,
-        KEYCODE_ARROW_LEFT,
-        KEYCODE_ARROW_UP,
-        KEYCODE_ARROW_RIGHT,
-        KEYCODE_ARROW_DOWN,
-      ].includes(event.keyCode);
-    });
-    isListening = true;
-  }
-}
 
 /**
  * Tab element of Tabs component
@@ -154,6 +136,7 @@ export class Tab extends React.Component<TabProps, TabState> {
   };
 
   private tabComponent: Nullable<React.ReactElement<Tab>> = null;
+  private isArrowKeyPressed: boolean = false;
 
   public componentWillMount() {
     invariant(
@@ -167,7 +150,7 @@ export class Tab extends React.Component<TabProps, TabState> {
     if (this.props.context && typeof id === 'string') {
       this.props.context.addTab(id, this.getTabInstance);
     }
-    listenTabPresses();
+    window.addEventListener('keydown', this.handleKeyDownGlobal);
   }
 
   public componentDidUpdate() {
@@ -185,6 +168,7 @@ export class Tab extends React.Component<TabProps, TabState> {
     if (this.props.context && typeof id === 'string') {
       this.props.context.removeTab(id);
     }
+    window.removeEventListener('keydown', this.handleKeyDownGlobal);
   }
 
   public render() {
@@ -224,6 +208,7 @@ export class Tab extends React.Component<TabProps, TabState> {
         })}
         onBlur={this.handleBlur}
         onClick={this.switchTab}
+        onMouseDown={this.handleMouseDown}
         onFocus={this.handleFocus}
         onKeyDown={this.handleKeyDown}
         tabIndex={disabled ? -1 : 0}
@@ -255,6 +240,12 @@ export class Tab extends React.Component<TabProps, TabState> {
     this.tabComponent = instance;
   };
 
+  private handleKeyDownGlobal = (event: KeyboardEvent) => {
+    this.isArrowKeyPressed = [KEYCODE_ARROW_LEFT, KEYCODE_ARROW_UP, KEYCODE_ARROW_RIGHT, KEYCODE_ARROW_DOWN].some(
+      keyCode => event.keyCode === keyCode,
+    );
+  };
+
   private getTabInstance = () => this;
 
   private switchTab = (event: React.MouseEvent<HTMLElement>) => {
@@ -273,6 +264,8 @@ export class Tab extends React.Component<TabProps, TabState> {
       this.props.context.switchTab(id);
     }
   };
+
+  private handleMouseDown = () => (this.isArrowKeyPressed = false);
 
   private handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (this.props.disabled) {
@@ -314,9 +307,8 @@ export class Tab extends React.Component<TabProps, TabState> {
     // focus event fires before keyDown eventlistener
     // so we should check focusKeyPressed in async way
     process.nextTick(() => {
-      if (focusKeyPressed) {
+      if (tabListener.isTabPressed || this.isArrowKeyPressed) {
         this.setState({ focusedByKeyboard: true });
-        focusKeyPressed = false;
       }
     });
   };

--- a/packages/retail-ui/components/Tabs/Tabs.tsx
+++ b/packages/retail-ui/components/Tabs/Tabs.tsx
@@ -117,7 +117,7 @@ class Tabs extends React.Component<TabsProps> {
       htmlNode = findDOMNode(tabNode);
     }
 
-    if (htmlNode && htmlNode instanceof HTMLElement && htmlNode.hasOwnProperty('focus')) {
+    if (htmlNode && htmlNode instanceof HTMLElement && typeof htmlNode.focus === 'function') {
       htmlNode.focus();
     }
   };

--- a/packages/retail-ui/components/Toggle/Toggle.tsx
+++ b/packages/retail-ui/components/Toggle/Toggle.tsx
@@ -144,9 +144,7 @@ export default class Toggle extends React.Component<ToggleProps, ToggleState> {
     }
 
     if (tabListener.isTabPressed) {
-      this.setState({ focusByTab: true }, () => {
-        tabListener.isTabPressed = false;
-      });
+      this.setState({ focusByTab: true });
     }
   };
 

--- a/packages/retail-ui/lib/events/tabListener.ts
+++ b/packages/retail-ui/lib/events/tabListener.ts
@@ -1,8 +1,9 @@
-const TAB = 9;
+const KEYCODE_TAB = 9;
+
 class TabListener {
   public isTabPressed: boolean = false;
   constructor() {
-    window.addEventListener('keydown', event => (this.isTabPressed = event.keyCode === TAB));
+    window.addEventListener('keydown', event => (this.isTabPressed = event.keyCode === KEYCODE_TAB));
     window.addEventListener('mousedown', () => (this.isTabPressed = false));
   }
 }


### PR DESCRIPTION
- добавил флаг `isFirefox47` для скриншотных тестов
- вернул старую проверку существования свойства `focus`, чтобы завести управление стрелками
- добавил тестов для проверки управления с клавиатуры

fix https://github.com/skbkontur/retail-ui/issues/1424
close https://github.com/skbkontur/retail-ui/issues/1410

---
Есть мыль вынести все проверки типа `event.keyCode === 32` в отдельную либу.
По сути я её почти доделал в этой ветке, но вовремя остановился и откатил)