### PR TITLE
fix(Tab): remove hover border from disabled tabs

### DIFF
--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/clicked/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/clicked/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:349ff305ca5e3a7dd2dc293acafad5fa1fbd69b996e7981ea487aa2c435f78ec
+size 3062

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/clicked/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/clicked/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3521ffbc65fe2eff0f86e499319c5290228d9e3982e49e809a1727be7738b6
+size 2328

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/clicked/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/clicked/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33788c4bb2d232c66c7604cc8239aa77668b1c7b6d569357a7d65b44dbd8f27c
+size 3344

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/enterPress/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/enterPress/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b91079f65c35005e64a5ce6bb210ac3b68ab6aab59040b6f9608cf22b088ac80
+size 3097

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/enterPress/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/enterPress/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51a3d73c9e5eb0838d9c5d7a822a8ae95e24715dd1082bb2e6f486dcf8cadf72
+size 2363

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/enterPress/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/enterPress/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc78b14bc5f0fcf2b5415fe1ebbf9628196d3ac6fc6c1804ac11a2694cae6311
+size 3375

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/focused/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/focused/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:349ff305ca5e3a7dd2dc293acafad5fa1fbd69b996e7981ea487aa2c435f78ec
+size 3062

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/focused/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/focused/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3521ffbc65fe2eff0f86e499319c5290228d9e3982e49e809a1727be7738b6
+size 2328

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/focused/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/focused/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33788c4bb2d232c66c7604cc8239aa77668b1c7b6d569357a7d65b44dbd8f27c
+size 3344

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/hovered/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/hovered/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:349ff305ca5e3a7dd2dc293acafad5fa1fbd69b996e7981ea487aa2c435f78ec
+size 3062

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/hovered/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/hovered/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3521ffbc65fe2eff0f86e499319c5290228d9e3982e49e809a1727be7738b6
+size 2328

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/hovered/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/hovered/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33788c4bb2d232c66c7604cc8239aa77668b1c7b6d569357a7d65b44dbd8f27c
+size 3344

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/mouseLeave/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/mouseLeave/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:349ff305ca5e3a7dd2dc293acafad5fa1fbd69b996e7981ea487aa2c435f78ec
+size 3062

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/mouseLeave/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/mouseLeave/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3521ffbc65fe2eff0f86e499319c5290228d9e3982e49e809a1727be7738b6
+size 2328

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/mouseLeave/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/mouseLeave/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33788c4bb2d232c66c7604cc8239aa77668b1c7b6d569357a7d65b44dbd8f27c
+size 3344

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/plain/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/plain/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:349ff305ca5e3a7dd2dc293acafad5fa1fbd69b996e7981ea487aa2c435f78ec
+size 3062

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/plain/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/plain/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3521ffbc65fe2eff0f86e499319c5290228d9e3982e49e809a1727be7738b6
+size 2328

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/plain/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/plain/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33788c4bb2d232c66c7604cc8239aa77668b1c7b6d569357a7d65b44dbd8f27c
+size 3344

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/tabPress/chrome.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/tabPress/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7750b4e673263ca18b994ca13780fa154870ef8886deca6a69bb48c9ad939682
+size 3096

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/tabPress/firefox.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/tabPress/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d2f2375078bd88ff9abd234182251729501a2d49c571b36b47bec7b36b78bc7
+size 2362

--- a/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/tabPress/ie11.png
+++ b/packages/react-ui-screenshot-tests/gemini/screens/tabs disabled/tabPress/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ee7a2f61a9ba87c1ef0f02d19e0ae32ca45c061ef529a08f0258654a35c8bb9
+size 3374

--- a/packages/react-ui-screenshot-tests/gemini/tabs.js
+++ b/packages/react-ui-screenshot-tests/gemini/tabs.js
@@ -54,5 +54,10 @@ gemini.suite('Tabs keyboard control', suite => {
     })
     .capture('reset focus after click', (actions, find) => {
       actions.click(find(tabAtIndex(3)));
-    })
+    });
+});
+
+gemini.suite('tabs disabled', suite => {
+  suite.before(renderStory('Tabs', 'with disabled tab'));
+  applyTest(suite);
 });

--- a/packages/retail-ui/components/Tabs/Tab.less
+++ b/packages/retail-ui/components/Tabs/Tab.less
@@ -71,10 +71,10 @@
   }
 
   .disabled:hover {
-    border-bottom-color: transparent;
+    border-bottom-color: transparent !important;
   }
 
   .disabled.vertical:hover {
-    border-left-color: transparent;
+    border-left-color: transparent !important;
   }
 }

