### PR TITLE
fix(ThemeProvider): 'blinkColor' fix for darkTheme

### DIFF
--- a/packages/retail-ui/components/ThemeProvider/Playground/darkTheme.ts
+++ b/packages/retail-ui/components/ThemeProvider/Playground/darkTheme.ts
@@ -48,7 +48,7 @@ export default {
   outlineColorFocus: '#fff',
   placeholderColor: '#aaa',
   placeholderColorLight: '#bbb',
-  blinkColor: 'rgba(0,136,255, .4)',
+  blinkColor: 'rgba(0, 136, 255, .4)',
   controlBorderWidth: '1px',
   controlLineHeightSmall: '20px',
   controlLineHeightMedium: '20px',

--- a/packages/retail-ui/components/ThemeProvider/Playground/darkTheme.ts
+++ b/packages/retail-ui/components/ThemeProvider/Playground/darkTheme.ts
@@ -48,7 +48,7 @@ export default {
   outlineColorFocus: '#fff',
   placeholderColor: '#aaa',
   placeholderColorLight: '#bbb',
-  blinkColor: '#cde4f8',
+  blinkColor: 'rgba(0,136,255, .4)',
   controlBorderWidth: '1px',
   controlLineHeightSmall: '20px',
   controlLineHeightMedium: '20px',

--- a/packages/retail-ui/components/variables.flat.less
+++ b/packages/retail-ui/components/variables.flat.less
@@ -1,7 +1,7 @@
 // Common
 @flat-border-color-focus: #1d85d0;
 @flat-outline-color-focus: #fff;
-@blink-color: rgba(0,136,255, .2);
+@blink-color: rgba(0, 136, 255, .2);
 
 // Button
 @btn-flat-height-shift: 0;

--- a/packages/retail-ui/components/variables.flat.less
+++ b/packages/retail-ui/components/variables.flat.less
@@ -1,7 +1,7 @@
 // Common
 @flat-border-color-focus: #1d85d0;
 @flat-outline-color-focus: #fff;
-@blink-color: #cde4f8;
+@blink-color: rgba(0,136,255, .2);
 
 // Button
 @btn-flat-height-shift: 0;

--- a/packages/retail-ui/components/variables.less
+++ b/packages/retail-ui/components/variables.less
@@ -51,7 +51,7 @@
 @placeholder-color: #a0a0a0;
 @placeholder-color-light: #cdcdcd;
 
-@blink-color: #cde4f8;
+@blink-color: rgba(0,136,255, .2);
 
 @control-border-width: 1px;
 @control-line-height-small: 20px;

--- a/packages/retail-ui/components/variables.less
+++ b/packages/retail-ui/components/variables.less
@@ -51,7 +51,7 @@
 @placeholder-color: #a0a0a0;
 @placeholder-color-light: #cdcdcd;
 
-@blink-color: rgba(0,136,255, .2);
+@blink-color: rgba(0, 136, 255, .2);
 
 @control-border-width: 1px;
 @control-line-height-small: 20px;


### PR DESCRIPTION
Закрывает https://github.com/skbkontur/retail-ui/issues/1646

Чисто на глаз `0088FF` с 20% прозрачности для светлой и 40% для темной выглядит лучше всего. 