### PR TITLE
feat(telemetry): add field for identifying components

### DIFF
--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -14,6 +14,8 @@ export interface ValidationContainerProps {
 }
 
 export default class ValidationContainer extends React.Component<ValidationContainerProps> {
+  public static __KONTUR_REACT_UI__ = 'ValidationContainer';
+
   public static propTypes = {
     scrollOffset(props: ValidationContainerProps, propName: keyof ValidationContainerProps, componentName: string) {
       const { scrollOffset } = props;

--- a/packages/react-ui-validations/src/ValidationWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationWrapper.tsx
@@ -21,6 +21,8 @@ export interface ValidationWrapperProps {
 }
 
 export default class ValidationWrapper extends React.Component<ValidationWrapperProps> {
+  public static __KONTUR_REACT_UI__ = 'ValidationWrapper';
+
   public render() {
     const { children, validationInfo, renderMessage } = this.props;
     const validation: Nullable<Validation> = validationInfo

--- a/packages/retail-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/retail-ui/components/Autocomplete/Autocomplete.tsx
@@ -50,6 +50,8 @@ export interface AutocomplpeteState {
  * Все свойства передаются во внутренний *Input*.
  */
 class Autocomplete extends React.Component<AutocompleteProps, AutocomplpeteState> {
+  public static __KONTUR_REACT_UI__ = 'Autocomplete';
+
   public static propTypes = {
     /**
      * Функция для отрисовки элемента в выпадающем списке. Единственный аргумент

--- a/packages/retail-ui/components/Button/Button.tsx
+++ b/packages/retail-ui/components/Button/Button.tsx
@@ -104,6 +104,8 @@ export interface ButtonState {
 }
 
 export default class Button extends React.Component<ButtonProps, ButtonState> {
+  public static __KONTUR_REACT_UI__ = 'Button';
+
   public static __BUTTON__ = true;
   public static TOP_LEFT = Corners.TOP_LEFT;
   public static TOP_RIGHT = Corners.TOP_RIGHT;

--- a/packages/retail-ui/components/Calendar/Calendar.tsx
+++ b/packages/retail-ui/components/Calendar/Calendar.tsx
@@ -47,6 +47,8 @@ const getTodayDate = () => {
 const wrapperStyle = { height: config.WRAPPER_HEIGHT };
 
 class Calendar extends React.Component<CalendarProps, CalendarState> {
+  public static __KONTUR_REACT_UI__ = 'Calendar';
+
   public static defaultProps = {
     holidays: [],
     minDate: {

--- a/packages/retail-ui/components/Center/Center.tsx
+++ b/packages/retail-ui/components/Center/Center.tsx
@@ -28,6 +28,8 @@ export interface CenterState {}
  * свойства как в любой *div* (кроме `className`)
  */
 export default class Center extends React.Component<CenterProps, CenterState> {
+  public static __KONTUR_REACT_UI__ = 'Center';
+
   public static defaultProps = {
     align: 'center',
   };

--- a/packages/retail-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/retail-ui/components/Checkbox/Checkbox.tsx
@@ -43,6 +43,8 @@ export interface CheckboxState {
  * Все свойства, кроме перечисленных, `className` и `style` передаются в `input`.
  */
 class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
+  public static __KONTUR_REACT_UI__ = 'Checkbox';
+
   public static propTypes = {
     checked: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/packages/retail-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/retail-ui/components/ComboBox/ComboBox.tsx
@@ -159,6 +159,8 @@ export interface ComboBoxItem {
 }
 
 class ComboBox<T = ComboBoxItem> extends React.Component<ComboBoxProps<T>> {
+  public static __KONTUR_REACT_UI__ = 'ComboBox';
+
   public static defaultProps = {
     itemToValue: (item: ComboBoxItem) => item.value,
     valueToString: (item: ComboBoxItem) => item.label,

--- a/packages/retail-ui/components/ComboBoxOld/ComboBoxOld.js
+++ b/packages/retail-ui/components/ComboBoxOld/ComboBoxOld.js
@@ -16,6 +16,8 @@ type Props = BaseProps & {
  * @deprecated Компонент устарел и будет удален в версии 2.0.0. Используйте актульный [ComboBox](#/Components/ComboBox).
  */
 export default class ComboBoxOld extends React.Component<Props, $FlowFixMeState> {
+  static __KONTUR_REACT_UI__ = 'ComboBoxOld';
+
   static propTypes = {
     autoFocus: PropTypes.bool,
 

--- a/packages/retail-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/retail-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -47,6 +47,8 @@ export interface CurrencyInputState {
  * Если `fractionDigits=15`, то в целой части допускается **0**.
  */
 export default class CurrencyInput extends React.Component<CurrencyInputProps, CurrencyInputState> {
+  public static __KONTUR_REACT_UI__ = 'CurrencyInput';
+
   public static propTypes = {
     align: PropTypes.oneOf(['left', 'center', 'right']),
     autoFocus: PropTypes.bool,

--- a/packages/retail-ui/components/CurrencyLabel/CurrencyLabel.tsx
+++ b/packages/retail-ui/components/CurrencyLabel/CurrencyLabel.tsx
@@ -25,6 +25,8 @@ export const CurrencyLabel = ({ value, fractionDigits, currencySymbol }: Currenc
   </span>
 );
 
+CurrencyLabel.__KONTUR_REACT_UI__ = 'CurrencyLabel';
+
 CurrencyLabel.defaultProps = defaultProps;
 
 CurrencyLabel.propTypes = {

--- a/packages/retail-ui/components/CustomComboBox/ComboBoxMenu.tsx
+++ b/packages/retail-ui/components/CustomComboBox/ComboBoxMenu.tsx
@@ -27,6 +27,8 @@ export interface ComboBoxMenuProps<T> {
 
 @locale('ComboBox', CustomComboBoxLocaleHelper)
 class ComboBoxMenu<T> extends Component<ComboBoxMenuProps<T>> {
+  public static __KONTUR_REACT_UI__ = 'ComboBoxMenu';
+
   public static defaultProps = {
     repeatRequest: () => undefined,
     requestStatus: ComboBoxRequestStatus.Unknown,

--- a/packages/retail-ui/components/CustomComboBox/ComboBoxView.tsx
+++ b/packages/retail-ui/components/CustomComboBox/ComboBoxView.tsx
@@ -62,6 +62,8 @@ interface ComboBoxViewProps<T> {
 }
 
 class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
+  public static __KONTUR_REACT_UI__ = 'ComboBoxView';
+
   public static defaultProps = {
     renderItem: (item: any) => item,
     renderValue: (item: any) => item,

--- a/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
+++ b/packages/retail-ui/components/CustomComboBox/CustomComboBox.tsx
@@ -75,6 +75,8 @@ export const DefaultState = {
 };
 
 class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T>, CustomComboBoxState<T>> {
+  public static __KONTUR_REACT_UI__ = 'CustomComboBox';
+
   public state: CustomComboBoxState<T> = DefaultState;
   public input: Nullable<Input>;
   public menu: Nullable<Menu>;

--- a/packages/retail-ui/components/DateInput/DateInput.tsx
+++ b/packages/retail-ui/components/DateInput/DateInput.tsx
@@ -73,6 +73,8 @@ const IS_IE = isIE || isEdge;
 
 @locale('DatePicker', DatePickerLocaleHelper)
 export class DateInput extends React.Component<DateInputProps, DateInputState> {
+  public static __KONTUR_REACT_UI__ = 'DateInput';
+
   public static defaultProps = {
     minDate: MIN_FULLDATE,
     maxDate: MAX_FULLDATE,

--- a/packages/retail-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/retail-ui/components/DatePicker/DatePicker.tsx
@@ -66,6 +66,8 @@ type DatePickerValue = string;
 
 // eslint-disable-next-line flowtype/no-weak-types
 class DatePicker extends React.Component<DatePickerProps<DatePickerValue>, DatePickerState> {
+  public static __KONTUR_REACT_UI__ = 'DatePicker';
+
   public static propTypes = {
     autoFocus: PropTypes.bool,
 

--- a/packages/retail-ui/components/DatePicker/Picker.tsx
+++ b/packages/retail-ui/components/DatePicker/Picker.tsx
@@ -39,6 +39,8 @@ const getTodayCalendarDate = () => {
 
 @locale('DatePicker', DatePickerLocaleHelper)
 export default class Picker extends React.Component<Props, State> {
+  public static __KONTUR_REACT_UI__ = 'Picker';
+
   private theme!: ITheme;
   private calendar: Calendar | null = null;
   private readonly locale!: DatePickerLocale;

--- a/packages/retail-ui/components/DatePickerOld/Calendar.js
+++ b/packages/retail-ui/components/DatePickerOld/Calendar.js
@@ -39,6 +39,8 @@ type State = {
 };
 
 export default class Calendar extends React.Component<Props, State> {
+  static __KONTUR_REACT_UI__ = 'CalendarOld';
+
   constructor(props: Props, context: mixed) {
     super(props, context);
 

--- a/packages/retail-ui/components/DatePickerOld/DateInput.js
+++ b/packages/retail-ui/components/DatePickerOld/DateInput.js
@@ -53,6 +53,8 @@ type Props = {
 const isIE8 = ieVerison === 8;
 
 export default class DateInput extends Component<Props> {
+  static __KONTUR_REACT_UI__ = 'DateInputOld';
+
   static propTypes = {
     getInputRef: PropTypes.func,
     opened: PropTypes.bool.isRequired,

--- a/packages/retail-ui/components/DatePickerOld/DatePickerOld.js
+++ b/packages/retail-ui/components/DatePickerOld/DatePickerOld.js
@@ -38,6 +38,7 @@ const INPUT_PASS_PROPS = {
  * @deprecated Компонент устарел и будет удален в версии 2.0.0. Используйте актульный [DatePicker](#/Components/DatePicker).
  */
 class DatePickerOld extends React.Component {
+  static __KONTUR_REACT_UI__ = 'DatePickerOld';
   static __REACT_UI_COMPONENT_NAME__ = 'DatePicker';
 
   static propTypes = {

--- a/packages/retail-ui/components/DateSelect/DateSelect.tsx
+++ b/packages/retail-ui/components/DateSelect/DateSelect.tsx
@@ -46,6 +46,8 @@ export interface DateSelectState {
 
 @locale('DatePicker', DatePickerLocaleHelper)
 export default class DateSelect extends React.Component<DateSelectProps, DateSelectState> {
+  public static __KONTUR_REACT_UI__ = 'DateSelect';
+
   public static propTypes = {
     disabled: PropTypes.bool,
 

--- a/packages/retail-ui/components/Dropdown/Dropdown.tsx
+++ b/packages/retail-ui/components/Dropdown/Dropdown.tsx
@@ -92,6 +92,8 @@ type DropdownSelectType = Select<React.ReactNode, React.ReactChild>;
  * Выпадающее меню.
  */
 export default class Dropdown extends React.Component<DropdownProps> {
+  public static __KONTUR_REACT_UI__ = 'Dropdown';
+
   public static Header = MenuHeader;
   public static MenuItem = MenuItem;
   public static Separator = MenuSeparator;

--- a/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
+++ b/packages/retail-ui/components/DropdownContainer/DropdownContainer.tsx
@@ -33,6 +33,8 @@ export interface DropdownContainerState {
 }
 
 export default class DropdownContainer extends React.Component<DropdownContainerProps, DropdownContainerState> {
+  public static __KONTUR_REACT_UI__ = 'DropdownContainer';
+
   public static defaultProps = {
     align: 'left',
     disablePortal: false,

--- a/packages/retail-ui/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/retail-ui/components/DropdownMenu/DropdownMenu.tsx
@@ -38,6 +38,8 @@ export interface DropdownMenuProps {
  * Меню, раскрывающееся по клику на переданный в ```caption``` элемент
  */
 export default class DropdownMenu extends React.Component<DropdownMenuProps> {
+  public static __KONTUR_REACT_UI__ = 'DropdownMenu';
+
   public static defaultProps = {
     disableAnimations: Boolean(process.env.enableReactTesting),
     positions: ['bottom left', 'bottom right', 'top left', 'top right'],

--- a/packages/retail-ui/components/Fias/Fias.tsx
+++ b/packages/retail-ui/components/Fias/Fias.tsx
@@ -127,6 +127,8 @@ function deepMerge<T>(dst: T, ...src: T[]): T {
 
 @locale('Fias', FiasLocaleHelper)
 export class Fias extends React.Component<FiasProps, FiasState> {
+  public static __KONTUR_REACT_UI__ = 'Fias';
+
   public static defaultProps = {
     showAddressText: true,
     error: false,

--- a/packages/retail-ui/components/Fias/FiasModal.tsx
+++ b/packages/retail-ui/components/Fias/FiasModal.tsx
@@ -12,6 +12,8 @@ interface FiasModalProps {
 
 @locale('Fias', FiasLocaleHelper)
 export class FiasModal extends React.Component<FiasModalProps> {
+  public static __KONTUR_REACT_UI__ = 'FiasModal';
+
   public static defaultProps = {
     onClose: () => null,
     onSave: () => null,

--- a/packages/retail-ui/components/Fias/FiasSearch/FiasSearch.tsx
+++ b/packages/retail-ui/components/Fias/FiasSearch/FiasSearch.tsx
@@ -41,6 +41,8 @@ export interface FiasSearchProps extends Pick<FiasComboBoxProps, keyof typeof CO
 
 @locale('Fias', FiasLocaleHelper)
 export class FiasSearch extends React.Component<FiasSearchProps> {
+  public static __KONTUR_REACT_UI__ = 'FiasSearch';
+
   public static defaultProps = {
     width: '100%',
     limit: 5,

--- a/packages/retail-ui/components/Fias/Form/FiasForm.tsx
+++ b/packages/retail-ui/components/Fias/Form/FiasForm.tsx
@@ -60,6 +60,8 @@ type FiasFormFieldMeta = ComboBoxMeta | InputMeta;
 
 @locale('Fias', FiasLocaleHelper)
 export class FiasForm extends React.Component<FiasFormProps, FiasFormState> {
+  public static __KONTUR_REACT_UI__ = 'FiasForm';
+
   public static defaultProps = {
     validationLevel: 'Error',
     limit: 5,

--- a/packages/retail-ui/components/FxInput/FxInput.tsx
+++ b/packages/retail-ui/components/FxInput/FxInput.tsx
@@ -36,6 +36,8 @@ export interface FxInputDefaultProps {
 
 /** Принимает все свойства `Input`'a */
 class FxInput extends React.Component<FxInputProps> {
+  public static __KONTUR_REACT_UI__ = 'FxInput';
+
   public static propTypes = {
     auto: PropTypes.bool,
     type: PropTypes.string,

--- a/packages/retail-ui/components/Gapped/Gapped.tsx
+++ b/packages/retail-ui/components/Gapped/Gapped.tsx
@@ -29,6 +29,8 @@ export interface GappedProps {
  * Контейнер, расстояние между элементами в котором равно `gap`.
  */
 class Gapped extends React.Component<GappedProps> {
+  public static __KONTUR_REACT_UI__ = 'Gapped';
+
   public static propTypes = {
     /**
      * Расстояние между элементами.

--- a/packages/retail-ui/components/Group/Group.tsx
+++ b/packages/retail-ui/components/Group/Group.tsx
@@ -23,6 +23,8 @@ export interface GroupChildProps {
  * передать свойство `mainInGroup`;
  */
 class Group extends React.Component<GroupProps> {
+  public static __KONTUR_REACT_UI__ = 'Group';
+
   public static propTypes = {
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   };

--- a/packages/retail-ui/components/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
+++ b/packages/retail-ui/components/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
@@ -3,6 +3,8 @@ import getComputedStyle from '../../lib/dom/getComputedStyle';
 import getScrollWidth from '../../lib/dom/getScrollWidth';
 
 export default class HideBodyVerticalScroll extends React.Component {
+  public static __KONTUR_REACT_UI__ = 'HideBodyVerticalScroll';
+
   public static hash = Math.random()
     .toString(16)
     .slice(2, 6);

--- a/packages/retail-ui/components/Hint/Hint.tsx
+++ b/packages/retail-ui/components/Hint/Hint.tsx
@@ -59,6 +59,8 @@ const Positions: PopupPosition[] = [
 ];
 
 class Hint extends React.Component<HintProps, HintState> {
+  public static __KONTUR_REACT_UI__ = 'Hint';
+
   public static defaultProps = {
     pos: 'top',
     manual: false,

--- a/packages/retail-ui/components/Icon/20px/Icon.tsx
+++ b/packages/retail-ui/components/Icon/20px/Icon.tsx
@@ -25,7 +25,7 @@ export interface IconProps {
 }
 
 class Icon extends React.Component<IconProps> {
-  public static __KONTUR_REACT_UI__ = 'Icon';
+  public static __KONTUR_REACT_UI__ = 'Icon20px';
 
   public static propTypes = {
     color: PropTypes.string,

--- a/packages/retail-ui/components/Icon/20px/Icon.tsx
+++ b/packages/retail-ui/components/Icon/20px/Icon.tsx
@@ -25,6 +25,8 @@ export interface IconProps {
 }
 
 class Icon extends React.Component<IconProps> {
+  public static __KONTUR_REACT_UI__ = 'Icon';
+
   public static propTypes = {
     color: PropTypes.string,
 

--- a/packages/retail-ui/components/IgnoreLayerClick/IgnoreLayerClick.tsx
+++ b/packages/retail-ui/components/IgnoreLayerClick/IgnoreLayerClick.tsx
@@ -19,7 +19,7 @@ interface WrapperProps {
 
 // NOTE Используется только в команде Контур.Бухгалтерия
 class IgnoreLayerClickWrapper extends React.Component<WrapperProps> {
-  public static __KONTUR_REACT_UI__ = 'IgnoreLayerClickWrapper';
+  public static __KONTUR_REACT_UI__ = 'IgnoreLayerClick';
 
   private element: Element | null = null;
 

--- a/packages/retail-ui/components/IgnoreLayerClick/IgnoreLayerClick.tsx
+++ b/packages/retail-ui/components/IgnoreLayerClick/IgnoreLayerClick.tsx
@@ -19,6 +19,8 @@ interface WrapperProps {
 
 // NOTE Используется только в команде Контур.Бухгалтерия
 class IgnoreLayerClickWrapper extends React.Component<WrapperProps> {
+  public static __KONTUR_REACT_UI__ = 'IgnoreLayerClickWrapper';
+
   private element: Element | null = null;
 
   public componentDidMount() {

--- a/packages/retail-ui/components/Input/Input.tsx
+++ b/packages/retail-ui/components/Input/Input.tsx
@@ -110,6 +110,8 @@ export interface InputState extends InputVisibilityState {
  *  Все пропсы кроме перечисленных, `className` и `style` передаются в `<input>`
  */
 class Input extends React.Component<InputProps, InputState> {
+  public static __KONTUR_REACT_UI__ = 'Input';
+
   public static defaultProps: {
     size: InputSize;
   } = {

--- a/packages/retail-ui/components/Kebab/Kebab.tsx
+++ b/packages/retail-ui/components/Kebab/Kebab.tsx
@@ -48,6 +48,8 @@ export interface KebabState {
 }
 
 export default class Kebab extends React.Component<KebabProps, KebabState> {
+  public static __KONTUR_REACT_UI__ = 'Kebab';
+
   public static propTypes = {};
 
   public static defaultProps = {

--- a/packages/retail-ui/components/Kladr/Kladr.js
+++ b/packages/retail-ui/components/Kladr/Kladr.js
@@ -26,6 +26,8 @@ type State = {
  * @deprecated Компонент устарел и, вероятно, будет удален в версии 2.0.0. Рассмотрите возможность перехода на [Fias](#/Components/Fias).
  */
 export default class Kladr extends React.Component<Props, State> {
+  static __KONTUR_REACT_UI__ = 'Kladr';
+
   static propTypes = {
     error: PropTypes.string,
     title: PropTypes.string,

--- a/packages/retail-ui/components/Link/Link.tsx
+++ b/packages/retail-ui/components/Link/Link.tsx
@@ -55,6 +55,7 @@ export interface LinkState {
  * `className` и `style` не поддерживаются
  */
 class Link extends React.Component<LinkProps, LinkState> {
+  public static __KONTUR_REACT_UI__ = 'Link';
   public static __ADAPTER__: any;
 
   public static propTypes = {

--- a/packages/retail-ui/components/Loader/Loader.tsx
+++ b/packages/retail-ui/components/Loader/Loader.tsx
@@ -35,6 +35,8 @@ export interface LoaderState {
  * DRAFT - лоадер-контейнер
  */
 class Loader extends React.Component<LoaderProps, LoaderState> {
+  public static __KONTUR_REACT_UI__ = 'Loader';
+
   public static defaultProps = {
     type: Spinner.Types.normal,
     active: false,

--- a/packages/retail-ui/components/LocaleProvider/LocaleProvider.tsx
+++ b/packages/retail-ui/components/LocaleProvider/LocaleProvider.tsx
@@ -15,6 +15,8 @@ export interface LocaleProviderProps {
 export const LocaleConsumer = LocaleContext.Consumer;
 
 export default class LocaleProvider extends React.Component<LocaleProviderProps> {
+  public static __KONTUR_REACT_UI__ = 'LocaleProvider';
+
   public static defaultProps = {
     locale: {},
     langCode: defaultLangCode,

--- a/packages/retail-ui/components/Logotype/Logotype.tsx
+++ b/packages/retail-ui/components/Logotype/Logotype.tsx
@@ -81,6 +81,8 @@ export interface LogotypeProps {
 
 @locale('Logotype', LogotypeLocaleHelper)
 class Logotype extends React.Component<LogotypeProps> {
+  public static __KONTUR_REACT_UI__ = 'Logotype';
+
   public static propTypes = {
     color: PropTypes.string,
     href: PropTypes.string,

--- a/packages/retail-ui/components/Menu/Menu.tsx
+++ b/packages/retail-ui/components/Menu/Menu.tsx
@@ -25,6 +25,8 @@ interface MenuState {
 }
 
 export default class Menu extends React.Component<MenuProps, MenuState> {
+  public static __KONTUR_REACT_UI__ = 'Menu';
+
   public static defaultProps = {
     width: 'auto',
     maxHeight: 300,

--- a/packages/retail-ui/components/MenuHeader/MenuHeader.tsx
+++ b/packages/retail-ui/components/MenuHeader/MenuHeader.tsx
@@ -16,6 +16,7 @@ export interface MenuHeaderProps {
  * Заголовок в меню.
  */
 export default class MenuHeader extends React.Component<MenuHeaderProps> {
+  public static __KONTUR_REACT_UI__ = 'MenuHeader';
   public static __MENU_HEADER__ = true;
 
   public static defaultProps = {

--- a/packages/retail-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/retail-ui/components/MenuItem/MenuItem.tsx
@@ -41,6 +41,7 @@ export interface MenuItemProps {
  * Элемент меню.
  */
 export default class MenuItem extends React.Component<MenuItemProps> {
+  public static __KONTUR_REACT_UI__ = 'MenuItem';
   public static __MENU_ITEM__ = true;
 
   public static propTypes = {

--- a/packages/retail-ui/components/MenuSeparator/MenuSeparator.tsx
+++ b/packages/retail-ui/components/MenuSeparator/MenuSeparator.tsx
@@ -9,6 +9,8 @@ import { ITheme } from '../../lib/theming/Theme';
  * Разделитель в меню.
  */
 export default class MenuSeparator extends React.Component<{}> {
+  public static __KONTUR_REACT_UI__ = 'MenuSeparator';
+
   private theme!: ITheme;
 
   public render() {

--- a/packages/retail-ui/components/Modal/Modal.tsx
+++ b/packages/retail-ui/components/Modal/Modal.tsx
@@ -74,6 +74,8 @@ export interface ModalState {
  * (по-умолчанию прилипание включено)
  */
 export default class Modal extends React.Component<ModalProps, ModalState> {
+  public static __KONTUR_REACT_UI__ = 'Modal';
+
   public static Header = Header;
   public static Body = Body;
   public static Footer = Footer;

--- a/packages/retail-ui/components/Modal/ModalBody.tsx
+++ b/packages/retail-ui/components/Modal/ModalBody.tsx
@@ -5,6 +5,7 @@ import { cx } from '../../lib/theming/Emotion';
 import ZIndex from '../ZIndex';
 
 export class Body extends React.Component {
+  public static __KONTUR_REACT_UI__ = 'ModalBody';
   public static __MODAL_BODY__ = true;
 
   public render(): JSX.Element {

--- a/packages/retail-ui/components/Modal/ModalFooter.tsx
+++ b/packages/retail-ui/components/Modal/ModalFooter.tsx
@@ -21,6 +21,7 @@ export interface FooterProps {
  * Футер модального окна.
  */
 export class Footer extends React.Component<FooterProps> {
+  public static __KONTUR_REACT_UI__ = 'ModalFooter';
   public static __MODAL_FOOTER__ = true;
 
   public static defaultProps = {

--- a/packages/retail-ui/components/Modal/ModalHeader.tsx
+++ b/packages/retail-ui/components/Modal/ModalHeader.tsx
@@ -15,6 +15,7 @@ export interface HeaderProps {
 }
 
 export class Header extends React.Component<HeaderProps> {
+  public static __KONTUR_REACT_UI__ = 'ModalHeader';
   public static __MODAL_HEADER__ = true;
 
   public static defaultProps = {

--- a/packages/retail-ui/components/Paging/Paging.tsx
+++ b/packages/retail-ui/components/Paging/Paging.tsx
@@ -67,6 +67,8 @@ export type ItemType = number | '.' | 'forward';
 
 @locale('Paging', PagingLocaleHelper)
 export default class Paging extends React.Component<PagingProps, PagingState> {
+  public static __KONTUR_REACT_UI__ = 'Paging';
+
   public static defaultProps = {
     component: ({ className, onClick, children }: any) => (
       <span className={className} onClick={onClick} children={children} />

--- a/packages/retail-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/retail-ui/components/PasswordInput/PasswordInput.tsx
@@ -26,6 +26,8 @@ export interface PasswordInputState {
  * **DRAFT**
  */
 export default class PasswordInput extends React.Component<PasswordInputProps, PasswordInputState> {
+  public static __KONTUR_REACT_UI__ = 'PasswordInput';
+
   public static propTypes = {
     /**
      * Включает CapsLock детектор

--- a/packages/retail-ui/components/PhoneInput/PhoneInput.js
+++ b/packages/retail-ui/components/PhoneInput/PhoneInput.js
@@ -5,6 +5,8 @@ import Input from '../Input';
  * Все пропсы пробрасываются во внутренний Input
  */
 class PhoneInput extends React.Component<*> {
+  static __KONTUR_REACT_UI__ = 'PhoneInput';
+
   render() {
     return <Input {...this.props} mask="+7 999 999-99-99" maskChar={null} placeholder="+7" />;
   }

--- a/packages/retail-ui/components/Popup/Popup.tsx
+++ b/packages/retail-ui/components/Popup/Popup.tsx
@@ -101,6 +101,8 @@ export interface PopupState {
 }
 
 export default class Popup extends React.Component<PopupProps, PopupState> {
+  public static __KONTUR_REACT_UI__ = 'Popup';
+
   public static propTypes = {
     /**
      * Ссылка (ref) на элемент или React компонент, для которого рисуется попап

--- a/packages/retail-ui/components/Popup/PopupPin.tsx
+++ b/packages/retail-ui/components/Popup/PopupPin.tsx
@@ -26,6 +26,8 @@ interface Props {
 }
 
 export default class PopupPin extends React.Component<Props> {
+  public static __KONTUR_REACT_UI__ = 'PopupPin';
+
   public static propTypes = {
     /**
      * Цвет фон пина

--- a/packages/retail-ui/components/Radio/Radio.tsx
+++ b/packages/retail-ui/components/Radio/Radio.tsx
@@ -66,6 +66,8 @@ export type RadioProps<T> = Override<
  * ```
  */
 class Radio<T> extends React.Component<RadioProps<T>> {
+  public static __KONTUR_REACT_UI__ = 'Radio';
+
   public static contextTypes = {
     activeItem: PropTypes.any,
     onSelect: PropTypes.func,

--- a/packages/retail-ui/components/RadioGroup/RadioGroup.tsx
+++ b/packages/retail-ui/components/RadioGroup/RadioGroup.tsx
@@ -35,6 +35,8 @@ export interface RadioGroupState<T> {
 }
 
 class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGroupState<T>> {
+  public static __KONTUR_REACT_UI__ = 'RadioGroup';
+
   public static childContextTypes = {
     error: PropTypes.bool,
     name: PropTypes.string,

--- a/packages/retail-ui/components/RenderContainer/RenderContainer.tsx
+++ b/packages/retail-ui/components/RenderContainer/RenderContainer.tsx
@@ -9,6 +9,8 @@ const HAS_BUILTIN_PORTAL = !!ReactDOM.createPortal;
 const RenderInnerContainer = HAS_BUILTIN_PORTAL ? RenderContainerNative : RenderContainerFallback;
 
 export class RenderContainer extends React.Component<RenderContainerProps> {
+  public static __KONTUR_REACT_UI__ = 'RenderContainer';
+
   private static getRootId = () => Math.random().toString(16).slice(2, 6);
   private domContainer: Nullable<HTMLElement> = null;
 

--- a/packages/retail-ui/components/RenderContainer/RenderContainerFallback.tsx
+++ b/packages/retail-ui/components/RenderContainer/RenderContainerFallback.tsx
@@ -13,6 +13,8 @@ export function RootContainer(props: { children?: React.ReactNode; rt_portalID: 
 }
 
 export class Portal extends React.Component<PortalProps> {
+  public static __KONTUR_REACT_UI__ = 'RenderContainerFallback';
+
   public componentDidMount() {
     if (!this.props.children) {
       return;

--- a/packages/retail-ui/components/RenderContainer/RenderContainerNative.tsx
+++ b/packages/retail-ui/components/RenderContainer/RenderContainerNative.tsx
@@ -13,6 +13,8 @@ export function Portal(props: PortalProps) {
 }
 
 export class RenderInnerContainer extends React.Component<RenderContainerNativeProps> {
+  public static __KONTUR_REACT_UI__ = 'RenderInnerContainer';
+
   public render() {
     if (this.props.children) {
       if (!this.props.domContainer) {

--- a/packages/retail-ui/components/RenderLayer/RenderLayer.tsx
+++ b/packages/retail-ui/components/RenderLayer/RenderLayer.tsx
@@ -10,6 +10,8 @@ export interface RenderLayerProps {
 }
 
 class RenderLayer extends React.Component<RenderLayerProps> {
+  public static __KONTUR_REACT_UI__ = 'RenderLayer';
+
   public static propTypes = {
     active(props: RenderLayerProps, propName: keyof RenderLayerProps, componentName: string) {
       const { active, onClickOutside, onFocusOutside } = props;

--- a/packages/retail-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/retail-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -37,6 +37,8 @@ export interface ScrollContainerState {
 }
 
 export default class ScrollContainer extends React.Component<ScrollContainerProps, ScrollContainerState> {
+  public static __KONTUR_REACT_UI__ = 'ScrollContainer';
+
   public static propTypes = {
     invert: PropTypes.bool,
     maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/packages/retail-ui/components/Select/Item.tsx
+++ b/packages/retail-ui/components/Select/Item.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import MenuItem from '../MenuItem/MenuItem';
 
 class Item extends React.Component<{ children?: React.ReactNode }> {
+  public static __KONTUR_REACT_UI__ = 'SelectItem';
+
   public render() {
     return <MenuItem>{this.props.children}</MenuItem>;
   }

--- a/packages/retail-ui/components/Select/Select.tsx
+++ b/packages/retail-ui/components/Select/Select.tsx
@@ -103,6 +103,8 @@ interface FocusableReactElement extends React.ReactElement<any> {
 
 @locale('Select', SelectLocaleHelper)
 class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps<TValue, TItem>, SelectState<TValue>> {
+  public static __KONTUR_REACT_UI__ = 'Select';
+
   public static propTypes = {
     /**
      * Функция для сравнения `value` с элементом из `items`

--- a/packages/retail-ui/components/SidePage/SidePage.tsx
+++ b/packages/retail-ui/components/SidePage/SidePage.tsx
@@ -84,6 +84,8 @@ interface ZIndexPropsType {
  * **Footer** необходимо передать пропс **panel**
  */
 class SidePage extends React.Component<SidePageProps, SidePageState> {
+  public static __KONTUR_REACT_UI__ = 'SidePage';
+
   public static Header = SidePageHeader;
   public static Body: (props: SidePageBodyProps) => JSX.Element = SidePageBodyWithContext;
   public static Footer: (props: SidePageFooterProps) => JSX.Element = SidePageFooterWithContext;

--- a/packages/retail-ui/components/SidePage/SidePageBody.tsx
+++ b/packages/retail-ui/components/SidePage/SidePageBody.tsx
@@ -9,6 +9,8 @@ export interface SidePageBodyProps {
 }
 
 export class SidePageBody extends React.Component<SidePageBodyProps> {
+  public static __KONTUR_REACT_UI__ = 'SidePageBody';
+
   public componentDidUpdate() {
     const { context } = this.props;
     if (context) {

--- a/packages/retail-ui/components/SidePage/SidePageContainer.tsx
+++ b/packages/retail-ui/components/SidePage/SidePageContainer.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import styles from './SidePage.module.less';
 
 export default class SidePageContainer extends React.Component {
+  public static __KONTUR_REACT_UI__ = 'SidePageContainer';
+
   public render(): JSX.Element {
     return <div className={styles.bodyContainer}>{this.props.children}</div>;
   }

--- a/packages/retail-ui/components/SidePage/SidePageFooter.tsx
+++ b/packages/retail-ui/components/SidePage/SidePageFooter.tsx
@@ -22,6 +22,8 @@ export interface SidePageFooterProps {
  */
 
 export class SidePageFooter extends React.Component<SidePageFooterProps> {
+  public static __KONTUR_REACT_UI__ = 'SidePageFooter';
+
   public state = {
     fixed: false,
   };

--- a/packages/retail-ui/components/SidePage/SidePageHeader.tsx
+++ b/packages/retail-ui/components/SidePage/SidePageHeader.tsx
@@ -24,6 +24,8 @@ export interface SidePageHeaderState {
 }
 
 export default class SidePageHeader extends React.Component<SidePageHeaderProps, SidePageHeaderState> {
+  public static __KONTUR_REACT_UI__ = 'SidePageHeader';
+
   public state = {
     isReadyToFix: false,
   };

--- a/packages/retail-ui/components/Spinner/Spinner.tsx
+++ b/packages/retail-ui/components/Spinner/Spinner.tsx
@@ -37,6 +37,8 @@ const CLOUD_SVG_PATH = `M32.0297086,9.1495774 L31.5978628,8.5870774 C29.3570968,
 
 @locale('Spinner', SpinnerLocaleHelper)
 class Spinner extends React.Component<SpinnerProps> {
+  public static __KONTUR_REACT_UI__ = 'Spinner';
+
   public static propTypes = {
     /**
      * Текст рядом с мини-лоадером.

--- a/packages/retail-ui/components/Spinner/SpinnerFallback.tsx
+++ b/packages/retail-ui/components/Spinner/SpinnerFallback.tsx
@@ -15,6 +15,8 @@ export interface SpinnerFallbackProps {
 }
 
 export default class SpinnerFallback extends React.Component<SpinnerFallbackProps> {
+  public static __KONTUR_REACT_UI__ = 'SpinnerFallback';
+
   public static propTypes = {
     type: PropTypes.oneOf(Object.keys(types)),
 

--- a/packages/retail-ui/components/Sticky/Sticky.tsx
+++ b/packages/retail-ui/components/Sticky/Sticky.tsx
@@ -39,6 +39,8 @@ export interface StickyState {
 }
 
 export default class Sticky extends React.Component<StickyProps, StickyState> {
+  public static __KONTUR_REACT_UI__ = 'Sticky';
+
   public static propTypes = {
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 

--- a/packages/retail-ui/components/Switcher/Switcher.tsx
+++ b/packages/retail-ui/components/Switcher/Switcher.tsx
@@ -40,6 +40,8 @@ interface SwitcherItem {
 }
 
 class Switcher extends React.Component<SwitcherProps, SwitcherState> {
+  public static __KONTUR_REACT_UI__ = 'Switcher';
+
   public static propTypes = {
     error: PropTypes.bool,
     items: PropTypes.oneOfType([

--- a/packages/retail-ui/components/Tabs/Tab.tsx
+++ b/packages/retail-ui/components/Tabs/Tab.tsx
@@ -104,6 +104,8 @@ export interface TabState {
  * Works only inside Tabs component, otherwise throws
  */
 export class Tab extends React.Component<TabProps, TabState> {
+  public static __KONTUR_REACT_UI__ = 'Tab';
+
   public static propTypes = {
     children: PropTypes.node,
     component: PropTypes.any,

--- a/packages/retail-ui/components/Tabs/Tabs.tsx
+++ b/packages/retail-ui/components/Tabs/Tabs.tsx
@@ -46,6 +46,8 @@ export interface TabsProps {
  * contains static property `Tab`
  */
 class Tabs extends React.Component<TabsProps> {
+  public static __KONTUR_REACT_UI__ = 'Tabs';
+
   public static propTypes = {
     children: PropTypes.node,
     indicatorClassName: PropTypes.string,

--- a/packages/retail-ui/components/Textarea/Textarea.tsx
+++ b/packages/retail-ui/components/Textarea/Textarea.tsx
@@ -74,6 +74,8 @@ export interface TextareaState {
  * ** `className` и `style`  игнорируются**
  */
 class Textarea extends React.Component<TextareaProps, TextareaState> {
+  public static __KONTUR_REACT_UI__ = 'Textarea';
+
   public static propTypes = {
     error: PropTypes.bool,
     warning: PropTypes.bool,

--- a/packages/retail-ui/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/retail-ui/components/ThemeProvider/ThemeProvider.tsx
@@ -12,6 +12,8 @@ interface ThemeProviderProps {
 }
 
 export class ThemeProvider extends React.Component<ThemeProviderProps> {
+  public static __KONTUR_REACT_UI__ = 'ThemeProvider';
+
   private theme: ITheme;
 
   constructor(props: ThemeProviderProps) {

--- a/packages/retail-ui/components/Toast/Toast.tsx
+++ b/packages/retail-ui/components/Toast/Toast.tsx
@@ -34,6 +34,8 @@ export interface ToastProps {
  * `Toast.push('message', {label: 'Cancel', handler: cancelHandler})`
  */
 class Toast extends React.Component<ToastProps, ToastState> {
+  public static __KONTUR_REACT_UI__ = 'Toast';
+
   public static push(notification: string, action?: Action) {
     ToastStatic.push(notification, action);
   }

--- a/packages/retail-ui/components/Toggle/Toggle.tsx
+++ b/packages/retail-ui/components/Toggle/Toggle.tsx
@@ -28,6 +28,8 @@ export interface ToggleState {
 }
 
 export default class Toggle extends React.Component<ToggleProps, ToggleState> {
+  public static __KONTUR_REACT_UI__ = 'Toggle';
+
   public static propTypes = {
     checked: PropTypes.bool,
     defaultChecked: PropTypes.bool,

--- a/packages/retail-ui/components/Token/Token.tsx
+++ b/packages/retail-ui/components/Token/Token.tsx
@@ -48,6 +48,8 @@ export interface TokenProps {
 }
 
 export default class Token extends React.Component<TokenProps & TokenActions> {
+  public static __KONTUR_REACT_UI__ = 'Token';
+
   private theme!: ITheme;
 
   public render() {

--- a/packages/retail-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/retail-ui/components/TokenInput/TokenInput.tsx
@@ -92,6 +92,8 @@ const defaultRenderToken = <T extends any>(
 );
 
 export default class TokenInput<T = string> extends React.PureComponent<TokenInputProps<T>, TokenInputState<T>> {
+  public static __KONTUR_REACT_UI__ = 'TokenInput';
+
   public static defaultProps: Partial<TokenInputProps<any>> = {
     selectedItems: [],
     renderItem: identity,

--- a/packages/retail-ui/components/TokenInput/TokenInputMenu.tsx
+++ b/packages/retail-ui/components/TokenInput/TokenInputMenu.tsx
@@ -15,6 +15,8 @@ export interface TokenInputMenuProps<T> extends ComboBoxMenuProps<T> {
 
 @locale('TokenInput', TokenInputLocaleHelper)
 export default class TokenInputMenu<T = string> extends React.Component<TokenInputMenuProps<T>> {
+  public static __KONTUR_REACT_UI__ = 'TokenInputMenu';
+
   private readonly locale!: TokenInputLocale;
 
   private menu: Menu | null = null;

--- a/packages/retail-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/retail-ui/components/Tooltip/Tooltip.tsx
@@ -145,6 +145,8 @@ export interface TooltipState {
 }
 
 class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
+  public static __KONTUR_REACT_UI__ = 'Tooltip';
+
   public static propTypes = {
     children(props: TooltipProps, propName: keyof TooltipProps, componentName: string) {
       const children = props[propName];

--- a/packages/retail-ui/components/TooltipMenu/TooltipMenu.tsx
+++ b/packages/retail-ui/components/TooltipMenu/TooltipMenu.tsx
@@ -39,6 +39,8 @@ export interface TooltipMenuProps {
  * Если ```positions``` передан или передан пустой массив, используются все возможные положения.
  */
 export default class TooltipMenu extends React.Component<TooltipMenuProps> {
+  public static __KONTUR_REACT_UI__ = 'TooltipMenu';
+
   public static defaultProps = {
     disableAnimations: Boolean(process.env.enableReactTesting),
   };

--- a/packages/retail-ui/components/TopBar/Divider.tsx
+++ b/packages/retail-ui/components/TopBar/Divider.tsx
@@ -6,6 +6,8 @@ import { ThemeConsumer } from '../ThemeConsumer';
 import { ITheme } from '../../lib/theming/Theme';
 
 class Divider extends React.Component<{}> {
+  public static __KONTUR_REACT_UI__ = 'TopBarDivider';
+
   private theme!: ITheme;
 
   public render() {

--- a/packages/retail-ui/components/TopBar/Item.tsx
+++ b/packages/retail-ui/components/TopBar/Item.tsx
@@ -19,6 +19,8 @@ export interface ItemProps {
 }
 
 class Item extends React.Component<ItemProps> {
+  public static __KONTUR_REACT_UI__ = 'TopBarItem';
+
   public static propTypes = {
     use: PropTypes.oneOf(['danger', 'pay', 'default']),
   };

--- a/packages/retail-ui/components/TopBar/Organizations.tsx
+++ b/packages/retail-ui/components/TopBar/Organizations.tsx
@@ -17,6 +17,8 @@ export interface OrganizationsState {
 }
 
 class Organizations extends React.Component<OrganizationsProps, OrganizationsState> {
+  public static __KONTUR_REACT_UI__ = 'TopBarOrganizations';
+
   public state = {
     captionWhiteSpace: 'normal' as React.CSSProperties['whiteSpace'],
     minWidth: null,

--- a/packages/retail-ui/components/TopBar/TopBar.tsx
+++ b/packages/retail-ui/components/TopBar/TopBar.tsx
@@ -56,6 +56,8 @@ export interface TopBarDefaultProps {
  *
  */
 class TopBar extends React.Component<TopBarProps> {
+  public static __KONTUR_REACT_UI__ = 'TopBar';
+
   public static Divider = Divider;
   public static Item = ButtonItem;
   public static Dropdown = TopBarDropdown;

--- a/packages/retail-ui/components/TopBar/TopBarDropdown.tsx
+++ b/packages/retail-ui/components/TopBar/TopBarDropdown.tsx
@@ -24,6 +24,8 @@ export interface TopBarDropdownProps {
 }
 
 class TopBarDropdown extends React.Component<TopBarDropdownProps> {
+  public static __KONTUR_REACT_UI__ = 'TopBarDropdown';
+
   public static defaultProps = {
     use: 'default',
   };

--- a/packages/retail-ui/components/TopBar/TopBarEnd.tsx
+++ b/packages/retail-ui/components/TopBar/TopBarEnd.tsx
@@ -3,4 +3,6 @@ import styles from './TopBar.module.less';
 
 const End: React.SFC = ({ children }) => <div className={styles.endItems}>{children}</div>;
 
+(End as any).__KONTUR_REACT_UI__ = 'TopBarEnd';
+
 export default End;

--- a/packages/retail-ui/components/TopBar/TopBarLogout.tsx
+++ b/packages/retail-ui/components/TopBar/TopBarLogout.tsx
@@ -5,6 +5,8 @@ import { TopBarLocale, TopBarLocaleHelper } from './locale';
 
 @locale('TopBar', TopBarLocaleHelper)
 class Logout extends React.Component<ButtonItemProps> {
+  public static __KONTUR_REACT_UI__ = 'TopBarLogout';
+
   public static defaultProps = ButtonItem.defaultProps;
   private readonly locale!: TopBarLocale;
 

--- a/packages/retail-ui/components/TopBar/TopBarStart.tsx
+++ b/packages/retail-ui/components/TopBar/TopBarStart.tsx
@@ -3,4 +3,6 @@ import styles from './TopBar.module.less';
 
 const Start: React.SFC = ({ children }) => <div className={styles.startItems}>{children}</div>;
 
+(Start as any).__KONTUR_REACT_UI__ = 'TopBarStart';
+
 export default Start;

--- a/packages/retail-ui/components/TopBar/User.tsx
+++ b/packages/retail-ui/components/TopBar/User.tsx
@@ -13,6 +13,8 @@ export interface UserProps {
 
 @locale('TopBar', TopBarLocaleHelper)
 class User extends React.Component<UserProps> {
+  public static __KONTUR_REACT_UI__ = 'TopBarUser';
+
   public static defaultProps = {
     cabinetUrl: 'https://cabinet.kontur.ru',
   };

--- a/packages/retail-ui/components/ZIndex/ZIndex.tsx
+++ b/packages/retail-ui/components/ZIndex/ZIndex.tsx
@@ -19,6 +19,8 @@ export interface ZIndexProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export default class ZIndex extends React.Component<ZIndexProps> {
+  public static __KONTUR_REACT_UI__ = 'ZIndex';
+
   public static defaultProps = {
     delta: 10,
     priority: 0,

--- a/packages/retail-ui/components/internal/FocusTrap/FocusTrap.tsx
+++ b/packages/retail-ui/components/internal/FocusTrap/FocusTrap.tsx
@@ -8,6 +8,8 @@ export interface FocusTrapProps {
 }
 
 export default class FocusTrap extends React.PureComponent<FocusTrapProps> {
+  public static __KONTUR_REACT_UI__ = 'FocusTrap';
+
   private focusOutsideListenerToken: {
     remove: () => void;
   } | null = null;

--- a/packages/retail-ui/components/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/retail-ui/components/internal/InputLikeText/InputLikeText.tsx
@@ -20,6 +20,8 @@ export interface InputLikeTextProps extends InputProps {
 interface InputLikeTextState extends InputVisibilityState {}
 
 export default class InputLikeText extends React.Component<InputLikeTextProps, InputLikeTextState> {
+  public static __KONTUR_REACT_UI__ = 'InputLikeText';
+
   public static defaultProps = {
     size: 'small',
   };

--- a/packages/retail-ui/components/internal/InternalMenu/InternalMenu.tsx
+++ b/packages/retail-ui/components/internal/InternalMenu/InternalMenu.tsx
@@ -37,6 +37,8 @@ interface MenuState {
 }
 
 export default class InternalMenu extends React.Component<MenuProps, MenuState> {
+  public static __KONTUR_REACT_UI__ = 'InternalMenu';
+
   public static defaultProps = {
     width: 'auto',
     maxHeight: 300,

--- a/packages/retail-ui/components/internal/MaskedInput/MaskedInput.tsx
+++ b/packages/retail-ui/components/internal/MaskedInput/MaskedInput.tsx
@@ -23,6 +23,8 @@ interface MaskedInputState {
 }
 
 export default class MaskedInput extends React.Component<MaskedInputProps, MaskedInputState> {
+  public static __KONTUR_REACT_UI__ = 'MaskedInput';
+
   public input: HTMLInputElement | null = null;
   private theme!: ITheme;
   private reactInputMask: ReactInputMask | null = null;

--- a/packages/retail-ui/components/internal/PopupMenu/PopupMenu.tsx
+++ b/packages/retail-ui/components/internal/PopupMenu/PopupMenu.tsx
@@ -62,6 +62,8 @@ export const PopupMenuType = {
 };
 
 export default class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
+  public static __KONTUR_REACT_UI__ = 'PopupMenu';
+
   public static defaultProps = {
     positions: PopupMenuPositions,
     type: PopupMenuType.Tooltip,

--- a/packages/retail-ui/components/internal/ResizeDetector/ResizeDetector.tsx
+++ b/packages/retail-ui/components/internal/ResizeDetector/ResizeDetector.tsx
@@ -6,6 +6,8 @@ export interface ResizeDetectorProps {
 }
 
 export default class ResizeDetector extends React.Component<ResizeDetectorProps> {
+  public static __KONTUR_REACT_UI__ = 'ResizeDetector';
+
   private iframeWindow: Window | null = null;
 
   public componentDidMount() {


### PR DESCRIPTION
Решил, что лучше добавить это в мастер, чтобы попало в старые и в новые `lts` и `latest`.

close #1838

---

Компоненты, в которых уже были статические свойства для их идентификации.
- `Button/Button.tsx`
- `MenuHeader/MenuHeader.tsx`
- `MenuItem/MenuItem.tsx`
- `Modal/ModalBody.tsx`
- `Modal/ModalHeader.tsx`
- `Modal/ModalFooter.tsx`