--- a/packages/retail-ui/components/Tabs/Tab.styles.ts
+++ b/packages/retail-ui/components/Tabs/Tab.styles.ts
@@ -40,7 +40,10 @@ const jsStyles = {
   primary(t: ITheme) {
     return css`
       &:hover {
-        border-bottom: 3px solid ${t.tabColorHoverPrimary};
+        border-bottom-color: ${t.tabColorHoverPrimary};
+      }
+      &.${styles.vertical}:hover {
+        border-left-color: ${t.tabColorHoverPrimary};
       }
     `;
   },
@@ -48,7 +51,10 @@ const jsStyles = {
   success(t: ITheme) {
     return css`
       &:hover {
-        border-bottom: 3px solid ${t.tabColorHoverSuccess};
+        border-bottom-color: ${t.tabColorHoverSuccess};
+      }
+      &.${styles.vertical}:hover {
+        border-left-color: ${t.tabColorHoverSuccess};
       }
     `;
   },
@@ -56,7 +62,10 @@ const jsStyles = {
   warning(t: ITheme) {
     return css`
       &:hover {
-        border-bottom: 3px solid ${t.tabColorHoverWarning};
+        border-bottom-color: ${t.tabColorHoverWarning};
+      }
+      &.${styles.vertical}:hover {
+        border-left-color: ${t.tabColorHoverWarning};
       }
     `;
   },
@@ -64,7 +73,10 @@ const jsStyles = {
   error(t: ITheme) {
     return css`
       &:hover {
-        border-bottom: 3px solid ${t.tabColorHoverError};
+        border-bottom-color: ${t.tabColorHoverError};
+      }
+      &.${styles.vertical}:hover {
+        border-left-color: ${t.tabColorHoverError};
       }
     `;
   },

--- a/packages/retail-ui/components/Tabs/__stories__/Tabs.stories.tsx
+++ b/packages/retail-ui/components/Tabs/__stories__/Tabs.stories.tsx
@@ -2,8 +2,9 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { linkTo } from '@storybook/addon-links';
-
+import { ComponentTable } from '../../internal/ComponentTable';
 import Tabs from '../Tabs';
+import { TabProps } from '../Tab';
 import Modal from '../../Modal';
 import Button from '../../Button';
 const { Tab } = Tabs;
@@ -220,6 +221,33 @@ class TabsInModal extends React.Component<any, any> {
   };
 }
 
+class TabsTable extends React.Component {
+  public static TestTab = class extends React.Component<TabProps & { vertical?: boolean }, any> {
+    public render() {
+      const { vertical, ...tabProps } = this.props;
+      return (
+        <Tabs vertical={vertical} value="">
+          <Tab {...tabProps}>Tab</Tab>
+        </Tabs>
+      );
+    }
+  };
+
+  public render() {
+    const rows = [{}, { primary: true }, { error: true }, { warning: true }];
+    const cols = [{}, { vertical: true }, { disabled: true }, { vertical: true, disabled: true }];
+    return (
+      <div>
+        <ComponentTable
+          Component={TabsTable.TestTab}
+          rows={rows.map(x => ({ props: x }))}
+          cols={cols.map(x => ({ props: x }))}
+        />
+      </div>
+    );
+  }
+}
+
 storiesOf('Tabs', module)
   .add('simple', () => <UncTabs />)
   .add('first', () => <RouterTabs value="first" />)
@@ -240,4 +268,5 @@ storiesOf('Tabs', module)
   .add('with component', () => <TabsWithMyLink />)
   .add('with unexpected tab size change', () => <OhMyTabs />)
   .add('with disabled tab', () => <DisabledTab />)
-  .add('tabs in modal', () => <TabsInModal />);
+  .add('tabs in modal', () => <TabsInModal />)
+  .add('hover table', () => <TabsTable />);

--- a/packages/retail-ui/components/Tabs/__stories__/Tabs.stories.tsx
+++ b/packages/retail-ui/components/Tabs/__stories__/Tabs.stories.tsx
@@ -119,8 +119,10 @@ class DisabledTab extends React.Component<any, any> {
         <Tab id="second" disabled>
           Second (disabled)
         </Tab>
-        <Tab id="third">Third</Tab>
-        <Tab id="fourth">Third</Tab>
+        <Tab id="third" disabled>
+          Third (disabled)
+        </Tab>
+        <Tab id="fourth">Fourth</Tab>
       </Tabs>
     );
   }


### PR DESCRIPTION
1. Убрал ховер на `disabled` вкладках 
2. Добавил скриншотов
3. Добавил цветных бордеров для вертикальных вкладок, как у горизонтальных

fix #1504 