### PR TITLE
fix(Button): fix paddings for medium size in flat theme

### DIFF
--- a/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 2/chromeFlat.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 2/chromeFlat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bca9ad8761d254fdc3afcfd5b2841bf09c551e6c8c5c82ae030b3cf7adc091f
-size 32703
+oid sha256:11704a2bd5bd6e30e5f8a2ac623661cae7070b13faa3cfa78e7c216766ed8d41
+size 32696

--- a/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 2/firefoxFlat.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 2/firefoxFlat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24b2bd6ed5309ea2683103adfcdf11fe72f877d4336f726b9ce91a6a7fdb707e
-size 27959
+oid sha256:bbb57dc7604df7377fb374b88003834a2747aafd28e9fcede702fac94af7acd9
+size 27945

--- a/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 2/ie11Flat.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 2/ie11Flat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28c133c8a19dc67ae68a70d0c4706d4a8445afc7e830a5c772ee0a8d85690ea0
-size 37792
+oid sha256:9e574e60ab9e777f1952324d1dc6fe11b169ae0b862ae2c01d1fefe98d943053
+size 37791

--- a/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 4/chromeFlat.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 4/chromeFlat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40accf58482d09bdc6125ea8a5891920d2695f69bf1f31fba72601aaf87013b9
-size 42140
+oid sha256:a05be6efbb889e3af68c1a7da43e357033add265413c8803e6aec6c995d44a9c
+size 42093

--- a/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 4/firefoxFlat.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 4/firefoxFlat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22573cd2731ec0f3fba5e0a2e72422c87cec03057ae1094c0108bf63d68e9495
-size 34753
+oid sha256:fba12d088091c03b256de0a3c928e9d762d09b677c03159dfe9446135a1c30af
+size 34733

--- a/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 4/ie11Flat.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/button/Button states/different visual states/page - 4/ie11Flat.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:befd5332eadb6f7cecf418a6ae859770974ae8cc95196780e3ccdf83073a3449
-size 41118
+oid sha256:0a4f676a2d06b1447a91ab1b6ea8388a6596ed577ac7e714549424f5eceebb05
+size 41753

--- a/packages/retail-ui/components/Button/Button.common.less
+++ b/packages/retail-ui/components/Button/Button.common.less
@@ -191,20 +191,20 @@
           background: @error-secondary;
         }
       }
-    }
 
-    .narrow {
-      padding-left: 5px;
-      padding-right: 5px;
-    }
+      &.narrow {
+        padding-left: 5px;
+        padding-right: 5px;
+      }
 
-    .noPadding {
-      padding-left: 0;
-      padding-right: 0;
-    }
+      &.noPadding {
+        padding-left: 0;
+        padding-right: 0;
+      }
 
-    .noRightPadding {
-      padding-right: 0;
+      &.noRightPadding {
+        padding-right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
В плоской теме класс `.DEPRECATED_sizeMedium` у средней кнопки перебивал общие стили, и не давал пропам `__noPadding`, `__noPaddingRight` и `narrow` делать свое дело.

| Было | Стало | Diff |
|-|-|-|
| ![image](https://user-images.githubusercontent.com/4607770/59249424-264dba80-8c3e-11e9-9203-a4ba8c279600.png) |![image](https://user-images.githubusercontent.com/4607770/59249380-074f2880-8c3e-11e9-8aaa-e4c5e3dbdb49.png)| ![image](https://user-images.githubusercontent.com/4607770/59249435-32397c80-8c3e-11e9-92aa-8256e6e5faff.png) |

fix #1451 
[comment из #1309](https://github.com/skbkontur/retail-ui/issues/1309#issuecomment-478968843)