### PR TITLE
fix(Popup): Не вызвать события обновления, когда контрол закрыт

### DIFF
--- a/packages/retail-ui/components/Popup/Popup.tsx
+++ b/packages/retail-ui/components/Popup/Popup.tsx
@@ -418,6 +418,10 @@ export default class Popup extends React.Component<PopupProps, PopupState> {
   }
 
   private handleLayoutEvent = () => {
+    if (!this.props.opened) {
+      return;
+    }
+
     if (this.anchorInstance) {
       this.updateAnchorElement(this.extractElement(this.anchorInstance));
     }


### PR DESCRIPTION
Появляются тормоза(особенно в ие), когда на странице больше 800 контролов.