### PR TITLE
fix(Modal): added word-break: break-word to Modal.Header

### DIFF
--- a/packages/retail-ui/components/Modal/Modal.module.less
+++ b/packages/retail-ui/components/Modal/Modal.module.less
@@ -107,6 +107,7 @@
     font-size: 22px;
     line-height: 30px;
     padding: 24px 110px 11px 30px;
+    word-break: break-word;
   }
 
   .fixedHeader {


### PR DESCRIPTION
Добавил css word-break: break-word  для Modal.Header, чтобы избегать проблем с оченьДлиннымиЗагловкамиМодалкиБезПробелов, которые ломают хедер при фиксированой ширине модалки
![Скрол при добавлении записи в справочник](https://user-images.githubusercontent.com/13113273/69339650-a2393d80-0c87-11ea-9415-d2be619bb34c.JPG)
