### PR TITLE
fix(react-selenium-testing): fix prop propagation

### DIFF
--- a/packages/react-ui-testing/react-selenium-testing.js
+++ b/packages/react-ui-testing/react-selenium-testing.js
@@ -327,7 +327,7 @@ function fillAttrsForDomElementByFiberNodeRecursive(attrContainer, node, visited
   if (node.tag === 1 || node.tag === 2 || node.tag === 12 || node.tag === 13 || node.tag === 10) {
     fillAttrsForDomElementByFiberNodeRecursive(attrContainer, node.child, visitedNodes);
   } else if (node.tag === 5) {
-    // I dont know what does it mean
+    fillAttrsForDomElementByFiberNodeRecursive(attrContainer, node.return, visitedNodes);
   } else if (node.tag === 4) {
     // I dont know what does it mean
   } else {


### PR DESCRIPTION
For FiberNode of HostComponent type

Исправление по следам запроса от маркета:

Привет, мы в маркете обновляем реакт и столкнулись с проблемой, что селениум перестал видеть элемент Radio из retail-ui. Еще с Radiogroup и Tooltip возникли проблемы. Позвали Славу Овчинникова, оказалось, что  теперь html атрибуты стали проставляться у Radio не в label, а в input. Но поскольку input на странице невидим, то селениум перестал видеть все Radio элементы. Слава сказал, что ты можешь помочь, потому что разбирался с подобной проблемой в Button, как я понял.