### PR TITLE
fix(Radio): decrease types checking time

### DIFF
--- a/packages/retail-ui/components/Radio/Radio.tsx
+++ b/packages/retail-ui/components/Radio/Radio.tsx
@@ -79,25 +79,6 @@ class Radio<T> extends React.Component<RadioProps<T>> {
     focused: false,
   };
 
-  public static propTypes = {
-    checked: PropTypes.bool,
-    children: PropTypes.node,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    focused: PropTypes.bool,
-    hovered: PropTypes.bool,
-    id: PropTypes.string,
-    name: PropTypes.string,
-    pressed: PropTypes.bool,
-    tabIndex: PropTypes.number,
-    value: PropTypes.any.isRequired,
-    warning: PropTypes.bool,
-    onChange: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
-  };
-
   private theme!: ITheme;
   private _node: Nullable<HTMLInputElement> = null;
 


### PR DESCRIPTION
Typescript очень долго обрабатывает компонент Radio (~ 1 мин). Самое безболезненное и простое решение, которое нашел - избавиться от propTypes. Они используются только для дополнительной проверки пропов в рантайме (в dev режиме).

Как воспроизвести проблему:

```
mkdir test-radio && cd test-radio
yarn init -y
yarn add @types/react @types/react-dom typescript @skbkontur/react-ui
echo "import React from 'react'; import Radio from '@skbkontur/react-ui/Radio'; <Radio value='' />" > index.tsx
yarn tsc index.tsx --skipLibCheck --jsx react --module commonJs --esModuleInterop
```

fix #1518