### PR TITLE
fix(MenuItem): call onMouseEnter/Leave in cloned element

### DIFF
--- a/packages/retail-ui/components/internal/InternalMenu/InternalMenu.tsx
+++ b/packages/retail-ui/components/internal/InternalMenu/InternalMenu.tsx
@@ -150,8 +150,18 @@ export default class InternalMenu extends React.Component<MenuProps, MenuState> 
                 ref,
                 state: highlight ? 'hover' : child.props.state,
                 onClick: this.select.bind(this, index, false),
-                onMouseEnter: () => this.highlightItem(index),
-                onMouseLeave: this.unhighlight,
+                onMouseEnter: event => {
+                  this.highlightItem(index);
+                  if (isMenuItem(child) && child.props.onMouseEnter) {
+                    child.props.onMouseEnter(event);
+                  }
+                },
+                onMouseLeave: event => {
+                  this.unhighlight();
+                  if (isMenuItem(child) && child.props.onMouseLeave) {
+                    child.props.onMouseLeave(event);
+                  }
+                },
               });
             }
 

--- a/packages/retail-ui/components/internal/InternalMenu/__tests__/InternalMenu-test.tsx
+++ b/packages/retail-ui/components/internal/InternalMenu/__tests__/InternalMenu-test.tsx
@@ -56,4 +56,38 @@ describe('Menu', () => {
 
     expect(onClick.mock.calls.length).toBe(0);
   });
+
+  it('calls onMouseEnter', () => {
+    const onMouseEnter = jest.fn();
+    const wrapper = mount(
+      <InternalMenu>
+        <MenuItem onMouseEnter={onMouseEnter} />
+      </InternalMenu>,
+    );
+
+    const props = wrapper.find(MenuItem).props();
+
+    if (props.onMouseEnter) {
+      props.onMouseEnter({} as React.MouseEvent);
+    }
+
+    expect(onMouseEnter.mock.calls.length).toBe(1);
+  });
+
+  it('calls onMouseLeave', () => {
+    const onMouseLeave = jest.fn();
+    const wrapper = mount(
+      <InternalMenu>
+        <MenuItem onMouseLeave={onMouseLeave} />
+      </InternalMenu>,
+    );
+
+    const props = wrapper.find(MenuItem).props();
+
+    if (props.onMouseLeave) {
+      props.onMouseLeave({} as React.MouseEvent);
+    }
+
+    expect(onMouseLeave.mock.calls.length).toBe(1);
+  });
 });


### PR DESCRIPTION
У `MenuItem` расположенного в `Menu` не вызывались пиропы `onMouseEnter/Leave`