### PR TITLE
fix(Gapped): don't cover other elements with horizontal layout

### DIFF
--- a/packages/retail-ui/.creevey/images/Gapped/Dont Cover Other Elements/click/chrome.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Dont Cover Other Elements/click/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1820adb9b6704e8b61f669fde13d350b75925a4999f28947c8ba88a26dd1005f
+size 2187

--- a/packages/retail-ui/.creevey/images/Gapped/Dont Cover Other Elements/click/firefox.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Dont Cover Other Elements/click/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ae994d7ba70dbfd16fe659d5ccc897de520743cd5bc84cdc35a3dacb0620bf5
+size 1747

--- a/packages/retail-ui/.creevey/images/Gapped/Dont Cover Other Elements/click/ie11.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Dont Cover Other Elements/click/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c01871b956e348cdcb98a9ffbd012ae5105155bd1caf06b9008f9df435aea23b
+size 1943

--- a/packages/retail-ui/.creevey/images/Gapped/Horizontal/chrome.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Horizontal/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de3521e6f23cf75920fc051a51385082365ba956d3ba90167b9da43a15678ebb
+size 287

--- a/packages/retail-ui/.creevey/images/Gapped/Horizontal/firefox.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Horizontal/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1fae8d9ce8e30fb5ab429645a105137988bc4159fa1124b1a7fcbb85ca0e64e
+size 261

--- a/packages/retail-ui/.creevey/images/Gapped/Horizontal/ie11.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Horizontal/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b991fbf49415c01e2e2d6f6af7a47878a3a0dde2a56467390f8bd0471f5a47b
+size 442

--- a/packages/retail-ui/.creevey/images/Gapped/Vertical/chrome.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Vertical/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76b86867198d3ce55458327f3040dee4d0c999776260e5aa9fbff8c4d071e1ab
+size 303

--- a/packages/retail-ui/.creevey/images/Gapped/Vertical/firefox.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Vertical/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edeb13c343aaed04e6b4ef5a700fe389a969307cb3f50a802c70aa7e6b86621e
+size 255

--- a/packages/retail-ui/.creevey/images/Gapped/Vertical/ie11.png
+++ b/packages/retail-ui/.creevey/images/Gapped/Vertical/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3f2167acf1ee2d865b4343ec1616b6bb31818881fe46d07d3dd0a91779c2826
+size 323

--- a/packages/retail-ui/.storybook/webpack.config.js
+++ b/packages/retail-ui/.storybook/webpack.config.js
@@ -76,5 +76,8 @@ module.exports = async ({ config, mode }) => {
     }),
   );
 
+  // NOTE Need to allow write tests inside stories for Creevey
+  config.node = { __filename: true };
+
   return config;
 };

--- a/packages/retail-ui/components/Gapped/Gapped.tsx
+++ b/packages/retail-ui/components/Gapped/Gapped.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export interface GappedProps {
   /**
-   * Расстояние между элементави в пикселях
+   * Расстояние между элементами в пикселях
    * @default 10
    */
   gap: number;

--- a/packages/retail-ui/components/Gapped/Gapped.tsx
+++ b/packages/retail-ui/components/Gapped/Gapped.tsx
@@ -65,7 +65,6 @@ class Gapped extends React.Component<GappedProps> {
     const itemStyle = {
       display: 'inline-block',
       marginLeft: this.props.gap,
-      marginTop: this.props.gap,
       verticalAlign: this.props.verticalAlign,
     };
     const children = React.Children.map(this.props.children, (child, index) => {
@@ -74,18 +73,10 @@ class Gapped extends React.Component<GappedProps> {
       }
       return <span style={itemStyle}>{child}</span>;
     });
-    const rootStyle = {
-      paddingTop: 1,
-    };
     const contStyle = {
-      marginTop: -this.props.gap! - 1,
       marginLeft: -this.props.gap!,
     };
-    return (
-      <div style={rootStyle}>
-        <div style={contStyle}>{children}</div>
-      </div>
-    );
+    return <div style={contStyle}>{children}</div>;
   }
 }
 

--- a/packages/retail-ui/components/Gapped/Gapped.tsx
+++ b/packages/retail-ui/components/Gapped/Gapped.tsx
@@ -1,10 +1,17 @@
-import * as React from 'react';
-
-import * as PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export interface GappedProps {
-  gap?: number;
-  verticalAlign?: 'top' | 'middle' | 'baseline' | 'bottom';
+  /**
+   * Расстояние между элементави в пикселях
+   * @default 10
+   */
+  gap: number;
+  /**
+   * Вертикальное выравнивание
+   * @default "middle"
+   */
+  verticalAlign: 'top' | 'middle' | 'baseline' | 'bottom';
   vertical?: boolean;
   children: React.ReactNode;
 }
