### PR TITLE
fix(docs): fix code formatter of the ThemeShowcase

### DIFF
--- a/packages/retail-ui/components/Input/Input.styles.ts
+++ b/packages/retail-ui/components/Input/Input.styles.ts
@@ -4,12 +4,6 @@ import { ITheme } from '../../lib/theming/Theme';
 import DimensionFunctions from '../../lib/styles/DimensionFunctions';
 import { resetText } from '../../lib/styles/Mixins';
 
-const getBlinkAnimation = (color: string) => keyframes`
-  0% {
-    background-color: ${color};
-  }
-`;
-
 const jsClasses = {
   root(t: ITheme) {
     return css`
@@ -125,9 +119,14 @@ const jsClasses = {
   },
 
   blink(t: ITheme) {
+    const blinkAnimation = keyframes`
+    0% {
+      background-color: ${t.blinkColor};
+    }
+  `;
     return css`
       .${classes.root}& {
-        animation: ${getBlinkAnimation(t.blinkColor)} 0.15s ease-in;
+        animation: ${blinkAnimation} 0.15s ease-in;
       }
     `;
   },

--- a/packages/retail-ui/components/ThemeShowcase/ThemeShowcaseHelpers/FormatSourceCode.tsx
+++ b/packages/retail-ui/components/ThemeShowcase/ThemeShowcaseHelpers/FormatSourceCode.tsx
@@ -5,7 +5,7 @@ import { Nullable } from '../../../typings/utility-types';
 import { isDevelopmentEnv } from '../../internal/currentEnvironment';
 
 export function formatSourceCode(input: string, componentName: string) {
-  const regEx = /\.__makeTemplateObject\((\[[\S\s]+\]),\s*(\[[\S\s]+\])\)\),\s*([\s\S]+)\)/gm;
+  const regEx = /\.css\(.*\.__makeTemplateObject\((\[[\S\s]+\]),\s*(\[[\S\s]+\])\)\),\s*([\s\S]+)\)/gm;
 
   const sourceParts = regEx.exec(input);
   if (!sourceParts) {
@@ -78,9 +78,9 @@ function renderVariables(variableString: string, componentName: string) {
 function getClassName(variableString: string, componentName: string) {
   let classNameRegExp: RegExp;
   if (isDevelopmentEnv) {
-    classNameRegExp = new RegExp(componentName + '_less_[\\d]+\\.default\\.', 'i');
+    classNameRegExp = new RegExp(componentName + '_module_less_[\\d]+\\.default\\.', 'i');
   } else {
-    classNameRegExp = /[a-z0-9]+\.default\./;
+    classNameRegExp = /[\w]+\.default\./;
   }
 
   if (classNameRegExp.test(variableString)) {


### PR DESCRIPTION
Усилили регулярку, чтобы корректно обрабатывать несколько шаблонных строк в одном наборе стилей. Например, в таком:
```
  blink(t: ITheme) {
    const blinkAnimation = keyframes`
    0% {
      background-color: ${t.blinkColor};
    }
  `;
    return css`
      .${classes.root}& {
        animation: ${blinkAnimation} 0.15s ease-in;
      }
    `;
  },
```

Также, пофиксили рендер имен классов после #1572 и #1629