### PR TITLE
fix(Group): removed vertical-align

### DIFF
--- a/packages/retail-ui/components/Group/Group.less
+++ b/packages/retail-ui/components/Group/Group.less
@@ -1,7 +1,6 @@
 :local {
   .root {
     display: inline-flex;
-    vertical-align: bottom;
   }
 
   .fixed {


### PR DESCRIPTION
Убрала `vertical-aling: bottom` у `Group`, чтобы нормально работало выравнивание. Раньше это было нужно для поддержки IE8, сейчас уже не требуется.

Fix https://github.com/skbkontur/retail-ui/issues/1537