### PR TITLE
fix(Button): change disabled bg & shadow for the FlatTheme

### DIFF
--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 1/chromeFlat/page - 1.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 1/chromeFlat/page - 1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c74d4ab2d44b233b3118ac06c6a6c370220a712fa5ce284762826817092d985d
-size 37102
+oid sha256:c59cfb6ff4c7f6b5ea01f9162ff0ab2c607fbfdf24fc3072bde232ad0becce88
+size 36997

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 1/firefoxFlat/page - 1.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 1/firefoxFlat/page - 1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be8837abb656530cbeb220db880a3bc6fc4f11b74760cc576e7fb74e350d6c76
-size 26036
+oid sha256:ab91cb3b28f2c2fc4cf8b45ac7c446c129c7d43f823c1300caaaf49dc3037a66
+size 26013

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 1/ie11Flat/page - 1.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 1/ie11Flat/page - 1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac098fc2e6415c7b457d2aafd645b9a36d0a1033258791b4bddab11cfa96c3a8
-size 35865
+oid sha256:62ce3135e5c77951f83de245bff32fb64b50e67efcd2dbada2765c9722f45a5d
+size 35507

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 2/chromeFlat/page - 2.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 2/chromeFlat/page - 2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52811a22d51e683e4c13987ee97515c637a4c4c3c000e4ce39b1b13d8bde0231
-size 28018
+oid sha256:62b47c95efad0fa43c2edc3c79a2db4046ee201aa83632c036bec849856edbf0
+size 27891

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 2/firefoxFlat/page - 2.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 2/firefoxFlat/page - 2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c7b5024421cdcf1bb9e666319babaedbfe2685d40f420f95ac2d3acb6cc1107
-size 21714
+oid sha256:7a7fd1836af0beffed6b96baefabc12aa2411759891d87f1fa430f1928d108f2
+size 21596

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 2/ie11Flat/page - 2.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 2/ie11Flat/page - 2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37acff7dc6ebb48fdfecadbfaccb4e541b921bb4df94e1e03151b0dfcdf6c784
-size 24583
+oid sha256:527fe65cd6292dd0332594df5650c62d89047c66a151eec023d1b3c11b4c1fa6
+size 24018

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 3/chromeFlat/page - 3.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 3/chromeFlat/page - 3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8cc49e55f168494dfdc43b1eb82a8d4eb92e1d7a32b41f95974141806edc939c
-size 18955
+oid sha256:a973c0a5bc8fa21d2a7c2eec2dde74ef93f4f318545e34f96d44b46aeb46539f
+size 18264

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 3/firefoxFlat/page - 3.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 3/firefoxFlat/page - 3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26fc391f59f4c5cfd9789ce13c16483a8d46e50683efe6bf731188023ba109e0
-size 13212
+oid sha256:ea2d9e66f6fd038adc5324dc064503eeb91a90dd257841cb6f3def979c7f196e
+size 12717

