### PR TITLE
fix(react-selenium-testing): attributes on wrong element

### DIFF
--- a/packages/react-ui-testing/react-selenium-testing.js
+++ b/packages/react-ui-testing/react-selenium-testing.js
@@ -306,9 +306,6 @@ function findDomElementByFiberNode(node) {
   if (typeof node.setAttribute === 'function') {
     return node;
   }
-  if (result == null && node._node) {
-    result = findDomElementByFiberNode(node._node);
-  }
   if (result == null && node.stateNode) {
     result = findDomElementByFiberNode(node.stateNode);
   }

--- a/packages/retail-ui/components/Button/Button.tsx
+++ b/packages/retail-ui/components/Button/Button.tsx
@@ -123,7 +123,7 @@ export default class Button extends React.Component<ButtonProps, ButtonState> {
   };
 
   private theme!: ITheme;
-  private _node: HTMLButtonElement | null = null;
+  private node: HTMLButtonElement | null = null;
 
   public componentDidMount() {
     if (this.props.autoFocus) {
@@ -136,8 +136,8 @@ export default class Button extends React.Component<ButtonProps, ButtonState> {
    * @public
    */
   public focus() {
-    if (this._node) {
-      this._node.focus();
+    if (this.node) {
+      this.node.focus();
     }
   }
 
@@ -145,8 +145,8 @@ export default class Button extends React.Component<ButtonProps, ButtonState> {
    * @public
    */
   public blur() {
-    if (this._node) {
-      this._node.blur();
+    if (this.node) {
+      this.node.blur();
     }
   }
 
@@ -336,7 +336,7 @@ export default class Button extends React.Component<ButtonProps, ButtonState> {
   };
 
   private _ref = (node: HTMLButtonElement | null) => {
-    this._node = node;
+    this.node = node;
   };
 }
 

--- a/packages/retail-ui/components/Radio/Radio.tsx
+++ b/packages/retail-ui/components/Radio/Radio.tsx
@@ -82,7 +82,7 @@ class Radio<T> extends React.Component<RadioProps<T>> {
   };
 
   private theme!: ITheme;
-  private _node: Nullable<HTMLInputElement> = null;
+  private node: Nullable<HTMLInputElement> = null;
 
   public render() {
     return (
@@ -99,8 +99,8 @@ class Radio<T> extends React.Component<RadioProps<T>> {
    * @public
    */
   public focus() {
-    if (this._node) {
-      this._node.focus();
+    if (this.node) {
+      this.node.focus();
     }
   }
 
@@ -108,8 +108,8 @@ class Radio<T> extends React.Component<RadioProps<T>> {
    * @public
    */
   public blur() {
-    if (this._node) {
-      this._node.blur();
+    if (this.node) {
+      this.node.blur();
     }
   }
 
@@ -218,7 +218,7 @@ class Radio<T> extends React.Component<RadioProps<T>> {
   }
 
   private _ref = (element: HTMLInputElement) => {
-    this._node = element;
+    this.node = element;
   };
 
   private _handleChange = () => {

--- a/packages/retail-ui/components/RadioGroup/RadioGroup.tsx
+++ b/packages/retail-ui/components/RadioGroup/RadioGroup.tsx
@@ -142,7 +142,7 @@ class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGroupState<
 
   public static Prevent = Prevent;
 
-  private _node: Nullable<HTMLSpanElement>;
+  private node: Nullable<HTMLSpanElement>;
   private _name = uuidv1();
   private getProps = createPropsGetter(RadioGroup.defaultProps);
 
@@ -189,7 +189,7 @@ class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGroupState<
    * @public
    */
   public focus() {
-    const node = this._node;
+    const node = this.node;
     if (!node) {
       return;
     }
@@ -245,7 +245,7 @@ class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGroupState<
   };
 
   private _ref = (element: HTMLSpanElement) => {
-    this._node = element;
+    this.node = element;
   };
 }
 


### PR DESCRIPTION
Подробности в #1866.

Выяснилось, что поля `_node` в Fiber'е нет. Оно использовалось до 16.0.0, но уже мертвый код был выпилен только в [16.1.0](https://github.com/facebook/react/pull/10794).

Кроме этого, отрефакторил компоненты для порядка и чтобы работало со старым react-selenium-testing.

PR #1480 про то же, но решение не работает.

fix #1866 
close #1480 