### PR TITLE
refactor(PasswordInput): remove unused type declaration

### DIFF
--- a/packages/retail-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/retail-ui/components/PasswordInput/PasswordInput.tsx
@@ -22,12 +22,6 @@ export interface PasswordInputState {
   capsLockEnabled?: boolean | null;
 }
 
-export type InputProps = {
-  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
-  onKeyPress: (event: React.KeyboardEvent<HTMLInputElement>) => void;
-  rightIcon: () => React.ReactNode;
-} & PasswordInputProps;
-
 /**
  * **DRAFT**
  */


### PR DESCRIPTION
При использовании контролов с typescript 3.7 вываливается ошибка:
```
node_modules/@skbkontur/react-ui/components/PasswordInput/PasswordInput.d.ts:3:10 - error TS2440: Import declaration conflicts with local declaration of 'InputProps'.

3 import { InputProps } from '../Input/Input';
           ~~~~~~~~~~


Found 1 error.
```