### PR TITLE
fix(Modal): don't close by click on scrollbar

### DIFF
--- a/packages/retail-ui/components/Modal/Modal.tsx
+++ b/packages/retail-ui/components/Modal/Modal.tsx
@@ -81,6 +81,8 @@ export default class Modal extends React.Component<ModalProps, ModalState> {
 
   private stackSubscription: EventSubscription | null = null;
   private containerNode: HTMLDivElement | null = null;
+  private mouseDownTarget: EventTarget | null = null;
+  private mouseUpTarget: EventTarget | null = null;
 
   public componentDidMount() {
     this.stackSubscription = ModalStack.add(this, this.handleStackChange);
@@ -165,7 +167,9 @@ export default class Modal extends React.Component<ModalProps, ModalState> {
           <div
             ref={this.refContainer}
             className={cn(styles.container, styles.mobile)}
-            onMouseDown={this.handleContainerClick}
+            onMouseDown={this.handleContainerMouseDown}
+            onMouseUp={this.handleContainerMouseUp}
+            onClick={this.handleContainerClick}
             data-tid="modal-container"
           >
             <div
@@ -213,10 +217,18 @@ export default class Modal extends React.Component<ModalProps, ModalState> {
     this.setState({ stackPosition: stack.indexOf(this) });
   };
 
+  private handleContainerMouseDown = (event: React.MouseEvent) => {
+    this.mouseDownTarget = event.target;
+  };
+
+  private handleContainerMouseUp = (event: React.MouseEvent) => {
+    this.mouseUpTarget = event.target;
+  };
+
   private handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!this.props.ignoreBackgroundClick) {
       const { target, currentTarget } = event;
-      if (target === currentTarget) {
+      if (target === currentTarget && this.mouseDownTarget === currentTarget && this.mouseUpTarget === currentTarget) {
         this.requestClose();
       }
     }

--- a/packages/retail-ui/components/Modal/__tests__/Modal-test.tsx
+++ b/packages/retail-ui/components/Modal/__tests__/Modal-test.tsx
@@ -4,6 +4,29 @@ import Modal from '../Modal';
 import { isHeader } from '../ModalHeader';
 import { isFooter } from '../ModalFooter';
 
+function emulateRealClick(
+  mouseDownTarget: Element | null,
+  mouseUpTarget?: Element | null,
+  clickTarget?: Element | null,
+) {
+  mouseUpTarget = mouseUpTarget || mouseDownTarget;
+  clickTarget = clickTarget || mouseDownTarget;
+
+  if (mouseDownTarget && mouseUpTarget && clickTarget) {
+    const mouseDownEvent = document.createEvent('HTMLEvents');
+    const mouseUpEvent = document.createEvent('HTMLEvents');
+    const clickEvent = document.createEvent('HTMLEvents');
+
+    mouseDownEvent.initEvent('mousedown', true, true);
+    mouseUpEvent.initEvent('mouseup', true, true);
+    clickEvent.initEvent('click', true, true);
+
+    mouseDownTarget.dispatchEvent(mouseDownEvent);
+    mouseUpTarget.dispatchEvent(mouseUpEvent);
+    clickTarget.dispatchEvent(clickEvent);
+  }
+}
+
 describe('Modal', () => {
   it('Simple render without crash', () => {
     const render = () =>
@@ -77,7 +100,7 @@ describe('Modal', () => {
     const wrapper = mount(<Modal onClose={onCloseHandler}>Modal content</Modal>);
 
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
-    wrapper.find('[data-tid="modal-container"]').simulate('mouseDown');
+    emulateRealClick(wrapper.find('[data-tid="modal-container"]').getDOMNode());
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
   });
 
@@ -88,9 +111,10 @@ describe('Modal', () => {
         <div data-tid="modal-content" />
       </Modal>,
     );
+    const contentNode = wrapper.find('[data-tid="modal-content"]').getDOMNode();
 
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
-    wrapper.find('[data-tid="modal-content"]').simulate('mouseDown');
+    emulateRealClick(contentNode);
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
   });
 
@@ -101,22 +125,24 @@ describe('Modal', () => {
         Modal content
       </Modal>,
     );
+    const containerNode = wrapper.find('[data-tid="modal-container"]').getDOMNode();
 
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
-    wrapper.find('[data-tid="modal-container"]').simulate('mouseDown');
+    emulateRealClick(containerNode);
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('click on background not work if disableClose is true', () => {
+  it("click on background doesn't work if disableClose is true", () => {
     const onCloseHandler = jest.fn();
     const wrapper = mount(
       <Modal disableClose onClose={onCloseHandler}>
         Modal content
       </Modal>,
     );
+    const containerNode = wrapper.find('[data-tid="modal-container"]').getDOMNode();
 
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
-    wrapper.find('[data-tid="modal-container"]').simulate('mouseDown');
+    emulateRealClick(containerNode);
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
   });
 
@@ -127,9 +153,10 @@ describe('Modal', () => {
         Modal content
       </Modal>,
     );
+    const containerNode = wrapper.find('[data-tid="modal-container"]').getDOMNode();
 
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
-    wrapper.find('[data-tid="modal-container"]').simulate('mouseDown');
+    emulateRealClick(containerNode);
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/retail-ui/components/Modal/__tests__/Modal-test.tsx
+++ b/packages/retail-ui/components/Modal/__tests__/Modal-test.tsx
@@ -95,13 +95,32 @@ describe('Modal', () => {
     expect(wrapper.find('Close')).toHaveLength(0);
   });
 
-  it('click on background call onClose', () => {
+  it('direct click on background calls onClose', () => {
     const onCloseHandler = jest.fn();
     const wrapper = mount(<Modal onClose={onCloseHandler}>Modal content</Modal>);
 
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
     emulateRealClick(wrapper.find('[data-tid="modal-container"]').getDOMNode());
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("click on background doesn't call onClose if started/ended on modal content", () => {
+    const onCloseHandler = jest.fn();
+    const wrapper = mount(
+      <Modal onClose={onCloseHandler}>
+        <div data-tid="modal-content" />
+      </Modal>,
+    );
+    const containerNode = wrapper.find('[data-tid="modal-container"]').getDOMNode();
+    const contentNode = wrapper.find('[data-tid="modal-content"]').getDOMNode();
+
+    expect(onCloseHandler).toHaveBeenCalledTimes(0);
+
+    emulateRealClick(contentNode, containerNode, containerNode);
+    expect(onCloseHandler).toHaveBeenCalledTimes(0);
+
+    emulateRealClick(containerNode, contentNode, containerNode);
+    expect(onCloseHandler).toHaveBeenCalledTimes(0);
   });
 
   it("click on content doesn't call onClose", () => {


### PR DESCRIPTION
Убрал нежелательное закрытие модалки после клика по скроллбару.

История вопроса. 
- Изначально, для закрытия модалки по клику на фоне, просто слушался клик на контейнере, с проверкой на `target === currentTarget`, пока не обнаружили #757. 
- После чего добавили другой элемент `сlickTrap`, на котором стали слушать клики, пытаясь его растянуть по размеру контейнера, но работало плохо #810, #1352.
- Потом отказались от `сlickTrap`, вернулись на контейнер и стали слушать `mouseDown` , чтобы обойти #757. Но возникла проблема #1456.
- Наконец, вернул самый простой клик на контейнере с проверкой на то, что он начался и закончился на нем же, для обхода #757.

fix #1456