@@ -37,12 +44,12 @@ class Gapped extends React.Component<GappedProps> {
 
   public render() {
     if (this.props.vertical) {
-      return this._renderVertical();
+      return this.renderVertical();
     }
-    return this._renderHorizontal();
+    return this.renderHorizontal();
   }
 
-  private _renderVertical() {
+  private renderVertical() {
     const subsequentItemStyle: React.CSSProperties = {
       paddingTop: this.props.gap,
     };
@@ -61,7 +68,7 @@ class Gapped extends React.Component<GappedProps> {
     return <div>{children}</div>;
   }
 
-  private _renderHorizontal() {
+  private renderHorizontal() {
     const itemStyle = {
       display: 'inline-block',
       marginLeft: this.props.gap,

--- a/packages/retail-ui/components/Gapped/__stories__/Gapped.stories.tsx
+++ b/packages/retail-ui/components/Gapped/__stories__/Gapped.stories.tsx
@@ -1,0 +1,71 @@
+import 'creevey';
+import React from 'react';
+import Chai from 'chai';
+import Mocha from 'mocha';
+import Selenium from 'selenium-webdriver';
+import Gapped from '../Gapped';
+import Toggle from '../../Toggle';
+
+export default {
+  title: 'Gapped',
+  parameters: {
+    creevey: {
+      // NOTE Overwrite top-level skip option
+      skip: { in: /.*Flat$/ },
+      captureElement: '#test-element',
+      __filename,
+    },
+  },
+};
+
+export const Horizontal = () => (
+  <div style={{ border: '1px solid black' }}>
+    <Gapped gap={20}>
+      <div style={{ width: '50px', height: '50px', background: '#aaa' }} />
+      <div style={{ width: '50px', height: '50px', background: '#aaa' }} />
+    </Gapped>
+  </div>
+);
+
+export const Vertical = () => (
+  <div style={{ border: '1px solid black' }}>
+    <Gapped gap={20} vertical>
+      <div style={{ width: '50px', height: '50px', background: '#aaa' }} />
+      <div style={{ width: '50px', height: '50px', background: '#aaa' }} />
+    </Gapped>
+  </div>
+);
+
+export const DontCoverOtherElements = () => (
+  <div style={{ border: '1px solid black' }}>
+    <div style={{ margin: '8px' }}>
+      <Toggle />
+      {' <= Try to click me!'}
+    </div>
+    <div style={{ zIndex: 1, transform: 'rotate(0)', isolation: 'isolate' }}>
+      <Gapped gap={100}>
+        <div style={{ width: '50px', height: '50px', background: '#aaa' }} />
+        <div style={{ width: '50px', height: '50px', background: '#aaa' }} />
+      </Gapped>
+    </div>
+  </div>
+);
+
+DontCoverOtherElements.story = {
+  parameters: {
+    creevey: {
+      _seleniumTests({ By }: typeof Selenium, { expect }: typeof Chai) {
+        return {
+          async click(this: Mocha.Context) {
+            await this.browser
+              .actions({ bridge: true })
+              .click(this.browser.findElement(By.css('[data-comp-name~="Toggle"]')))
+              .perform();
+
+            await expect(await this.browser.findElement(By.css('#test-element')).takeScreenshot()).to.matchImage();
+          },
+        };
+      },
+    },
+  },
+};

--- a/packages/retail-ui/components/ThemeProvider/Playground/ThemeEditor.tsx
+++ b/packages/retail-ui/components/ThemeProvider/Playground/ThemeEditor.tsx
@@ -42,7 +42,7 @@ export class ThemeEditor extends React.Component<IThemeEditorProps, IThemeEditor
   }
 
   public componentDidMount() {
-    this.updateTimeout = setTimeout(() => {
+    this.updateTimeout = window.setTimeout(() => {
       this.setState({ groups: VARIABLES_GROUPS, isLoading: false });
     }, 500);
   }

--- a/packages/retail-ui/components/ThemeProvider/Playground/VariableValue.tsx
+++ b/packages/retail-ui/components/ThemeProvider/Playground/VariableValue.tsx
@@ -164,7 +164,7 @@ export class VariableValue extends React.Component<IVariableValueProps, IVariabl
     });
 
     if (this.debounceInterval === undefined) {
-      this.debounceInterval = setInterval(this.debounceHandler, this.debounceTimeout);
+      this.debounceInterval = window.setInterval(this.debounceHandler, this.debounceTimeout);
     }
   };
 

--- a/packages/retail-ui/lib/theming/Emotion.ts
+++ b/packages/retail-ui/lib/theming/Emotion.ts
@@ -1,7 +1,18 @@
-import createEmotion from 'create-emotion';
-import extraScopePlugin from 'stylis-plugin-extra-scope';
+import createEmotion, { Options } from 'create-emotion';
 import Upgrade from '../Upgrades';
 import LESS_VARIABLES from '../../components/variables.module.less';
+
+// NOTE Copy-paste from https://github.com/Andarist/stylis-plugin-extra-scope
+function extraScopePlugin(extra: string): Options['stylisPlugins'] {
+  return (context, _content, selectors, _parents, _line, _column, _length, type) => {
+    if (context !== 2 || type === 107) {
+      return;
+    }
+    for (let i = 0; i < selectors.length; i++) {
+      selectors[i] = `${extra} ${selectors[i]}`;
+    }
+  };
+}
 
 const PREFIX = 'react-ui';
 
@@ -26,7 +37,7 @@ export const {
   cache,
 } = createEmotion({
   key: PREFIX,
-  stylisPlugins: scope ? [extraScopePlugin(scope)] : undefined,
+  stylisPlugins: scope ? extraScopePlugin(scope) : undefined,
 });
 
 export function prefixer<T = { [key: string]: string }>(classes: T): T {

--- a/packages/retail-ui/lib/theming/Emotion.ts
+++ b/packages/retail-ui/lib/theming/Emotion.ts
@@ -1,11 +1,15 @@
-import createEmotion, { Options } from 'create-emotion';
+import createEmotion from 'create-emotion';
+import { Context, Plugin } from '@emotion/stylis';
 import Upgrade from '../Upgrades';
 import LESS_VARIABLES from '../../components/variables.module.less';
 
+// NOTE Type according by https://github.com/thysultan/stylis.js
+const KEYFRAME = 107;
+
 // NOTE Copy-paste from https://github.com/Andarist/stylis-plugin-extra-scope
-function extraScopePlugin(extra: string): Options['stylisPlugins'] {
+function extraScopePlugin(extra: string): Plugin {
   return (context, _content, selectors, _parents, _line, _column, _length, type) => {
-    if (context !== 2 || type === 107) {
+    if (context !== Context.BLCKS || type === KEYFRAME) {
       return;
     }
     for (let i = 0; i < selectors.length; i++) {
@@ -22,7 +26,7 @@ if (specificityLevel) {
   Upgrade.setSpecificityLevel(specificityLevel);
 }
 
-const scope = new Array(Upgrade.getSpecificityLevel()).fill('.retail-ui').join('');
+const scope = new Array(Upgrade.getSpecificityLevel()).fill(`.${PREFIX}`).join('');
 
 export const {
   flush,

--- a/packages/retail-ui/package.json
+++ b/packages/retail-ui/package.json
@@ -63,7 +63,6 @@
     "react-focus-lock": "^1.11.2",
     "react-input-mask": "2.0.4",
     "react-transition-group": "^2.4.0",
-    "stylis-plugin-extra-scope": "^0.1.1",
     "tabbable": "^3.1.1",
     "tslib": "^1.10.0",
     "uuid": "^3.3.2",

--- a/packages/retail-ui/package.json
+++ b/packages/retail-ui/package.json
@@ -105,7 +105,7 @@
     "babel-jest": "^24.9.0",
     "babel-loader": "8.0.6",
     "core-js": "^3.2.1",
-    "creevey": "^0.2.2",
+    "creevey": "^0.2.4",
     "cross-env": "^5.2.0",
     "css-loader": "^0.28.11",
     "enzyme": "^3.10.0",

--- a/packages/retail-ui/prod.tsconfig.json
+++ b/packages/retail-ui/prod.tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.json",
   "exclude": ["**/__mocks__/**/*", "**/__tests__/**/*", "**/__stories__/**/*", ".styleguide"]
 }

--- a/packages/retail-ui/prod.tsconfig.json
+++ b/packages/retail-ui/prod.tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/__mocks__/**/*", "**/__tests__/**/*", "**/__stories__/**/*", ".styleguide", "creevey.config.ts"]
+  "exclude": ["**/__mocks__/**/*", "**/__tests__/**/*", "**/__stories__/**/*", ".styleguide"]
 }

--- a/packages/retail-ui/tsconfig.json
+++ b/packages/retail-ui/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  "compilerOptions": {
+    "typeRoots": ["typings", "node_modules/@types"]
+  },
   "extends": "../../tsconfig.json"
 }

--- a/packages/retail-ui/typings/mocha/index.d.ts
+++ b/packages/retail-ui/typings/mocha/index.d.ts
@@ -1,0 +1,2 @@
+// NOTE This need to resolve jest/mocha type conflicts and allow use jest typings in jest tests
+declare var it: jest.It;

--- a/packages/retail-ui/typings/stylis-plugin-extra-scope.d.ts
+++ b/packages/retail-ui/typings/stylis-plugin-extra-scope.d.ts
@@ -1,3 +1,0 @@
-declare module 'stylis-plugin-extra-scope' {
-  export default (scope: string) => StylisPlugin;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18515,11 +18515,6 @@ stylelint@^9.9.0:
     svg-tags "^1.0.0"
     table "^5.0.0"
 
-stylis-plugin-extra-scope@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/stylis-plugin-extra-scope/-/stylis-plugin-extra-scope-0.1.1.tgz#57899046899aa5102632b8e1f4b3d71c575395b5"
-  integrity sha512-0dRLrsgLb8H4qnzDwoMAMfm4sayeMrG9SpI/NycWR7Cx1hPf4byj8SeA8x7gzensvEDk94tut0lQn9hX3DBGiw==
-
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3304,10 +3304,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/chai@^4.2.6":
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.6.tgz#a55625d151d9c7c7a0a95920632131d66480bce9"
-  integrity sha512-HF8faEUA4JurIm+68VaA2KedtZf5LYdXpQEAbIAN79DwWQbO82BNTksZgCH3UMqbZHXex9C6TrBfg7OUInRISQ==
+"@types/chai@^4.2.7":
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.7.tgz#1c8c25cbf6e59ffa7d6b9652c78e547d9a41692d"
+  integrity sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==
 
 "@types/cheerio@*":
   version "0.22.8"
@@ -6837,12 +6837,12 @@ create-react-context@^0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
-creevey@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/creevey/-/creevey-0.2.2.tgz#4d8737bd3430b5e1091760fccba6016c0d1e7ac9"
-  integrity sha512-c3L/R0CEa76M3yRXJQUZqSPKMQEVPLnDV7n0vEFnmWjVrNVP3ar8UibZtfzS3qCCY2av+ars61JF+AqMFcsUBA==
+creevey@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/creevey/-/creevey-0.2.4.tgz#fcde3579c1ad65ac4baaa7b79e84da57f2193878"
+  integrity sha512-Y+4DReBmsB0wxzFyuJfrcANEOuTFmKE6YWSLZODOA88XPQQZ1BSTZeBhIAQGKuBQYO2EmD3ez/1JGDAFrNaDGQ==
   dependencies:
-    "@types/chai" "^4.2.6"
+    "@types/chai" "^4.2.7"
     "@types/mocha" "^5.2.7"
     chai "^4.2.0"
     chalk "^3.0.0"
@@ -6860,7 +6860,7 @@ creevey@^0.2.2:
     pixelmatch "^5.1.0"
     pngjs "^3.4.0"
     uuid "^3.3.3"
-    ws "^7.2.0"
+    ws "^7.2.1"
 
 cross-env@^5.1.3, cross-env@^5.2.0:
   version "5.2.0"
@@ -20204,12 +20204,17 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.0.0, ws@^7.2.0:
+ws@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.0.tgz#422eda8c02a4b5dba7744ba66eebbd84bcef0ec7"
   integrity sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==
   dependencies:
     async-limiter "^1.0.0"
+
+ws@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.1.tgz#03ed52423cd744084b2cf42ed197c8b65a936b8e"
+  integrity sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==
 
 x-is-string@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- Заинлайнил код пакета `stylis-plugin-extra-scope`, так как на него не было тайпингов, а Creevey по какой-то причине не могу подгрузить тайпинги описанные в typings директории контролов
- Обновил Creevey до 0.2.4, были баги связанные с сериализацией skip опции вебдрайверами и за одно поправил загрузку тестов из стори по правильному имени стори
- Добавил тестов на Gapped
- Удалил `margin-top` при использовании горизонтального лейаута