### PR TITLE
fix(ComboBox): set menu wider than caption by default

### DIFF
--- a/packages/retail-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/retail-ui/components/ComboBox/ComboBox.tsx
@@ -55,6 +55,8 @@ export interface ComboBoxProps<T> {
    */
   itemToValue: (item: T) => string | number;
 
+  menuWidth?: number | string;
+
   maxLength?: number;
 
   menuAlign?: 'left' | 'right';

--- a/packages/retail-ui/components/CustomComboBox/ComboBoxView.tsx
+++ b/packages/retail-ui/components/CustomComboBox/ComboBoxView.tsx
@@ -35,6 +35,7 @@ interface ComboBoxViewProps<T> {
   warning?: boolean;
   width?: string | number;
   maxLength?: number;
+  menuWidth?: number | string;
   maxMenuHeight?: number | string;
 
   onChange?: (item: T, e: React.SyntheticEvent) => void;
@@ -114,6 +115,7 @@ class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
       totalCount,
       size,
       width,
+      menuWidth,
     } = this.props;
 
     const input = this.renderInput();
@@ -148,6 +150,7 @@ class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
               getParent={() => findDOMNode(this)}
               offsetY={1}
               offsetX={-1}
+              width={menuWidth}
               disablePortal={this.props.disablePortal}
             >
               <ComboBoxMenu

--- a/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
+++ b/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
@@ -37,6 +37,7 @@ export interface CustomComboBoxProps<T> {
   warning?: boolean;
   width?: string | number;
   maxMenuHeight?: number | string;
+  menuWidth?: number | string;
   renderNotFound?: () => React.ReactNode;
   renderTotalCount?: (found: number, total: number) => React.ReactNode;
   renderItem: (item: T, state?: MenuItemState) => React.ReactNode;
@@ -225,6 +226,7 @@ class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T>, Cust
       value: this.props.value,
       warning: this.props.warning,
       width: this.props.width,
+      menuWidth: this.props.menuWidth,
       maxLength: this.props.maxLength,
       maxMenuHeight: this.props.maxMenuHeight,
 

--- a/packages/retail-ui/components/DropdownContainer/__stories__/DropdownContainer.stories.tsx
+++ b/packages/retail-ui/components/DropdownContainer/__stories__/DropdownContainer.stories.tsx
@@ -7,10 +7,58 @@ import DropdownContainer, { DropdownContainerProps } from '../DropdownContainer'
 import { findDOMNode } from 'react-dom';
 import Menu from '../../Menu/Menu';
 import Button from '../../Button/Button';
+import Input from '../../Input';
+import { Nullable } from '../../../typings/utility-types';
+
+// default
+//  - short item < minWidth (container + 30px)
+//  - lond item < maxWidth (450px)
+//  - very long item > maxWidth (450px)
+// with width
+//  - short item < width
+//  - lond item > width
+
+storiesOf('DropdownContainer/defaultWidth', module)
+  .add('short items', () => <DropdownContainerDefaultWidth type="short" />)
+  .add('medium items', () => <DropdownContainerDefaultWidth type="medium" />)
+  .add('long items', () => <DropdownContainerDefaultWidth type="long" />);
+
+storiesOf('DropdownContainer/customWidth', module)
+  .add('short items', () => <div />)
+  .add('long items', () => <div />);
 
 storiesOf('DropdownContainer', module).add('various aligns, portals, items and scrolls', () => (
   <VariousAlignsPortalsItemsAndScrolls />
 ));
+
+class DropdownContainerDefaultWidth extends React.Component<
+  { type: 'short' | 'medium' | 'long' },
+  { input: Nullable<Input> }
+> {
+  public state: { input: Nullable<Input> } = { input: null };
+  private items = {
+    short: 'Lorem ipsum',
+    medium: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    long:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat',
+  };
+  public render() {
+    const { type } = this.props;
+    const { input } = this.state;
+    return (
+      <div>
+        <Input ref={el => input !== el && this.setState({ input: el })} />
+        {input && (
+          <DropdownContainer getParent={() => findDOMNode(input)}>
+            <Menu>
+              <MenuItem>{this.items[type]}</MenuItem>
+            </Menu>
+          </DropdownContainer>
+        )}
+      </div>
+    );
+  }
+}
 
 class VariousAlignsPortalsItemsAndScrolls extends React.Component {
   public aligns: Array<'left' | 'right'> = ['left', 'right'];


### PR DESCRIPTION
- `ComboBox` добавлены проп `menuWidth`
- `DropdownContainer` добавлен проп `width`
- Если проп `width` не задан для `DropdownContainer` ширина выставляется в соответствии с гайдами
  - `minWidth == parent.width + 35px`
  - `maxWidth == 450px`

close #1661 