### PR TITLE
chore(retail-ui): move critical styles from less to js

### DIFF
--- a/packages/retail-ui/components/Button/Button.module.less
+++ b/packages/retail-ui/components/Button/Button.module.less
@@ -113,10 +113,6 @@
       position: relative;
       z-index: 2;
 
-      &:not(.disabled):not(.loading):not(.link) {
-        border: none;
-      }
-
       &.errorRoot,
       &.warningRoot {
         border-color: transparent !important;

--- a/packages/retail-ui/components/Button/Button.module.less
+++ b/packages/retail-ui/components/Button/Button.module.less
@@ -150,17 +150,11 @@
   .buttonArrowMixin(sizeSmall, 7.5px, -9.6px, -7.5px, 16.8px, rotate(53deg) skewX(24deg) skewY(10deg));
   .buttonLoadingArrowMixin(sizeSmall, 7px, 7px, -207px, 441%);
 
-  .sizeSmall {
-    font-size: 14px;
-  }
-
   // size Medium
   .buttonArrowMixin(sizeMedium, 9px, -9.6px, -10.2px, 20.2px, rotate(53deg) skewX(24deg) skewY(8deg));
   .buttonLoadingArrowMixin(sizeMedium, 0, 0, -208px, 441%);
 
   .sizeMedium {
-    font-size: 16px;
-
     .arrow.arrow_loading {
       &::before {
         background: linear-gradient(-56deg, transparent 46.9%, #ccc 0, #ccc 69.5%, transparent 0);
@@ -173,8 +167,6 @@
   .buttonLoadingArrowMixin(sizeLarge, -32px, -36px, -198px, 700%);
 
   .sizeLarge {
-    font-size: 16px;
-
     .arrow.arrow_loading {
       &::before {
         background: linear-gradient(-56deg, transparent 48.2%, #ccc 0, #ccc 63.4%, transparent 0);

--- a/packages/retail-ui/components/Button/Button.module.less
+++ b/packages/retail-ui/components/Button/Button.module.less
@@ -197,7 +197,6 @@
   .wrap {
     box-sizing: border-box;
     display: inline-block;
-    padding: 1px;
 
     &_link {
       padding: 0;

--- a/packages/retail-ui/components/Button/Button.styles.ts
+++ b/packages/retail-ui/components/Button/Button.styles.ts
@@ -115,14 +115,17 @@ const jsClasses = {
 
   link(t: ITheme) {
     return css`
-      color: ${t.linkColor};
+      &.${classes.link} {
+        color: ${t.linkColor};
+        border-radius: ${t.btnLinkBorderRadius};
 
-      &:hover {
-        color: ${t.linkHoverColor};
-        text-decoration: ${t.linkHoverTextDecoration};
-      }
-      &:active {
-        color: ${t.linkActiveColor};
+        &:hover {
+          color: ${t.linkHoverColor};
+          text-decoration: ${t.linkHoverTextDecoration};
+        }
+        &:active {
+          color: ${t.linkActiveColor};
+        }
       }
     `;
   },

--- a/packages/retail-ui/components/Modal/Modal.module.less
+++ b/packages/retail-ui/components/Modal/Modal.module.less
@@ -36,7 +36,6 @@
   .centerContainer {
     position: relative;
     display: inline-block;
-    margin: 40px 20px;
     text-align: left;
     vertical-align: middle;
     box-sizing: border-box;
@@ -57,7 +56,6 @@
   .close {
     position: relative;
     float: right;
-    background: none;
     cursor: pointer;
 
     &.disabled {

--- a/packages/retail-ui/components/Modal/Modal.styles.ts
+++ b/packages/retail-ui/components/Modal/Modal.styles.ts
@@ -18,6 +18,8 @@ const jsStyles = {
   },
   centerContainer(t: ITheme) {
     return css`
+      margin: 40px 20px;
+
       @media screen and (max-width: ${t.modalAdaptiveThreshold}) {
         margin: 0;
         width: 100%;
@@ -29,6 +31,7 @@ const jsStyles = {
     return css`
       ${resetButton()};
 
+      background: none;
       margin: 2px 2px 0 0;
       width: 76px;
       height: 65px;

--- a/packages/retail-ui/components/Radio/Radio.module.less
+++ b/packages/retail-ui/components/Radio/Radio.module.less
@@ -3,35 +3,15 @@
     position: relative;
     white-space: nowrap;
     cursor: pointer;
-
-    &:hover {
-      .radio {
-        background: linear-gradient(-180deg, #f2f2f2 0, #dfdfdf 100%);
-        box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.2);
-      }
-    }
-
-    &:active {
-      .radio {
-        background: linear-gradient(-180deg, #e1e1e1 0, #e1e1e1 100%);
-        box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-      }
-    }
   }
 
   .radio {
-    background-image: linear-gradient(-180deg, #fff 0, #ebebeb 100%);
-    border: 0 none;
-    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.15);
     position: relative;
     border-radius: 50%;
     display: inline-block;
     box-sizing: border-box;
     margin-top: 2px;
     margin-bottom: 2px;
-    vertical-align: -2px;
-    width: 16px;
-    height: 16px;
 
     &::after {
       content: ' ';
@@ -62,16 +42,13 @@
     border-style: solid;
     border-radius: 50%;
     box-sizing: border-box;
-    box-shadow: none;
   }
 
   .root .radio.checked {
     position: relative;
-    background-color: transparent;
   }
 
   .root .radio.checked::before {
-    background: #404040;
     content: ' ';
     position: absolute;
     top: 0;
@@ -88,7 +65,6 @@
   .disabled {
     background: #f2f2f2 !important;
     border-color: transparent !important;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15) !important;
   }
 
   .root .radio.disabled.checked::before {
@@ -96,7 +72,6 @@
   }
 
   .label {
-    display: inline-table;
     margin-left: 9px;
     white-space: normal;
     line-height: 20px;

--- a/packages/retail-ui/components/Tabs/Tab.module.less
+++ b/packages/retail-ui/components/Tabs/Tab.module.less
@@ -9,11 +9,9 @@
     padding-bottom: 11px;
     box-sizing: border-box;
     font-size: 18px;
-    border-bottom: 3px solid transparent;
     transition: border-bottom @easing;
     cursor: pointer;
     position: relative;
-    color: inherit;
     text-decoration: inherit;
   }
 
@@ -23,8 +21,6 @@
     margin-right: 0;
     padding-left: 17px;
     padding-right: 20px;
-    border-bottom: none;
-    border-left: 3px solid transparent;
   }
 
   .root:focus {

--- a/packages/retail-ui/components/Tabs/Tab.styles.ts
+++ b/packages/retail-ui/components/Tabs/Tab.styles.ts
@@ -6,6 +6,9 @@ import { ITheme } from '../../lib/theming/Theme';
 const jsStyles = {
   root(t: ITheme) {
     return css`
+      color: inherit;
+      border-bottom: 3px solid transparent;
+
       &:hover {
         border-bottom: 3px solid ${t.tabColorHover};
       }
@@ -14,6 +17,9 @@ const jsStyles = {
 
   vertical(t: ITheme) {
     return css`
+      border-bottom: none;
+      border-left: 3px solid transparent;
+
       .${styles.root}&:hover {
         border-left: 3px solid ${t.tabColorHover};
       }

--- a/packages/retail-ui/components/Textarea/Textarea.module.less
+++ b/packages/retail-ui/components/Textarea/Textarea.module.less
@@ -6,7 +6,6 @@
 
   .textarea {
     box-sizing: border-box;
-    box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.05);
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
@@ -22,10 +21,6 @@
     &:focus {
       position: relative;
       z-index: 2;
-    }
-
-    &:disabled {
-      box-shadow: none;
     }
   }
 

--- a/packages/retail-ui/components/Textarea/Textarea.styles.ts
+++ b/packages/retail-ui/components/Textarea/Textarea.styles.ts
@@ -30,6 +30,7 @@ const jsStyles = {
         color: ${t.textColorDisabled};
         background: ${t.textareaDisabledBg};
         border-color: ${t.textareaDisabledBorderColor};
+        box-shadow: none;
       }
 
       &::placeholder {

--- a/packages/retail-ui/components/Toast/ToastView.module.less
+++ b/packages/retail-ui/components/Toast/ToastView.module.less
@@ -13,7 +13,6 @@
     position: relative;
     top: 20px;
     padding: 10px 20px 11px;
-    background: #333;
     opacity: 1;
     font-size: 14px;
     border-radius: 2px;

--- a/packages/retail-ui/components/Toggle/Toggle.module.less
+++ b/packages/retail-ui/components/Toggle/Toggle.module.less
@@ -10,7 +10,6 @@
 
 :local {
   .handle {
-    background: linear-gradient(-180deg, #fff, #ebebeb);
     height: 18px;
     width: @handleSize;
     border-radius: @handleSize / 2;

--- a/packages/retail-ui/components/variables.flat.less
+++ b/packages/retail-ui/components/variables.flat.less
@@ -8,6 +8,7 @@
 @btn-flat-checked-bg: #7e7e7e;
 @btn-flat-checked-shadow: none;
 @btn-flat-wrap-padding: 0;
+@btn-flat-link-border-radius: 2px;
 @btn-flat-small-border-radius: 2px;
 
 @btn-flat-shadow-checked-arrow: '__COMPUTED__';
@@ -211,6 +212,7 @@
 @value blinkColor: @blink-color;
 @value btnHeightShift: @btn-flat-height-shift;
 @value btnWrapPadding: @btn-flat-wrap-padding;
+@value btnLinkBorderRadius: @btn-flat-link-border-radius;
 @value btnSmallBorderRadius: @btn-flat-small-border-radius;
 @value btnFocusShadowWidth: @btn-flat-focus-shadow-width;
 @value btnFocusBorder: @btn-flat-focus-border;

--- a/packages/retail-ui/components/variables.flat.less
+++ b/packages/retail-ui/components/variables.flat.less
@@ -167,6 +167,7 @@
 @radio-flat-hover-shadow: none;
 @radio-flat-active-shadow: none;
 @radio-flat-focus-shadow: '__COMPUTED__';
+@radio-flat-checked-bg-color: transparent;
 @radio-flat-checked-bullet-color: #fff;
 @radio-flat-disabled-shadow: none;
 @radio-flat-label-display: inline-block;

--- a/packages/retail-ui/components/variables.less
+++ b/packages/retail-ui/components/variables.less
@@ -345,6 +345,7 @@
 @btn-shadow-checked-arrow-left: 1px -1px 0 0 rgba(0, 0, 0, 0.6), inset -4px 0 2px -3px rgba(0, 0, 0, 0.3);
 
 // Toggle
+@toggle-bg: linear-gradient(-180deg, #fff, #ebebeb);
 @toggle-bg-checked: #3072c4;
 @toggle-bg-warning: '__COMPUTED__';
 @toggle-bg-error: '__COMPUTED__';
@@ -623,6 +624,7 @@
 @value menuItemPaddingForIcon: @menu-item-padding-for-icon;
 @value menuBorder: @menu-border;
 @value menuShadow: @menu-shadow;
+@value toggleBg: @toggle-bg;
 @value toggleBgChecked: @toggle-bg-checked;
 @value toggleBgActive: @toggle-bg-active;
 @value toggleBorderColor: @toggle-border-color;

--- a/packages/retail-ui/components/variables.less
+++ b/packages/retail-ui/components/variables.less
@@ -379,6 +379,12 @@
 @chb-border-radius: 2px;
 @chb-shadow-width: 2px;
 
+// Textarea
+@textarea-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.05);
+@textarea-border-top-color: '__COMPUTED__';
+@textarea-disabled-color: '__COMPUTED__';
+@textarea-disabled-border-color: '__COMPUTED__';
+
 // Specificity
 @specificity-level: 0;
 
@@ -669,3 +675,7 @@
 @value toggleBgWarning: @toggle-bg-warning;
 @value toggleBgError: @toggle-bg-error;
 @value toggleFocusShadowColor: @toggle-focus-shadow-color;
+@value textareaShadow: @textarea-shadow;
+@value textareaBorderTopColor: @textarea-border-top-color;
+@value textareaDisabledBg: @textarea-disabled-color;
+@value textareaDisabledBorderColor: @textarea-disabled-border-color;

--- a/packages/retail-ui/components/variables.less
+++ b/packages/retail-ui/components/variables.less
@@ -387,6 +387,22 @@
 @textarea-disabled-color: '__COMPUTED__';
 @textarea-disabled-border-color: '__COMPUTED__';
 
+// Radio
+@radio-size: 16px;
+@radio-vertical-align: -2px;
+@radio-bg-image: linear-gradient(-180deg, #fff 0, #ebebeb 100%);
+@radio-hover-bg: linear-gradient(-180deg, #f2f2f2 0, #dfdfdf 100%);
+@radio-active-bg: linear-gradient(-180deg, #e1e1e1 0, #e1e1e1 100%);
+@radio-box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.15);
+@radio-border: 0 none;
+@radio-hover-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.2);
+@radio-active-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+@radio-focus-shadow: none;
+@radio-checked-bg-color: transparent;
+@radio-checked-bullet-color: #404040;
+@radio-disabled-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+@radio-label-display: inline-table;
+
 // Specificity
 @specificity-level: 0;
 
@@ -683,3 +699,17 @@
 @value textareaBorderTopColor: @textarea-border-top-color;
 @value textareaDisabledBg: @textarea-disabled-color;
 @value textareaDisabledBorderColor: @textarea-disabled-border-color;
+@value radioSize: @radio-size;
+@value radioVerticalAlign: @radio-vertical-align;
+@value radioBgImage: @radio-bg-image;
+@value radioHoverBg: @radio-hover-bg;
+@value radioActiveBg: @radio-active-bg;
+@value radioBoxShadow: @radio-box-shadow;
+@value radioBorder: @radio-border;
+@value radioHoverShadow: @radio-hover-shadow;
+@value radioActiveShadow: @radio-active-shadow;
+@value radioFocusShadow: @radio-focus-shadow;
+@value radioCheckedBgColor: @radio-checked-bg-color;
+@value radioCheckedBulletColor: @radio-checked-bullet-color;
+@value radioDisabledShadow: @radio-disabled-shadow;
+@value radioLabelDisplay: @radio-label-display;

--- a/packages/retail-ui/components/variables.less
+++ b/packages/retail-ui/components/variables.less
@@ -93,6 +93,7 @@
 @loader-opacity: 0.8;
 
 // Button
+@btn-wrap-padding: 1px;
 @btn-height-shift: -2;
 @btn-focus-shadow-width: 2px;
 @btn-border-radius: 2px;
@@ -452,6 +453,7 @@
 @value tokenDisabledBg: @token-disabled-bg;
 @value loaderBg: @loader-bg;
 @value loaderOpacity: @loader-opacity;
+@value btnWrapPadding: @btn-wrap-padding;
 @value btnHeightShift: @btn-height-shift;
 @value btnFocusShadowWidth: @btn-focus-shadow-width;
 @value btnDisabledBg: @btn-disabled-bg;


### PR DESCRIPTION
Перенес все стили, которые ломаются code-splitting'ом, в JS.

#1625