### PR TITLE
chore: branch and tag determination

### DIFF
--- a/packages/retail-ui/scripts/git/index.js
+++ b/packages/retail-ui/scripts/git/index.js
@@ -1,29 +1,36 @@
 const { execSync } = require('child_process');
 
-const getCurrentBranch = () => {
-  return execSync('git rev-parse --abbrev-ref HEAD', { shell: true })
-    .toString()
-    .trim();
-};
+const getRevisionRefs = (revId = getRevisionID()) => {
+  const refs = {
+    heads: [],
+    tags: [],
+  };
 
-const getRevisionTags = (pattern = '*') => {
-  const stdout = execSync(`git tag -l ${pattern} --points-at HEAD`, {
+  execSync('git ls-remote --heads --tags origin', {
     shell: true,
   })
     .toString()
-    .trim();
+    .trim()
+    .split('\n')
+    .filter(str => str.includes(revId))
+    .forEach(str => {
+      const match = str.match(/refs\/(heads|tags)\/(.+)$/);
+      if (match) {
+        const [str, type, name] = match;
+        refs[type].push(name.replace('^{}', ''));
+      }
+    });
 
-  return stdout ? stdout.split('\n') : [];
+  return refs;
 };
 
-const getRevisionHash = () => {
+const getRevisionID = () => {
   return execSync('git rev-parse HEAD', { shell: true })
     .toString()
     .trim();
 };
 
 module.exports = {
-  getCurrentBranch,
-  getRevisionHash,
-  getRevisionTags,
+  getRevisionID,
+  getRevisionRefs,
 };

--- a/packages/retail-ui/scripts/package/__tests__/package.test.js
+++ b/packages/retail-ui/scripts/package/__tests__/package.test.js
@@ -5,38 +5,39 @@ describe('package', () => {
     const { LATEST, UNSTABLE, OLD, LTS } = TAGS;
     it.each([
       // invalid
-      ['!valid(v)', 'invalid', 'any', undefined, null],
+      ['!valid(v)', 'invalid', ['any'], [], null],
 
       // valid, no git tag
-      ['no git tag', '1.0.0', 'any', undefined, UNSTABLE],
+      ['no git tag', '1.0.0', ['any'], [], UNSTABLE],
+      ['no git tag', '1.0.0', ['any'], ['retail-ui@any'], UNSTABLE],
 
       // valid, git tag, master branch
-      ['v > npm@latest, master, git tag', '1.0.0', 'master', 'retail-ui@1.0.0', LATEST],
-      ['v = npm@latest, master, git tag', '0.3.2', 'master', 'retail-ui@0.3.2', LATEST],
-      ['v < npm@latest, master, git tag', '0.3.1', 'master', 'retail-ui@0.3.1', null],
+      ['v > npm@latest, master, git tag', '1.0.0', ['master'], ['retail-ui@1.0.0'], LATEST],
+      ['v = npm@latest, master, git tag', '0.3.2', ['master'], ['retail-ui@0.3.2'], LATEST],
+      ['v < npm@latest, master, git tag', '0.3.1', ['master'], ['retail-ui@0.3.1'], null],
 
       // valid, git tag, lts branch
-      ['v > npm@lts && diff == patch, lts, git tag', '0.1.2', 'lts', 'retail-ui@0.1.2', LTS],
-      ['v > npm@lts && diff != patch, lts, git tag', '0.2.0', 'lts', 'retail-ui@0.2.0', null],
-      ['v = npm@lts, lts, git tag', '0.1.1', 'lts', 'retail-ui@0.1.1', LTS],
-      ['v < npm@lts, lts, git tag', '0.1.0', 'lts', 'retail-ui@0.1.0', null],
+      ['v > npm@lts && diff == patch, lts, git tag', '0.1.2', ['lts'], ['retail-ui@0.1.2'], LTS],
+      ['v > npm@lts && diff != patch, lts, git tag', '0.2.0', ['lts'], ['retail-ui@0.2.0'], null],
+      ['v = npm@lts, lts, git tag', '0.1.1', ['lts'], ['retail-ui@0.1.1'], LTS],
+      ['v < npm@lts, lts, git tag', '0.1.0', ['lts'], ['retail-ui@0.1.0'], null],
 
       // valid, git tag, any other branch
-      ['!master && !lts, git tag', '10.0.0', '10.0.x', 'retail-ui@10.0.0', OLD],
-    ])('%s', (label, version, gitBranch, gitTag, result) => {
+      ['!master && !lts, git tag', '10.0.0', ['10.0.x'], ['retail-ui@10.0.0'], OLD],
+    ])('%s', (label, version, revBranches, revTags, result) => {
       const npmTags = {
         latest: '0.3.2',
         lts: '0.1.1',
       };
-      expect(getDistTag(version, npmTags, gitBranch, gitTag)).toBe(result);
+      expect(getDistTag(version, npmTags, revBranches, revTags)).toBe(result);
     });
 
     it('!valid(npm@latest)', () => {
-      expect(getDistTag('0.0.0', {}, 'master', true)).toBe(null);
+      expect(getDistTag('0.0.0', {}, ['master'], ['retail-ui@0.0.0'])).toBe(null);
     });
 
     it('!valid(npm@lts)', () => {
-      expect(getDistTag('0.0.0', {}, 'lts', true)).toBe(null);
+      expect(getDistTag('0.0.0', {}, ['lts'], ['retail-ui@0.0.0'])).toBe(null);
     });
   });
 });


### PR DESCRIPTION
Обновил механизм определения ветки и тега при выпуске релизов.

Старый метод не работал, когда происходил checkout тега на TeamCity. В таком состоянии HEAD уже не указывает ни на одну из веток. Более надежно смотреть на ссылки на текущую ревизию в upstream-репозитории.