### PR TITLE
chore: replace deprecated prettier options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,13 @@
 {
   "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
   "editor.rulers": [120],
   "editor.tabSize": 2,
   "files.autoSave": "onFocusChange",
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "prettier.eslintIntegration": true,
-  "prettier.stylelintIntegration": true,
-  "prettier.tslintIntegration": true,
   "prettier.printWidth": 120
 }


### PR DESCRIPTION
Опции устарели, рекомендуют использовать `fixAll` https://github.com/prettier/prettier-vscode#linter-integration