### PR TITLE
fix(RenderLayer): add touchstart handling

### DIFF
--- a/packages/retail-ui/components/RenderLayer/RenderLayer.tsx
+++ b/packages/retail-ui/components/RenderLayer/RenderLayer.tsx
@@ -58,6 +58,7 @@ class RenderLayer extends React.Component<RenderLayerProps> {
     this.focusOutsideListenerToken = listenFocusOutside(() => [this.getDomNode()], this.handleFocusOutside);
     window.addEventListener('blur', this.handleFocusOutside);
     document.addEventListener('mousedown', this.handleNativeDocClick);
+    document.addEventListener('touchstart', this.handleNativeDocClick);
   }
 
   private detachListeners() {
@@ -68,6 +69,7 @@ class RenderLayer extends React.Component<RenderLayerProps> {
 
     window.removeEventListener('blur', this.handleFocusOutside);
     document.removeEventListener('mousedown', this.handleNativeDocClick);
+    document.removeEventListener('touchstart', this.handleNativeDocClick);
   }
 
   private getDomNode() {


### PR DESCRIPTION
По мотивам #1439 
`mousedown` ивент всплывает не всегда, подробнее — [по ссылке](https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html)
Дополнительно к `mousedown` добавил `touchstart`