--- a/packages/react-ui-selenium/images/Button/disabled combinations/page - 3/ie11Flat/page - 3.png
+++ b/packages/react-ui-selenium/images/Button/disabled combinations/page - 3/ie11Flat/page - 3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1032e264c34f26630a20e7d652d49dd65ff4f80bcf09d1427a2d20e648ae1d9
-size 16946
+oid sha256:1cb5221e35281e2e0c8d6b2c3f7383e05756d3ba919c0c1a71898d48b5b6fe5b
+size 15752

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 1/chromeFlat/page - 1.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 1/chromeFlat/page - 1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebe2c6272c8a549e8aca45856702dc00bc43d29e10ec185ef542087fedef02da
-size 43736
+oid sha256:3aed357dadc5ab6e8ca2766d7b8ee00db914ad23bd4a1d616756f088b9628919
+size 43713

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 1/firefoxFlat/page - 1.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 1/firefoxFlat/page - 1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0dbe00bc70da1955eb52fec6ae5702af9171f7fdb546618815e75a1f59217e08
-size 28636
+oid sha256:0e828815522da75d26c7f649d8f5b30ea0147a69e7273802cdfdfb98751e625b
+size 28588

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 1/ie11Flat/page - 1.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 1/ie11Flat/page - 1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb0b27331fbabca0f1bee0fcd6a7765644e23f19fd33d6cfedac289026656f4a
-size 59153
+oid sha256:207bedc141f453a31bb2ac5d2ad968633897069e6156e3c0aaa85f2d137d63d6
+size 58724

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 2/chromeFlat/page - 2.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 2/chromeFlat/page - 2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e60bbe1d004dd3f365359adb42a28b6c76df20a18fc44e459bcd7ef8a421a7ec
-size 36904
+oid sha256:ee5aecc90bd18f8dfb9707b0f561065b8add33232ee4e94dd18218cfa6053cb4
+size 36879

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 2/firefoxFlat/page - 2.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 2/firefoxFlat/page - 2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2f732a59774ee716a3fc195db508e489ecdd3e7c3c7376c12cecda5485311b0
-size 27533
+oid sha256:4a9ad4b4f735c7289116a867dcc93757e20a2a426655b0f9024dd3c90d2110ee
+size 27580

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 2/ie11Flat/page - 2.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 2/ie11Flat/page - 2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00daf66cf97195a1b1c61cba8cc7e2bddbadc0d882592cf3c06f4e62a8a88189
-size 41674
+oid sha256:df0daad80df76fd48cf081961b970a4cf7bc8dc548cc84b5772659a83e92e891
+size 41273

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 3/chromeFlat/page - 3.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 3/chromeFlat/page - 3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f9d2e5d4552a93e90dcfc842c6457215534be5bf7ac289a99d19fe796a3b2ba
-size 21746
+oid sha256:120883699e48a54357118861a51e6bbe23e66d719f0cd96b6dc79822cc6826a7
+size 21737

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 3/firefoxFlat/page - 3.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 3/firefoxFlat/page - 3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4b31c16f5121dd94e287c2d489fdb1de819ef622403c38a9c53e8518a4c0e95
-size 15789
+oid sha256:d73ff2e199fc10f549028afec18a351b3cae35df6922559c75ed8f59c3033318
+size 15495

--- a/packages/react-ui-selenium/images/Button/loading combinations/page - 3/ie11Flat/page - 3.png
+++ b/packages/react-ui-selenium/images/Button/loading combinations/page - 3/ie11Flat/page - 3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b2f4820ff0f21e90acf632ce16c368962f2743e97e5b1d3913688f569689c17
-size 25163
+oid sha256:96f5892f2947c145ff04143dcd4a62fdfa24dc7c25965a033499cf51bc2d7df8
+size 24131

--- a/packages/retail-ui/components/variables.flat.less
+++ b/packages/retail-ui/components/variables.flat.less
@@ -13,9 +13,9 @@
 @btn-flat-shadow-checked-arrow: '__COMPUTED__';
 @btn-flat-shadow-checked-arrow-left: '__COMPUTED__';
 @btn-flat-checked-text-color: #fff;
-@btn-flat-disabled-bg: #f4f4f4;
+@btn-flat-disabled-bg: #f2f2f2;
 @btn-flat-disabled-shadow: none;
-@btn-flat-disabled-shadow-color: #f4f4f4;
+@btn-flat-disabled-shadow-color: #f2f2f2;
 @btn-flat-focus-shadow-width: 1px;
 @btn-flat-focus-border: '__COMPUTED__';
 


### PR DESCRIPTION
У плоской кнопки фон и тень стрелки в состоянии `disabled` отличаются от [фигмы](https://www.figma.com/file/FTSaUIW3EUjCzOwZfP7II9/Kontur-UI-Flat?node-id=1450%3A9). Неверные значения `@btn-flat-disabled-bg` и `@btn-flat-disabled-shadow-color`, по факту, применяются [только к стрелке](https://github.com/skbkontur/retail-ui/blob/7481e502cae1dd3cef8a2ef8dc05151d9b67881e/packages/retail-ui/components/Button/Button.styles.ts#L176-L177), с самой кнопкой все норм.

