### PR TITLE
feature(theme): cache

### DIFF
--- a/packages/react-ui/CUSTOMIZATION.md
+++ b/packages/react-ui/CUSTOMIZATION.md
@@ -1,12 +1,80 @@
 ## Резюме
 
 Для кастомизации компонентов используется ThemeContext:
+
 - чтобы задать тему `ThemeContext.Provider`;
 - использовать тему в своих компонентах `ThemeContext.Consumer`.
 
 Механизм работы: динамические стили генерируются в зависимости от темы в процессе render'а с помощью <a href="https://www.npmjs.com/package/emotion" target="_blank">emotion</a>, полученные классы добавляются в `className` соответствующих элементов.
 
 ## Мотивация
+
+```jsx harmony
+import { ThemeContext, ThemeFactory, Button, Loader, Logotype, TopBar } from '@skbkontur/react-ui';
+import { ShowcaseGroup } from '@skbkontur/react-ui/internal/ThemePlayground/ShowcaseGroup';
+import BabyIcon from '@skbkontur/react-icons/Baby';
+
+const myTheme = ThemeFactory.create({ btnSmallBorderRadius: '1px' });
+const myTheme2 = ThemeFactory.create({ tdDividerBg: 'red', btnSmallBorderRadius: '10px' });
+const myTheme3 = ThemeFactory.create({ btnSmallBorderRadius: '20px' });
+
+console.log(window.myTheme === myTheme);
+window.myTheme = myTheme;
+
+let pageStyle = {
+  background: '#e6e6e6',
+  height: 400,
+  border: '1px solid #dedfdf',
+  overflow: 'hidden',
+};
+
+let contentStyle = {
+  background: 'white',
+  padding: 15,
+  height: 280,
+};
+
+initialState = {opened: true};
+
+<ThemeContext.Provider value={myTheme}>
+  <Button>Ok</Button>
+  <ShowcaseGroup title="My Theme" />
+  {state.opened ? (
+    <ThemeContext.Provider value={myTheme3}>
+        <Button>Ok</Button>
+      </ThemeContext.Provider>
+  ): null}
+  <ThemeContext.Provider value={myTheme2}>
+    <div style={pageStyle}>
+      <TopBar>
+        <TopBar.Start>
+          <TopBar.ItemStatic>
+            <Logotype suffix="ui" withWidget />
+          </TopBar.ItemStatic>
+          <TopBar.Item>
+            <BabyIcon color="#666" />
+          </TopBar.Item>
+          <TopBar.Item>
+            <BabyIcon color="#666" />
+          </TopBar.Item>
+        </TopBar.Start>
+        <TopBar.End>
+          <TopBar.Item>
+            <Button>Ok</Button>
+            <BabyIcon color="#666" />
+          </TopBar.Item>
+          <TopBar.User userName="Alexander The Great" />
+          <TopBar.Divider />
+          <TopBar.Logout onClick={() => alert('Logout!')} />
+        </TopBar.End>
+      </TopBar>
+      <Loader active caption="neverending...">
+        <div style={contentStyle} />
+      </Loader>
+    </div>
+  </ThemeContext.Provider>
+</ThemeContext.Provider>;
+```
 
 На данный момент существует 2 версии библиотеки:
 
@@ -25,7 +93,7 @@
 
 ### Механизм работы кастомизации
 
-1. Из файла с переменными (variables.less для стандартной темы, variables.flat.less - для плоской) все значения - после "накатывания" переопределенных в сервисе-потребителе значений - экспортируются в camelCase:
+1.  Из файла с переменными (variables.less для стандартной темы, variables.flat.less - для плоской) все значения - после "накатывания" переопределенных в сервисе-потребителе значений - экспортируются в camelCase:
 
     ```less
     @blue_dark: #1e5aa4;
@@ -39,8 +107,8 @@
 
     Это позволит пользователям _retail-ui_ "просто обновиться" - их переопределенные переменные будут учтены на 2ом шаге при сборке тем.
 
-2. В библиотеке из коробки определены два файла с темами: _lib/theming/themes/DefaultTheme.ts_ и _lib/theming/themes/FlatTheme.ts_.
-   В этих файлах определяются вычисляемые (зависящие от других) переменные, например:
+2.  В библиотеке из коробки определены два файла с темами: _lib/theming/themes/DefaultTheme.ts_ и _lib/theming/themes/FlatTheme.ts_.
+    В этих файлах определяются вычисляемые (зависящие от других) переменные, например:
 
     ```typescript
     import DEFAULT_VARIABLES from '../../../components/variables.less';
@@ -85,8 +153,8 @@
 
     **\*ВАЖНО:** файл FlatTheme.ts не используется напрямую ни в одном компоненте и не попадет в итоговый bundle, если не будет использован в явном виде (см. \*Использование плоской темы\_).
 
-3. В статическом классе `ThemeFactory` (_lib/theming/ThemeFactory.ts_) определяется `defaultTheme`.
-   `ThemeFactory` так же предоставляет следующие методы:
+3.  В статическом классе `ThemeFactory` (_lib/theming/ThemeFactory.ts_) определяется `defaultTheme`.
+    `ThemeFactory` так же предоставляет следующие методы:
 
     ```typescript
     class ThemeFactory {
@@ -122,7 +190,7 @@
     };
     ```
 
-4. Перед тем как использовать собственные значение, нужно c помощью `ThemeFactory.create` создать объект `Theme`, и получившуюся тему передать в `ThemeContext.Provider`.
+4.  Перед тем как использовать собственные значение, нужно c помощью `ThemeFactory.create` создать объект `Theme`, и получившуюся тему передать в `ThemeContext.Provider`.
 
     ```jsx harmony static
     import { Button, ButtonProps, Gapped, ThemeContext, ThemeFactory } from '@skbkontur/react-ui';
@@ -141,7 +209,7 @@
     };
     ```
 
-5. Для каждого компонента, в less стилях которого использовались (напрямую или косвенно) переменные из variables.less, с помощью codemod создан файл динамических стилей. Например (_ToastView.styles.ts_):
+5.  Для каждого компонента, в less стилях которого использовались (напрямую или косвенно) переменные из variables.less, с помощью codemod создан файл динамических стилей. Например (_ToastView.styles.ts_):
 
     ```typescript
     export const jsStyles = {
@@ -179,59 +247,61 @@
     - чтобы избежать конфликтов с проектами, которые используют или захотят использовать emotion;
     - чтобы задать сгенерированным классам дополнительным `scope` для specificityLevel (см. Specificity Level).
 
-6. В каждом кастомизируемом компоненте `render()` завернут в `ThemeContext.Consumer`:
+6.  В каждом кастомизируемом компоненте `render()` завернут в `ThemeContext.Consumer`:
 
-    ```jsx harmony static
-    class MyComponent extends React.Component<{}, {}> {
-      public render() {
-        return (
-          <ThemeContext.Consumer>
-            {theme => {
-              this.theme = theme;
-              return this.renderMain();
-            }}
-          </ThemeContext.Consumer>
-        );
-      }
-    }
-    ```
+        ```jsx harmony static
+        class MyComponent extends React.Component<{}, {}> {
+          public render() {
+            return (
+              <ThemeContext.Consumer>
+                {theme => {
+                  this.theme = theme;
+                  return this.renderMain();
+                }}
+              </ThemeContext.Consumer>
+            );
+          }
+        }
+        ```
 
-    Это позволяет использовать `this.theme` внутри любого рендерящего метода, например (_Spinner.tsx_):
+        Это позволяет использовать `this.theme` внутри любого рендерящего метода, например (_Spinner.tsx_):
 
-    ```jsx harmony static
-    import styles from './Spinner.less';
-    import { jsStyles } from './Spinner.styles';
+        ```jsx harmony static
+        import styles from './Spinner.less';
+        import { ThemeFactory } from '../../lib/theming/ThemeFactory';
+
+    import { Styles } from './Spinner.styles';
     import { cx } from '../../lib/theming/Emotion';
 
-    private _renderCloud = (type) => {
-      const { props, theme } = this;
-      const bgClassName = jsStyles.cloudBg(this.theme);
-      const strokeClassName = cx(
-        styles.cloudStroke,
-        props.dimmed ? jsStyles.cloudStrokeDimmed(theme) : jsStyles.cloudStroke(theme)
-      );
+        private _renderCloud = (type) => {
+          const { props, theme } = this;
+          const bgClassName = jsStyles.cloudBg(this.theme);
+          const strokeClassName = cx(
+            styles.cloudStroke,
+            props.dimmed ? jsStyles.cloudStrokeDimmed(theme) : jsStyles.cloudStroke(theme)
+          );
 
-      return (
-        <svg className={styles.cloud}>
-          <path className={bgClassName} />
-          <path className={strokeClassName} />
-        </svg>
-      );
-    };
+          return (
+            <svg className={styles.cloud}>
+              <path className={bgClassName} />
+              <path className={strokeClassName} />
+            </svg>
+          );
+        };
 
-    private _renderCircle = (type) => {
-      const { props, theme } = this;
-      const strokeClassName = props.dimmed ?
-        jsStyles.circleStrokeDimmed(theme) :
-        jsStyles.circleStroke(theme);
+        private _renderCircle = (type) => {
+          const { props, theme } = this;
+          const strokeClassName = props.dimmed ?
+            jsStyles.circleStrokeDimmed(theme) :
+            jsStyles.circleStroke(theme);
 
-      return (
-        <svg className={cx(styles.circle, jsStyles.circle(theme))}>
-          <circle className={strokeClassName} />
-        </svg>
-      );
-    };
-    ```
+          return (
+            <svg className={cx(styles.circle, jsStyles.circle(theme))}>
+              <circle className={strokeClassName} />
+            </svg>
+          );
+        };
+        ```
 
 7\. PROFIT :)
 
@@ -243,34 +313,34 @@
 1. Путь джедая:
    В начале времен, где-то в _App.(j|t)sx_
 
-    ```jsx harmony static
-    import { ThemeContext } from '@skbkontur/react-ui';
-    import { FLAT_THEME } from '@skbkontur/react-ui/lib/theming/themes/FlatTheme';
+   ```jsx harmony static
+   import { ThemeContext } from '@skbkontur/react-ui';
+   import { FLAT_THEME } from '@skbkontur/react-ui/lib/theming/themes/FlatTheme';
 
-    const App = (
-      <ThemeContext.Provider value={FLAT_THEME}>
-        <div />
-      </ThemeContext.Provider>
-    );
-    ```
+   const App = (
+     <ThemeContext.Provider value={FLAT_THEME}>
+       <div />
+     </ThemeContext.Provider>
+   );
+   ```
 
 2. Для ленивых:
 
-    - выделить и скопировать "ThemeFactory.overrideDefaultTheme(FlatTheme)"
-    - ctrl+shift+f -> "Uprgades.enableFlatDesign()" -> enter;
-    - вставить "ThemeFactory.overrideDefaultTheme(FlatTheme)";
-    - alt+enter 2 раза (add import statement).
+   - выделить и скопировать "ThemeFactory.overrideDefaultTheme(FlatTheme)"
+   - ctrl+shift+f -> "Uprgades.enableFlatDesign()" -> enter;
+   - вставить "ThemeFactory.overrideDefaultTheme(FlatTheme)";
+   - alt+enter 2 раза (add import statement).
 
-    Должно получиться:
+   Должно получиться:
 
-    ```typescript
-    import { ThemeFactory } from '@skbkontur/react-ui/lib/theming/ThemeFactory';
-    import { FLAT_THEME } from '@skbkontur/react-ui/lib/theming/themes/FlatTheme';
+   ```typescript
+   import { ThemeFactory } from '@skbkontur/react-ui/lib/theming/ThemeFactory';
+   import { FLAT_THEME } from '@skbkontur/react-ui/lib/theming/themes/FlatTheme';
 
-    // вместо:
-    // Uprgades.enableFlatDesign();
-    ThemeFactory.overrideDefaultTheme(FLAT_THEME);
-    ```
+   // вместо:
+   // Uprgades.enableFlatDesign();
+   ThemeFactory.overrideDefaultTheme(FLAT_THEME);
+   ```
 
 ### Отказ от less
 

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -11,6 +11,11 @@ Button has different use styles
 
 ```jsx harmony
 import { Gapped } from '@skbkontur/react-ui';
+import { ThemeFactory } from '@skbkontur/react-ui/lib/theming/ThemeFactory';
+
+ThemeFactory.overrideDefaultTheme({
+  btnSmallBorderRadius: '5px'
+});
 
 <Gapped>
   <Button use="default">Default</Button>

--- a/packages/react-ui/components/Button/Button.mixins.ts
+++ b/packages/react-ui/components/Button/Button.mixins.ts
@@ -1,4 +1,4 @@
-import { css } from '../../lib/theming/Emotion';
+import { cssFromCache as css } from '../../lib/theming/Emotion';
 import { shift } from '../../lib/styles/DimensionFunctions';
 
 const getBtnPadding = (fontSize: string, paddingY: string, paddingX: string, additionalOffset = 0): string => {

--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -1,14 +1,14 @@
-import { css, cssName, keyframes, memoizeStyle } from '../../lib/theming/Emotion';
-import { Theme } from '../../lib/theming/Theme';
 import { resetButton, resetText } from '../../lib/styles/Mixins';
+import { cssName, GrandStyles, keyframes } from '../../lib/theming/Emotion';
+import { Theme } from '../../lib/theming/Theme';
 
 import {
-  buttonUseMixin,
-  buttonHoverMixin,
   buttonActiveMixin,
-  buttonSizeMixin,
   buttonArrowMixin,
+  buttonHoverMixin,
   buttonLoadingArrowMixin,
+  buttonSizeMixin,
+  buttonUseMixin,
 } from './Button.mixins';
 
 const btn_loading_arrow = keyframes`
@@ -21,9 +21,9 @@ const btn_loading_arrow = keyframes`
 }
 `;
 
-const styles = {
+export class Styles extends GrandStyles {
   root(t: Theme) {
-    return css`
+    return this.css`
       ${resetButton()};
       ${resetText()};
 
@@ -48,22 +48,22 @@ const styles = {
         vertical-align: baseline;
         width: 0;
       }
-      &:not(${cssName(styles.sizeSmall(t))}) {
+      &:not(${cssName(this.sizeSmall(t))}) {
         border-radius: ${t.btnBorderRadius};
       }
-      ${cssName(styles.link(t))}& {
+      ${cssName(this.link(t))}& {
         padding: 0;
       }
-      &:active:not(${cssName(styles.link(t))}):not(${cssName(styles.disabled(t))}) {
-        ${cssName(styles.caption())} {
+      &:active:not(${cssName(this.link(t))}):not(${cssName(this.disabled(t))}) {
+        ${cssName(this.caption())} {
           transform: translateY(1px) !important;
         }
       }
     `;
-  },
+  }
 
   warning(t: Theme) {
-    return css`
+    return this.css`
       border-radius: inherit;
       position: absolute;
       top: 0;
@@ -72,10 +72,10 @@ const styles = {
       right: 0;
       box-shadow: 0 0 0 2px ${t.borderColorWarning};
     `;
-  },
+  }
 
   error(t: Theme) {
-    return css`
+    return this.css`
       border-radius: inherit;
       position: absolute;
       top: 0;
@@ -84,10 +84,10 @@ const styles = {
       right: 0;
       box-shadow: 0 0 0 2px ${t.borderColorError};
     `;
-  },
+  }
 
   sizeSmall(t: Theme) {
-    return css`
+    return this.css`
       border-radius: ${t.btnSmallBorderRadius};
 
       ${buttonSizeMixin(
@@ -97,11 +97,11 @@ const styles = {
         t.controlLineHeightSmall,
         t.btnPaddingXSmall,
         t.btnPaddingYSmall,
-        cssName(styles.link(t)),
-        cssName(styles.fallback(t)),
+        cssName(this.link(t)),
+        cssName(this.fallback(t)),
       )};
 
-      ${cssName(styles.arrow())} {
+      ${cssName(this.arrow())} {
         border-radius: ${t.btnSmallArrowBorderRadius};
       }
 
@@ -111,14 +111,14 @@ const styles = {
         t.btnSmallArrowRight,
         t.btnSmallArrowLength,
         'rotate(53deg) skewX(24deg) skewY(10deg)',
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   sizeMedium(t: Theme) {
-    return css`
+    return this.css`
       ${buttonSizeMixin(
         t.btnFontSizeMedium,
         t.controlHeightMedium,
@@ -126,8 +126,8 @@ const styles = {
         t.controlLineHeightMedium,
         t.btnPaddingXMedium,
         t.btnPaddingYMedium,
-        cssName(styles.link(t)),
-        cssName(styles.fallback(t)),
+        cssName(this.link(t)),
+        cssName(this.fallback(t)),
       )};
 
       ${buttonArrowMixin(
@@ -136,14 +136,14 @@ const styles = {
         t.btnMediumArrowRight,
         '20.2px',
         t.btnMediumArrowTransform,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   sizeLarge(t: Theme) {
-    return css`
+    return this.css`
       ${buttonSizeMixin(
         t.btnFontSizeLarge,
         t.controlHeightLarge,
@@ -151,8 +151,8 @@ const styles = {
         t.controlLineHeightLarge,
         t.btnPaddingXLarge,
         t.btnPaddingYLarge,
-        cssName(styles.link(t)),
-        cssName(styles.fallback(t)),
+        cssName(this.link(t)),
+        cssName(this.fallback(t)),
       )};
 
       ${buttonArrowMixin(
@@ -161,14 +161,14 @@ const styles = {
         '-10.8px',
         '22.2px',
         t.btnLargeArrowTransform,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   sizeSmallLoading(t: Theme) {
-    return css`
+    return this.css`
       ${buttonLoadingArrowMixin(
         t.btnSmallArrowTop,
         t.btnSmallArrowTop,
@@ -177,14 +177,14 @@ const styles = {
         t.btnSmallArrowBg,
         t.btnSmallArrowLeftLoadingDelay,
         btn_loading_arrow,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   sizeMediumLoading(t: Theme) {
-    return css`
+    return this.css`
       ${buttonLoadingArrowMixin(
         '0',
         '0',
@@ -193,14 +193,14 @@ const styles = {
         t.btnMediumArrowBg,
         t.btnMediumArrowLeftLoadingDelay,
         btn_loading_arrow,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   sizeLargeLoading(t: Theme) {
-    return css`
+    return this.css`
       ${buttonLoadingArrowMixin(
         '-32px',
         '-36px',
@@ -209,14 +209,14 @@ const styles = {
         t.btnLargeArrowBg,
         t.btnLargeArrowLeftLoadingDelay,
         btn_loading_arrow,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   link(t: Theme) {
-    return css`
+    return this.css`
       background: none;
       border-radius: ${t.btnLinkBorderRadius} !important;
       border: none;
@@ -234,131 +234,131 @@ const styles = {
       &:active {
         color: ${t.linkActiveColor} !important;
       }
-      ${cssName(styles.caption())} {
+      ${cssName(this.caption())} {
         display: inline;
       }
-      ${cssName(styles.icon())} {
+      ${cssName(this.icon())} {
         padding-right: ${t.linkIconMarginRight};
       }
-      ${cssName(styles.warning(t))} ,
-      ${cssName(styles.error(t))}  {
+      ${cssName(this.warning(t))} ,
+      ${cssName(this.error(t))}  {
         box-shadow: none;
         left: -2px !important;
         right: -2px !important;
         bottom: -2px !important;
       }
-      ${cssName(styles.error(t))}  {
+      ${cssName(this.error(t))}  {
         background: ${t.errorSecondary} !important;
       }
     `;
-  },
+  }
 
   focus(t: Theme) {
-    return css`
+    return this.css`
       position: relative;
       z-index: 2;
 
-      &${cssName(styles.link(t))} {
+      &${cssName(this.link(t))} {
         color: ${t.linkColor};
         text-decoration: ${t.linkHoverTextDecoration};
       }
 
-      &:not(${cssName(styles.disabled(t))}):not(${cssName(styles.link(t))}) {
+      &:not(${cssName(this.disabled(t))}):not(${cssName(this.link(t))}) {
         border: ${t.btnFocusBorder};
 
         &,
         &:hover,
         &:active,
-        ${cssName(styles.active(t))} {
+        ${cssName(this.active(t))} {
           box-shadow: inset 0 0 0 1px ${t.outlineColorFocus}, 0 0 0 ${t.btnFocusShadowWidth} ${t.borderColorFocus};
 
-          &${cssName(styles.warning(t))}, &${cssName(styles.error(t))} {
+          &${cssName(this.warning(t))}, &${cssName(this.error(t))} {
             box-shadow: inset 0 0 0 1px ${t.outlineColorFocus} !important;
             border-color: transparent !important;
           }
-          ${cssName(styles.arrow())} {
+          ${cssName(this.arrow())} {
             box-shadow: inset -1px 1px 0 0 ${t.outlineColorFocus}, 2px -2px 0 0 ${t.borderColorFocus};
 
-            &${cssName(styles.arrowWarning(t))} {
+            &${cssName(this.arrowWarning(t))} {
               box-shadow: inset -1px 1px 0 0 ${t.outlineColorFocus}, 2px -2px 0 0 ${t.borderColorWarning} !important;
             }
 
-            &${cssName(styles.arrowError(t))} {
+            &${cssName(this.arrowError(t))} {
               box-shadow: inset -1px 1px 0 0 ${t.outlineColorFocus}, 2px -2px 0 0 ${t.borderColorError} !important;
             }
           }
         }
       }
     `;
-  },
+  }
 
   disabled(t: Theme) {
-    return css`
+    return this.css`
       cursor: default;
       pointer-events: none;
       border-color: transparent !important;
 
-      &:not(${cssName(styles.link(t))}) {
+      &:not(${cssName(this.link(t))}) {
         background: ${t.btnDisabledBg} !important;
         color: ${t.btnDisabledTextColor} !important;
         box-shadow: ${t.btnDisabledShadow} !important;
 
-        ${cssName(styles.arrow())} {
+        ${cssName(this.arrow())} {
           background: ${t.btnDisabledBg} !important;
           box-shadow: ${t.btnDisabledShadowArrow} !important;
         }
       }
 
-      &${cssName(styles.link(t))} {
+      &${cssName(this.link(t))} {
         color: ${t.linkDisabledColor} !important;
       }
     `;
-  },
+  }
 
   fallback(t: Theme) {
-    return css`
-      &${cssName(styles.disabled(t))} {
+    return this.css`
+      &${cssName(this.disabled(t))} {
         outline-color: transparent;
       }
-      &:not(${cssName(styles.link(t))}) {
+      &:not(${cssName(this.link(t))}) {
         line-height: normal !important;
       }
     `;
-  },
+  }
 
   validationRoot(t: Theme) {
-    return css`
-      ${cssName(styles.focus(t))} {
+    return this.css`
+      ${cssName(this.focus(t))} {
         box-shadow: inset 0 0 0 1px ${t.outlineColorFocus};
         border-color: transparent !important;
       }
     `;
-  },
+  }
 
   arrowWarning(t: Theme) {
-    return css`
+    return this.css`
       box-shadow: 2px -2px 0 0 ${t.borderColorWarning} !important;
     `;
-  },
+  }
 
   arrowError(t: Theme) {
-    return css`
+    return this.css`
       box-shadow: 2px -2px 0 0 ${t.borderColorError} !important;
     `;
-  },
+  }
 
   arrowLeft(t: Theme) {
-    return css`
+    return this.css`
       visibility: visible;
 
-      ${cssName(styles.checked(t))}:not(${cssName(styles.focus(t))}) & {
+      ${cssName(this.checked(t))}:not(${cssName(this.focus(t))}) & {
         box-shadow: ${t.btnCheckedShadowArrowLeft} !important;
       }
     `;
-  },
+  }
 
   default(t: Theme) {
-    return css`
+    return this.css`
       ${buttonUseMixin(
         t.btnDefaultBg,
         t.btnDefaultBgStart,
@@ -370,9 +370,9 @@ const styles = {
         t.btnDefaultShadowArrowLeft,
         t.btnDefaultTextColor,
         t.btnDefaultBorder,
-        cssName(styles.checked(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.checked(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonHoverMixin(
@@ -385,8 +385,8 @@ const styles = {
         t.btnDefaultHoverShadowArrow,
         t.btnDefaultHoverShadowArrowLeft,
         t.btnDefaultHoverBorderColor,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonActiveMixin(
@@ -396,15 +396,15 @@ const styles = {
         t.btnDefaultActiveShadow,
         t.btnDefaultActiveShadowArrow,
         t.btnDefaultActiveShadowArrowLeft,
-        cssName(styles.active(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.active(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   primary(t: Theme) {
-    return css`
+    return this.css`
       ${buttonUseMixin(
         t.btnPrimaryBg,
         t.btnPrimaryBgStart,
@@ -416,9 +416,9 @@ const styles = {
         t.btnPrimaryShadowArrowLeft,
         t.btnPrimaryTextColor,
         t.btnPrimaryBorder,
-        cssName(styles.checked(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.checked(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonHoverMixin(
@@ -431,8 +431,8 @@ const styles = {
         t.btnPrimaryHoverShadowArrow,
         t.btnPrimaryHoverShadowArrowLeft,
         t.btnPrimaryHoverBorderColor,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonActiveMixin(
@@ -442,15 +442,15 @@ const styles = {
         t.btnPrimaryActiveShadow,
         t.btnPrimaryActiveShadowArrow,
         t.btnPrimaryActiveShadowArrowLeft,
-        cssName(styles.active(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.active(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   success(t: Theme) {
-    return css`
+    return this.css`
       ${buttonUseMixin(
         t.btnSuccessBg,
         t.btnSuccessBgStart,
@@ -462,9 +462,9 @@ const styles = {
         t.btnSuccessShadowArrowLeft,
         t.btnSuccessTextColor,
         t.btnSuccessBorder,
-        cssName(styles.checked(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.checked(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonHoverMixin(
@@ -477,8 +477,8 @@ const styles = {
         t.btnSuccessHoverShadowArrow,
         t.btnSuccessHoverShadowArrowLeft,
         t.btnSuccessHoverBorderColor,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonActiveMixin(
@@ -488,15 +488,15 @@ const styles = {
         t.btnSuccessActiveShadow,
         t.btnSuccessActiveShadowArrow,
         t.btnSuccessActiveShadowArrowLeft,
-        cssName(styles.active(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.active(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   danger(t: Theme) {
-    return css`
+    return this.css`
       ${buttonUseMixin(
         t.btnDangerBg,
         t.btnDangerBgStart,
@@ -508,9 +508,9 @@ const styles = {
         t.btnDangerShadowArrowLeft,
         t.btnDangerTextColor,
         t.btnDangerBorder,
-        cssName(styles.checked(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.checked(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonHoverMixin(
@@ -523,8 +523,8 @@ const styles = {
         t.btnDangerHoverShadowArrow,
         t.btnDangerHoverShadowArrowLeft,
         t.btnDangerHoverBorderColor,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonActiveMixin(
@@ -534,15 +534,15 @@ const styles = {
         t.btnDangerActiveShadow,
         t.btnDangerActiveShadowArrow,
         t.btnDangerActiveShadowArrowLeft,
-        cssName(styles.active(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.active(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   pay(t: Theme) {
-    return css`
+    return this.css`
       ${buttonUseMixin(
         t.btnPayBg,
         t.btnPayBgStart,
@@ -554,9 +554,9 @@ const styles = {
         t.btnPayShadowArrowLeft,
         t.btnPayTextColor,
         t.btnPayBorder,
-        cssName(styles.checked(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.checked(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonHoverMixin(
@@ -569,8 +569,8 @@ const styles = {
         t.btnPayHoverShadowArrow,
         t.btnPayHoverShadowArrowLeft,
         t.btnPayHoverBorderColor,
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
 
       ${buttonActiveMixin(
@@ -580,135 +580,135 @@ const styles = {
         t.btnPayActiveShadow,
         t.btnPayActiveShadowArrow,
         t.btnPayActiveShadowArrowLeft,
-        cssName(styles.active(t)),
-        cssName(styles.arrow()),
-        cssName(styles.arrowLeft(t)),
+        cssName(this.active(t)),
+        cssName(this.arrow()),
+        cssName(this.arrowLeft(t)),
       )};
     `;
-  },
+  }
 
   checked(t: Theme) {
-    return css`
+    return this.css`
       box-shadow: ${t.btnCheckedShadow} !important;
       background: ${t.btnCheckedBg} !important;
       color: ${t.btnCheckedTextColor} !important;
       border: ${t.btnDefaultCheckedBorder} !important;
 
-      &:not(${cssName(styles.link(t))}):not(${cssName(styles.disabled(t))}) {
-        ${cssName(styles.caption())} {
+      &:not(${cssName(this.link(t))}):not(${cssName(this.disabled(t))}) {
+        ${cssName(this.caption())} {
           transform: translateY(1px) !important;
         }
       }
 
       &,
-      &:not(${cssName(styles.focus(t))}) {
-        ${cssName(styles.arrow())} {
+      &:not(${cssName(this.focus(t))}) {
+        ${cssName(this.arrow())} {
           background: ${t.btnCheckedBg} !important;
           box-shadow: ${t.btnCheckedShadowArrow} !important;
         }
       }
     `;
-  },
+  }
 
   active(t: Theme) {
-    return css`
-      &:not(${cssName(styles.link(t))}):not(${cssName(styles.disabled(t))}) {
-        ${cssName(styles.caption())} {
+    return this.css`
+      &:not(${cssName(this.link(t))}):not(${cssName(this.disabled(t))}) {
+        ${cssName(this.caption())} {
           transform: translateY(1px) !important;
         }
       }
     `;
-  },
+  }
 
   caption() {
-    return css`
+    return this.css`
       position: relative;
       white-space: nowrap;
       display: inline-block;
       width: 100%;
       vertical-align: top;
     `;
-  },
+  }
 
   wrap(t: Theme) {
-    return css`
+    return this.css`
       padding: ${t.btnWrapPadding};
       box-sizing: border-box;
       display: inline-block;
     `;
-  },
+  }
 
   narrow() {
-    return css`
+    return this.css`
       padding-left: 5px !important;
       padding-right: 5px !important;
     `;
-  },
+  }
 
   noPadding() {
-    return css`
+    return this.css`
       padding-left: 0 !important;
       padding-right: 0 !important;
     `;
-  },
+  }
 
   noRightPadding() {
-    return css`
+    return this.css`
       padding-right: 0 !important;
     `;
-  },
+  }
 
   wrapLink(t: Theme) {
-    return css`
-      ${styles.wrap(t)};
+    return this.css`
+      ${this.wrap(t)};
 
       padding: 0;
     `;
-  },
+  }
 
   wrapArrow() {
-    return css`
+    return this.css`
       margin-right: 10px;
     `;
-  },
+  }
 
   wrapArrowLeft() {
-    return css`
+    return this.css`
       margin-right: 0;
       margin-left: 10px;
     `;
-  },
+  }
 
   arrow() {
-    return css`
+    return this.css`
       position: absolute;
       border-radius: 2px 2px 2px 16px;
       box-sizing: border-box;
       z-index: 1;
     `;
-  },
+  }
 
   icon() {
-    return css`
+    return this.css`
       display: inline-block;
       padding-right: 7px;
     `;
-  },
+  }
 
   buttonWithIcon() {
-    return css`
+    return this.css`
       padding-right: 15px;
       padding-left: 15px;
     `;
-  },
+  }
 
   borderless(t: Theme) {
-    const focus = cssName(styles.focus(t));
-    const disabled = cssName(styles.disabled(t));
-    const checked = cssName(styles.checked(t));
-    const active = cssName(styles.active(t));
+    const focus = cssName(this.focus(t));
+    const disabled = cssName(this.disabled(t));
+    const checked = cssName(this.checked(t));
+    const active = cssName(this.active(t));
 
-    return css`
+    return this.css`
       &:not(${focus}):not(${disabled}):not(${active}):not(${checked}) {
         &,
         &:hover,
@@ -717,7 +717,7 @@ const styles = {
         }
       }
     `;
-  },
+  }
 
   loading() {
     const btn_loading = keyframes`
@@ -729,7 +729,7 @@ const styles = {
       transform: translateX(-30px) rotateY(180deg);
     }
   `;
-    return css`
+    return this.css`
       position: absolute;
       top: 0;
       bottom: 0;
@@ -752,7 +752,5 @@ const styles = {
         transform: rotateY(180deg);
       }
     `;
-  },
-};
-
-export const jsStyles = memoizeStyle(styles);
+  }
+}

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import cn from 'classnames';
 
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 import { isIE11, isEdge } from '../../lib/utils';
 import { tabListener } from '../../lib/events/tabListener';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 
-import { jsStyles } from './Button.styles';
+import { Styles } from './Button.styles';
 import { Corners } from './Corners';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
@@ -157,6 +158,8 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
   }
 
   private renderMain() {
+    const jsStyles = getJsStyles(Button, Styles, this.theme);
+
     const { corners = 0 } = this.props;
     const sizeClass = this.getSizeClassName();
 
@@ -282,6 +285,8 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
   }
 
   private getSizeClassName() {
+    const jsStyles = getJsStyles(Button, Styles, this.theme);
+
     switch (this.props.size) {
       case 'large':
         return cn(jsStyles.sizeLarge(this.theme), {

--- a/packages/react-ui/components/Input/Input.styles.ts
+++ b/packages/react-ui/components/Input/Input.styles.ts
@@ -1,11 +1,11 @@
-import { css, cssName, keyframes, memoizeStyle } from '../../lib/theming/Emotion';
+import { cssName, GrandStyles, keyframes } from '../../lib/theming/Emotion';
 import { Theme } from '../../lib/theming/Theme';
 import { shift } from '../../lib/styles/DimensionFunctions';
 import { resetText } from '../../lib/styles/Mixins';
 
-const styles = {
+export class Styles extends GrandStyles {
   wrapper() {
-    return css`
+    return this.css`
       align-items: center;
       display: flex;
       margin: 0;
@@ -22,10 +22,10 @@ const styles = {
         width: 0;
       }
     `;
-  },
+  }
 
   root(t: Theme) {
-    return css`
+    return this.css`
       ${resetText()};
 
       align-items: center;
@@ -46,49 +46,49 @@ const styles = {
         box-sizing: border-box;
       }
     `;
-  },
+  }
 
   borderless() {
-    return css`
+    return this.css`
       box-shadow: none;
       border-color: transparent;
     `;
-  },
+  }
 
   useDefaultColor(t: Theme) {
-    return css`
+    return this.css`
       color: ${t.inputIconColor};
     `;
-  },
+  }
 
   focus(t: Theme) {
-    return css`
+    return this.css`
       border-color: ${t.borderColorFocus};
       box-shadow: ${t.inputFocusShadow};
       outline: none;
       z-index: 2;
 
-      ${cssName(styles.input(t))}:-moz-placeholder {
+      ${cssName(this.input(t))}:-moz-placeholder {
         color: ${t.placeholderColorLight};
       }
-      ${cssName(styles.input(t))}::-moz-placeholder {
+      ${cssName(this.input(t))}::-moz-placeholder {
         color: ${t.placeholderColorLight};
       }
-      ${cssName(styles.input(t))}::placeholder {
+      ${cssName(this.input(t))}::placeholder {
         color: ${t.placeholderColorLight};
       }
     `;
-  },
+  }
 
   focusFallback(t: Theme) {
-    return css`
+    return this.css`
       box-shadow: none;
       outline: 1px solid ${t.inputFocusOutline};
     `;
-  },
+  }
 
   placeholder(t: Theme) {
-    return css`
+    return this.css`
       -ms-user-select: none;
       color: ${t.placeholderColor};
       cursor: text;
@@ -103,14 +103,14 @@ const styles = {
       white-space: nowrap;
       width: 100%;
 
-      ${cssName(styles.focus(t))} & {
+      ${cssName(this.focus(t))} & {
         color: ${t.placeholderColorLight};
       }
     `;
-  },
+  }
 
   input(t: Theme) {
-    return css`
+    return this.css`
       -webkit-appearance: none;
       background: transparent;
       border: 0 none;
@@ -143,67 +143,67 @@ const styles = {
         color: ${t.placeholderColor};
       }
     `;
-  },
+  }
 
   warning(t: Theme) {
-    return css`
+    return this.css`
       & {
         border-color: ${t.borderColorWarning} !important;
         box-shadow: 0 0 0 1px ${t.borderColorWarning} !important;
         z-index: 2;
       }
     `;
-  },
+  }
 
   warningFallback(t: Theme) {
-    return css`
+    return this.css`
       box-shadow: none !important;
       outline: 1px solid ${t.borderColorWarning} !important;
     `;
-  },
+  }
 
   error(t: Theme) {
-    return css`
+    return this.css`
       border-color: ${t.borderColorError} !important;
       box-shadow: 0 0 0 1px ${t.borderColorError} !important;
       z-index: 2;
     `;
-  },
+  }
 
   errorFallback(t: Theme) {
-    return css`
+    return this.css`
       box-shadow: none !important;
       outline: 1px solid ${t.borderColorError} !important;
     `;
-  },
+  }
 
   disabled(t: Theme) {
-    return css`
+    return this.css`
       background: ${t.inputDisabledBg};
       border-color: ${t.inputDisabledBorderColor} !important;
       box-shadow: none;
 
-      ${cssName(styles.leftIcon())},
-      ${cssName(styles.rightIcon())} {
+      ${cssName(this.leftIcon())},
+      ${cssName(this.rightIcon())} {
         cursor: default;
       }
-      ${cssName(styles.input(t))} {
+      ${cssName(this.input(t))} {
         color: ${t.textColorDisabled};
         pointer-events: none;
         /* fix text color in safari */
         -webkit-text-fill-color: currentcolor;
       }
-      ${cssName(styles.input(t))}:-moz-placeholder {
+      ${cssName(this.input(t))}:-moz-placeholder {
         -webkit-text-fill-color: ${t.placeholderColor};
       }
-      ${cssName(styles.input(t))}::-moz-placeholder {
+      ${cssName(this.input(t))}::-moz-placeholder {
         -webkit-text-fill-color: ${t.placeholderColor};
       }
-      ${cssName(styles.input(t))}::placeholder {
+      ${cssName(this.input(t))}::placeholder {
         -webkit-text-fill-color: ${t.placeholderColor};
       }
     `;
-  },
+  }
 
   blink(t: Theme) {
     const blinkAnimation = keyframes`
@@ -211,13 +211,13 @@ const styles = {
       background-color: ${t.blinkColor};
     }
   `;
-    return css`
+    return this.css`
       animation: ${blinkAnimation} 0.15s ease-in;
     `;
-  },
+  }
 
   sizeSmall(t: Theme) {
-    return css`
+    return this.css`
       & {
         font-size: ${t.inputFontSizeSmall};
         line-height: ${t.controlLineHeightSmall} !important;
@@ -226,66 +226,66 @@ const styles = {
         height: ${t.controlHeightSmall};
       }
     `;
-  },
+  }
 
   sizeSmallFallback(t: Theme) {
-    return css`
+    return this.css`
       padding-top: ${shift(t.controlPaddingYSmall, '-1')};
       padding-bottom: ${shift(t.controlPaddingYSmall, '1')};
       line-height: normal !important;
     `;
-  },
+  }
 
   sizeMedium(t: Theme) {
-    return css`
+    return this.css`
       font-size: ${t.inputFontSizeMedium};
       line-height: ${t.controlLineHeightMedium} !important;
       padding-top: ${t.controlPaddingYMedium};
       padding-bottom: ${t.controlPaddingYMedium};
       height: ${t.controlHeightMedium};
     `;
-  },
+  }
 
   sizeMediumFallback(t: Theme) {
-    return css`
+    return this.css`
       padding-top: ${shift(t.controlPaddingYMedium, '-1')};
       padding-bottom: ${shift(t.controlPaddingYMedium, '1')};
       line-height: normal !important;
     `;
-  },
+  }
 
   sizeLarge(t: Theme) {
-    return css`
+    return this.css`
       font-size: ${t.inputFontSizeLarge};
       line-height: ${t.controlLineHeightLarge} !important;
       height: ${t.controlHeightLarge};
       padding-top: ${shift(t.controlPaddingYLarge, '-1')};
       padding-bottom: ${shift(t.controlPaddingYLarge, '1')};
     `;
-  },
+  }
 
   sizeLargeFallback(t: Theme) {
-    return css`
+    return this.css`
       padding-top: ${shift(t.controlPaddingYLarge, '-2')};
       padding-bottom: ${shift(t.controlPaddingYLarge, '2')};
       line-height: normal !important;
     `;
-  },
+  }
 
   prefix(t: Theme) {
-    return css`
+    return this.css`
       color: ${t.placeholderColor};
     `;
-  },
+  }
 
   suffix(t: Theme) {
-    return css`
+    return this.css`
       color: ${t.placeholderColor};
     `;
-  },
+  }
 
   sideContainer() {
-    return css`
+    return this.css`
       align-items: center;
       display: flex;
       flex-shrink: 0;
@@ -299,34 +299,32 @@ const styles = {
         width: 0;
       }
     `;
-  },
+  }
 
   rightContainer() {
-    return css`
+    return this.css`
       justify-self: flex-end;
       margin: 0 0 0 auto;
       padding-left: 0;
       padding-right: 10px;
     `;
-  },
+  }
 
   leftIcon() {
-    return css`
+    return this.css`
       padding-right: 2px;
       flex-shrink: 0;
       cursor: text;
       z-index: 2;
     `;
-  },
+  }
 
   rightIcon() {
-    return css`
+    return this.css`
       padding-left: 2px;
       flex-shrink: 0;
       cursor: text;
       z-index: 2;
     `;
-  },
-};
-
-export const jsStyles = memoizeStyle(styles);
+  }
+}

--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import raf from 'raf';
 import cn from 'classnames';
 
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 import { isIE11, isEdge } from '../../lib/utils';
 import { isKeyBackspace, isKeyDelete, someKeys } from '../../lib/events/keyboard/identifiers';
 import { polyfillPlaceholder } from '../../lib/polyfillPlaceholder';
@@ -11,7 +12,7 @@ import { MaskedInput } from '../../internal/MaskedInput';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 
-import { jsStyles } from './Input.styles';
+import { Styles } from './Input.styles';
 
 export type InputSize = 'small' | 'medium' | 'large';
 export type InputAlign = 'left' | 'center' | 'right';
@@ -274,6 +275,7 @@ export class Input extends React.Component<InputProps, InputState> {
     } = this.props;
 
     const { blinking, focused } = this.state;
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
 
     const labelProps = {
       className: cn(jsStyles.root(this.theme), this.getSizeClassName(), {
@@ -356,10 +358,12 @@ export class Input extends React.Component<InputProps, InputState> {
   }
 
   private renderLeftIcon() {
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
     return this.renderIcon(this.props.leftIcon, jsStyles.leftIcon());
   }
 
   private renderRightIcon() {
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
     return this.renderIcon(this.props.rightIcon, jsStyles.rightIcon());
   }
 
@@ -372,6 +376,8 @@ export class Input extends React.Component<InputProps, InputState> {
       return <span className={className}>{icon()}</span>;
     }
 
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
+
     return (
       <span className={cn(className, jsStyles.useDefaultColor(this.theme), jsStyles.useDefaultColor(this.theme))}>
         {icon}
@@ -381,6 +387,7 @@ export class Input extends React.Component<InputProps, InputState> {
 
   private renderPlaceholder() {
     let placeholder = null;
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
 
     if (this.state.polyfillPlaceholder && this.props.placeholder && !this.isMaskVisible && !this.props.value) {
       placeholder = (
@@ -397,6 +404,7 @@ export class Input extends React.Component<InputProps, InputState> {
   }
 
   private getSizeClassName() {
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
     switch (this.props.size) {
       case 'large':
         return { [jsStyles.sizeLarge(this.theme)]: true, [jsStyles.sizeLargeFallback(this.theme)]: isIE11 || isEdge };
@@ -494,6 +502,7 @@ export class Input extends React.Component<InputProps, InputState> {
 
   private renderPrefix = () => {
     const { prefix } = this.props;
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
 
     if (!prefix) {
       return null;
@@ -504,6 +513,7 @@ export class Input extends React.Component<InputProps, InputState> {
 
   private renderSuffix = () => {
     const { suffix } = this.props;
+    const jsStyles = getJsStyles(Input, Styles, this.theme);
 
     if (!suffix) {
       return null;

--- a/packages/react-ui/components/Input/__tests__/Input-test.tsx
+++ b/packages/react-ui/components/Input/__tests__/Input-test.tsx
@@ -2,9 +2,14 @@ import React from 'react';
 import { mount } from 'enzyme';
 import MaskedInput from 'react-input-mask';
 
+import { overrideDefaultTheme } from '../../../lib/theming/ThemeContext';
+import { getJsStyles } from '../../../lib/theming/ThemeCache';
 import { DEFAULT_THEME } from '../../../lib/theming/themes/DefaultTheme';
 import { Input, InputProps } from '../Input';
-import { jsStyles } from '../Input.styles';
+import { Styles } from '../Input.styles';
+
+overrideDefaultTheme({});
+const jsStyles = getJsStyles(Input, Styles);
 
 const render = (props: InputProps) => mount<Input, InputProps>(React.createElement(Input, props));
 
@@ -45,6 +50,7 @@ describe('<Input />', () => {
   });
 
   it('applies error styles on error prop', () => {
+    console.log('jsStyles', jsStyles);
     const wrapper = render({ value: '', error: true });
     expect(wrapper.find(`.${jsStyles.error(DEFAULT_THEME as any)}`)).toHaveLength(1);
   });

--- a/packages/react-ui/components/TopBar/TopBar.styles.ts
+++ b/packages/react-ui/components/TopBar/TopBar.styles.ts
@@ -1,50 +1,50 @@
-import { css, cssName, memoizeStyle } from '../../lib/theming/Emotion';
+import { cssName, GrandStyles } from '../../lib/theming/Emotion';
 import { Theme } from '../../lib/theming/Theme';
 
-const styles = {
+export class Styles extends GrandStyles {
   root(t: Theme) {
-    return css`
+    return this.css`
       background: ${t.tbBg};
       box-shadow: ${t.tbShadow};
       height: 50px;
       margin-bottom: 20px;
       padding: 0 15px;
     `;
-  },
+  }
 
   divider(t: Theme) {
-    return css`
+    return this.css`
       align-self: center;
       background-color: ${t.tdDividerBg};
       height: 30px;
       width: 1px;
     `;
-  },
+  }
 
   endItems() {
-    return css`
+    return this.css`
       align-items: stretch;
       display: flex;
       flex-wrap: nowrap;
     `;
-  },
+  }
 
   startItems() {
-    return css`
-      ${styles.endItems()};
+    return this.css`
+      ${cssName(this.endItems())};
 
       padding-right: 60px;
     `;
-  },
+  }
 
   buttonActive() {
-    return css`
+    return this.css`
       background: rgba(0, 0, 0, 0.06);
     `;
-  },
+  }
 
   button() {
-    return css`
+    return this.css`
       cursor: pointer;
       height: 50px;
       line-height: 50px;
@@ -62,76 +62,76 @@ const styles = {
         background: rgba(0, 0, 0, 0.06);
       }
     `;
-  },
+  }
 
   noShadow() {
-    return css`
-      ${styles.endItems()} & {
+    return this.css`
+      ${cssName(this.endItems())} & {
         box-shadow: none;
       }
     `;
-  },
+  }
 
   icon() {
-    return css`
+    return this.css`
       margin-right: 4px;
     `;
-  },
+  }
 
   iconOnly() {
-    return css`
+    return this.css`
       margin-right: 0;
     `;
-  },
+  }
 
   usePay() {
-    return css`
+    return this.css`
       &,
       &:hover,
-      ${cssName(styles.buttonActive())} {
+      ${cssName(this.buttonActive())} {
         background: #ffeca9;
       }
     `;
-  },
+  }
 
   useDanger() {
-    return css`
+    return this.css`
       &,
       &:hover,
-      ${cssName(styles.buttonActive())} {
+      ${cssName(this.buttonActive())} {
         background: #ffe3e3;
       }
     `;
-  },
+  }
 
   noMargin() {
-    return css`
+    return this.css`
       margin-bottom: 0;
     `;
-  },
+  }
 
   center() {
-    return css`
+    return this.css`
       margin: auto;
     `;
-  },
+  }
 
   containerWrap() {
-    return css`
+    return this.css`
       margin: 0 -10px;
     `;
-  },
+  }
 
   container() {
-    return css`
+    return this.css`
       display: flex;
       flex-wrap: nowrap;
       justify-content: space-between;
     `;
-  },
+  }
 
   item() {
-    return css`
+    return this.css`
       display: inline-block;
       box-sizing: border-box;
       height: 50px;
@@ -140,18 +140,18 @@ const styles = {
       vertical-align: middle;
       white-space: nowrap;
     `;
-  },
+  }
 
   spwDropdown() {
-    return css`
+    return this.css`
       display: table-cell;
       height: 50px;
       white-space: nowrap;
     `;
-  },
+  }
 
   organizationsTitle() {
-    return css`
+    return this.css`
       box-sizing: border-box;
       left: 0;
       overflow: hidden;
@@ -160,41 +160,39 @@ const styles = {
       text-overflow: ellipsis;
       width: 100%;
     `;
-  },
+  }
 
   organizationsComment() {
-    return css`
+    return this.css`
       color: #aaa;
       padding-left: 10px;
       position: absolute;
       right: 20px;
     `;
-  },
+  }
 
   organizationsArrow() {
-    return css`
+    return this.css`
       position: absolute;
       right: 0;
       text-align: center;
       width: 20px;
     `;
-  },
+  }
 
   organizationsTitleDummy() {
-    return css`
+    return this.css`
       box-sizing: border-box;
       height: 0;
       overflow: hidden;
       padding-right: 10px;
       white-space: normal;
     `;
-  },
+  }
 
   organizationsCommentDummy() {
-    return css`
+    return this.css`
       padding-left: 10px;
     `;
-  },
-};
-
-export const jsStyles = memoizeStyle(styles);
+  }
+}

--- a/packages/react-ui/components/TopBar/TopBar.tsx
+++ b/packages/react-ui/components/TopBar/TopBar.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import cn from 'classnames';
 
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 import { Logotype } from '../Logotype';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -16,7 +17,7 @@ import { TopBarUser } from './TopBarUser';
 import { TopBarEnd } from './TopBarEnd';
 import { TopBarStart } from './TopBarStart';
 import { TopBarLogout } from './TopBarLogout';
-import { jsStyles } from './TopBar.styles';
+import { Styles } from './TopBar.styles';
 
 export interface TopBarProps {
   children?: React.ReactNode;
@@ -174,6 +175,7 @@ export class TopBar extends React.Component<TopBarProps> {
     } = this.props;
 
     const _rightItems: Array<React.ReactElement<any>> = [...rightItems];
+    const jsStyles = getJsStyles(TopBar, Styles, this.theme);
 
     if (userName) {
       _rightItems.push(<TopBarUser userName={userName} cabinetUrl={cabinetUrl} />, <TopBarDivider />);

--- a/packages/react-ui/components/TopBar/TopBarButtonItem.tsx
+++ b/packages/react-ui/components/TopBar/TopBarButtonItem.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
 import { IconProps } from '../../internal/icons/20px';
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 
+import { TopBar } from './TopBar';
 import { TopBarItem, TopBarItemProps } from './TopBarItem';
-import { jsStyles } from "./TopBar.styles";
+import { Styles } from "./TopBar.styles";
 
 export interface TopBarButtonItemProps extends TopBarItemProps {
   active?: boolean;
@@ -27,6 +29,7 @@ export class TopBarButtonItem extends React.Component<TopBarButtonItemProps> {
   };
   public render() {
     const { onClick, children, onKeyDown, ...rest } = this.props;
+    const jsStyles = getJsStyles(TopBar, Styles);
     return (
       <TopBarItem {...rest} className={jsStyles.button()} _onKeyDown={onKeyDown} _onClick={onClick}>
         {children}

--- a/packages/react-ui/components/TopBar/TopBarDivider.tsx
+++ b/packages/react-ui/components/TopBar/TopBarDivider.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from 'react';
 
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 
-import { jsStyles } from './TopBar.styles';
+import { TopBar } from './TopBar';
+import { Styles } from './TopBar.styles';
 
 /**
  * Разделитель в топбаре
@@ -11,6 +13,7 @@ import { jsStyles } from './TopBar.styles';
  */
 function TopBarDivider() {
   const theme = useContext(ThemeContext);
+  const jsStyles = getJsStyles(TopBar, Styles, theme);
 
   return <span className={jsStyles.divider(theme)} />;
 }

--- a/packages/react-ui/components/TopBar/TopBarEnd.tsx
+++ b/packages/react-ui/components/TopBar/TopBarEnd.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { jsStyles } from "./TopBar.styles";
+import { getJsStyles } from '../../lib/theming/ThemeCache';
+
+import { TopBar } from './TopBar';
+import { Styles } from './TopBar.styles';
 
 /**
  * Контейнер для смещения к концу
@@ -8,5 +11,9 @@ import { jsStyles } from "./TopBar.styles";
  * @visibleName TopBar.End
  */
 
-export const TopBarEnd: React.SFC = ({ children }) => <div className={jsStyles.endItems()}>{children}</div>;
+export const TopBarEnd: React.SFC = ({ children }) => {
+  const jsStyles = getJsStyles(TopBar, Styles);
+
+  return <div className={jsStyles.endItems()}>{children}</div>;
+};
 (TopBarEnd as any).__KONTUR_REACT_UI__ = 'TopBarEnd';

--- a/packages/react-ui/components/TopBar/TopBarItem.tsx
+++ b/packages/react-ui/components/TopBar/TopBarItem.tsx
@@ -4,8 +4,10 @@ import cn from 'classnames';
 
 import { Icon, IconProps } from '../../internal/icons/20px';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 
-import { jsStyles } from './TopBar.styles';
+import { TopBar } from './TopBar';
+import { Styles } from './TopBar.styles';
 
 export interface TopBarItemProps {
   _onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
@@ -41,6 +43,7 @@ export class TopBarItem extends React.Component<TopBarItemProps> {
 
   public render() {
     const { active, children, _onClick, _onKeyDown, iconOnly, icon, minWidth, use, ...rest } = this.props;
+    const jsStyles = getJsStyles(TopBar, Styles);
 
     const className: string = this.getProps().className;
 

--- a/packages/react-ui/components/TopBar/TopBarOrganizations.tsx
+++ b/packages/react-ui/components/TopBar/TopBarOrganizations.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 import { Nullable } from '../../typings/utility-types';
 import { ArrowChevronDownIcon } from '../../internal/icons/16px';
 
+import { TopBar } from './TopBar';
 import { TopBarDropdown } from './TopBarDropdown';
-import { jsStyles } from "./TopBar.styles";
+import { Styles } from "./TopBar.styles";
 
 export interface TopBarOrganizationsProps {
   caption: React.ReactNode;
@@ -44,6 +46,7 @@ export class TopBarOrganizations extends React.Component<TopBarOrganizationsProp
 
   public render() {
     const { caption, comment } = this.props;
+    const jsStyles = getJsStyles(TopBar, Styles);
 
     const title = (
       <div>

--- a/packages/react-ui/components/TopBar/TopBarStart.tsx
+++ b/packages/react-ui/components/TopBar/TopBarStart.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { jsStyles } from "./TopBar.styles";
+import { getJsStyles } from '../../lib/theming/ThemeCache';
+
+import { TopBar } from './TopBar';
+import { Styles } from './TopBar.styles';
 
 /**
  * Контейнер для сдвига к началу
@@ -8,5 +11,8 @@ import { jsStyles } from "./TopBar.styles";
  * @visibleName TopBar.Start
  */
 
-export const TopBarStart: React.SFC = ({ children }) => <div className={jsStyles.startItems()}>{children}</div>;
+export const TopBarStart: React.SFC = ({ children }) => {
+  const jsStyles = getJsStyles(TopBar, Styles);
+  return <div className={jsStyles.startItems()}>{children}</div>;
+};
 (TopBarStart as any).__KONTUR_REACT_UI__ = 'TopBarStart';

--- a/packages/react-ui/components/TopBar/__tests__/TopBarDropdown-test.tsx
+++ b/packages/react-ui/components/TopBar/__tests__/TopBarDropdown-test.tsx
@@ -1,10 +1,14 @@
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 
+import { getJsStyles } from '../../../lib/theming/ThemeCache';
 import { MenuItem } from '../../MenuItem';
+import { TopBar } from '../TopBar';
 import { TopBarDropdown, TopBarDropdownProps } from '../TopBarDropdown';
 import { TopBarItem } from '../TopBarItem';
-import { jsStyles } from "../TopBar.styles";
+import { Styles } from "../TopBar.styles";
+
+const jsStyles = getJsStyles(TopBar, Styles);
 
 describe('TopBarDropdown', () => {
   describe('open/close methods', () => {

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -3,11 +3,12 @@ import cn from 'classnames';
 
 import { isKeyTab, isShortcutPaste } from '../../lib/events/keyboard/identifiers';
 import { MouseDrag, MouseDragEventHandler } from '../../lib/events/MouseDrag';
+import { getJsStyles } from '../../lib/theming/ThemeCache';
 import { isEdge, isIE11 } from '../../lib/utils';
 import { Nullable } from '../../typings/utility-types';
 import { removeAllSelections, selectNodeContents } from '../../components/DateInput/helpers/SelectionHelpers';
-import { InputProps, InputIconType, InputState } from '../../components/Input';
-import { jsStyles as jsInputStyles } from '../../components/Input/Input.styles';
+import { InputProps, InputIconType, InputState, Input } from '../../components/Input';
+import { Styles as InputStyles } from '../../components/Input/Input.styles';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 
@@ -24,6 +25,8 @@ export interface InputLikeTextProps extends InputProps {
 }
 
 export type InputLikeTextState = Omit<InputState, 'polyfillPlaceholder'>;
+
+const jsInputStyles = getJsStyles(Input, InputStyles);
 
 export class InputLikeText extends React.Component<InputLikeTextProps, InputLikeTextState> {
   public static __KONTUR_REACT_UI__ = 'InputLikeText';

--- a/packages/react-ui/internal/ThemePlayground/darkTheme.ts
+++ b/packages/react-ui/internal/ThemePlayground/darkTheme.ts
@@ -264,4 +264,4 @@ export const darkTheme = ThemeFactory.create({
   specificityLevel: '0',
   textareaBg: 'none',
   textareaColor: 'inherit',
-});
+}, 'dark');

--- a/packages/react-ui/lib/styles/Mixins.ts
+++ b/packages/react-ui/lib/styles/Mixins.ts
@@ -1,4 +1,4 @@
-import { css } from '../theming/Emotion';
+import { cssFromCache as css } from '../theming/Emotion';
 
 export const resetButton = () => {
   return css`

--- a/packages/react-ui/lib/theming/Theme.ts
+++ b/packages/react-ui/lib/theming/Theme.ts
@@ -3,3 +3,6 @@ import { FlatThemeInternal } from '../../internal/themes/FlatTheme';
 
 export type Theme = Readonly<typeof DefaultThemeInternal | typeof FlatThemeInternal>;
 export type ThemeIn = Partial<typeof DefaultThemeInternal>;
+
+export const DEFAULT_THEME_HASH = 'default';
+export const FLAT_THEME_HASH = 'flat';

--- a/packages/react-ui/lib/theming/ThemeCache.ts
+++ b/packages/react-ui/lib/theming/ThemeCache.ts
@@ -1,0 +1,63 @@
+import { SerializedStyles, EmotionCache, StyleSheet } from '@emotion/utils';
+import warning from 'warning';
+
+import { Constructor } from '../../typings/utility-types';
+
+import { createCache } from './Emotion';
+import { DEFAULT_THEME_HASH, Theme } from './Theme';
+
+export type EmotionCacheExtra = EmotionCache & {
+  // method `insert()` is not described in types
+  insert: (selector: string, serialized: SerializedStyles, sheet: StyleSheet, shouldCache: boolean) => void;
+};
+
+type Storage<S> = {
+  theme: Theme;
+  emotionCache: EmotionCacheExtra;
+  jsStylesOfComponents: Map<string, S>;
+};
+
+type ComponentTech = {
+  __KONTUR_REACT_UI__: string;
+};
+
+const themeCache = new Map();
+const HASH_KEY = '__REACT_UI_THEME_HASH__';
+
+export function setCache(theme: Theme, hash: string) {
+  Object.defineProperty(theme, HASH_KEY, {
+    value: hash,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  if (!themeCache.has(hash)) {
+    themeCache.set(hash, {
+      theme: theme,
+      emotionCache: createCache(hash),
+      jsStylesOfComponents: new Map(),
+    });
+  }
+}
+
+export function deleteCache(hash: string) {
+  themeCache.delete(hash);
+}
+
+export function setJsStyles<C extends ComponentTech, S>(component: C, styles: Constructor<S>, hash: string): void {
+  warning(component !== undefined, `Perhaps you are using the component until the module is finished loading.`);
+
+  const storage: Storage<S> = themeCache.get(hash)!;
+  const { jsStylesOfComponents, emotionCache, theme } = storage;
+
+  if (!jsStylesOfComponents.has(component.__KONTUR_REACT_UI__)) {
+    jsStylesOfComponents.set(component.__KONTUR_REACT_UI__, new styles(emotionCache, theme));
+  }
+}
+
+export function getJsStyles<C extends ComponentTech, S>(component: C, styles: Constructor<S>, theme?: any): S {
+  const hash = theme ? theme[HASH_KEY] : DEFAULT_THEME_HASH;
+  setJsStyles(component, styles, hash);
+
+  return themeCache.get(hash)!.jsStylesOfComponents.get(component.__KONTUR_REACT_UI__);
+}

--- a/packages/react-ui/lib/theming/ThemeContext.md
+++ b/packages/react-ui/lib/theming/ThemeContext.md
@@ -14,6 +14,26 @@ import { Button, ThemeContext, FLAT_THEME } from '@skbkontur/react-ui';
 </ThemeContext.Provider>;
 ```
 
+```jsx harmony
+import { ThemeContext, ThemeFactory, Button } from '@skbkontur/react-ui';
+import { ShowcaseGroup } from '@skbkontur/react-ui/internal/ThemePlayground/ShowcaseGroup';
+
+const myTheme = ThemeFactory.create({ btnSmallBorderRadius: '1px' });
+const myTheme2 = ThemeFactory.create({ btnSmallBorderRadius: '1px' });
+
+console.log(window.myTheme === myTheme);
+window.myTheme = myTheme;
+
+<ThemeContext.Provider value={myTheme}>
+  <Button>Ok</Button>
+  <ShowcaseGroup title="My Theme" />
+  <ThemeContext.Provider value={myTheme2}>
+    <Button>Ok</Button>
+    <ShowcaseGroup title="My Theme" />
+  </ThemeContext.Provider>
+</ThemeContext.Provider>;
+```
+
 Использовать тему в компоненте можно через `Consumer`:
 
 ```jsx static

--- a/packages/react-ui/lib/theming/ThemeContext.ts
+++ b/packages/react-ui/lib/theming/ThemeContext.ts
@@ -1,5 +1,11 @@
 import React from 'react';
 
+import { DEFAULT_THEME_HASH, ThemeIn } from './Theme';
+import { ThemeFactory } from './ThemeFactory';
 import { DEFAULT_THEME } from './themes/DefaultTheme';
 
-export const ThemeContext = React.createContext(DEFAULT_THEME);
+export let ThemeContext = React.createContext(DEFAULT_THEME);
+
+export const overrideDefaultTheme = (theme: ThemeIn) => {
+  ThemeContext = React.createContext(ThemeFactory.create(theme, DEFAULT_THEME_HASH));
+};

--- a/packages/react-ui/lib/theming/themes/DefaultTheme.ts
+++ b/packages/react-ui/lib/theming/themes/DefaultTheme.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_THEME_HASH } from '../Theme';
 import { ThemeFactory } from '../ThemeFactory';
 
-export const DEFAULT_THEME = ThemeFactory.create({});
+export const DEFAULT_THEME = ThemeFactory.create({}, DEFAULT_THEME_HASH);

--- a/packages/react-ui/lib/theming/themes/FlatTheme.ts
+++ b/packages/react-ui/lib/theming/themes/FlatTheme.ts
@@ -1,4 +1,5 @@
 import { FlatThemeInternal } from '../../../internal/themes/FlatTheme';
+import { FLAT_THEME_HASH } from '../Theme';
 import { ThemeFactory } from '../ThemeFactory';
 
-export const FLAT_THEME = ThemeFactory.create(FlatThemeInternal);
+export const FLAT_THEME = ThemeFactory.create(FlatThemeInternal, FLAT_THEME_HASH);

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -16,15 +16,15 @@ const platform = ((navigator && navigator.platform) || '').toLowerCase();
 const userAgent = ((navigator && navigator.userAgent) || '').toLowerCase();
 const vendor = ((navigator && navigator.vendor) || '').toLowerCase();
 
-export const isMac = platform.includes("mac");
-export const isWindows = platform.includes("win");
+export const isMac = platform.includes('mac');
+export const isWindows = platform.includes('win');
 
 export const isSafari = /version\/(\d+).+?safari/.test(userAgent);
 export const isFirefox = /(?:firefox|fxios)\/(\d+)/.test(userAgent);
 export const isOpera = /(?:^opera.+?version|opr)\/(\d+)/.test(userAgent);
-export const isChrome = vendor.includes("google inc") && /(?:chrome|crios)\/(\d+)/.test(userAgent) && !isOpera;
-export const isEdge = userAgent.includes("edge/");
-export const isIE11 = userAgent.includes("trident/");
+export const isChrome = vendor.includes('google inc') && /(?:chrome|crios)\/(\d+)/.test(userAgent) && !isOpera;
+export const isEdge = userAgent.includes('edge/');
+export const isIE11 = userAgent.includes('trident/');
 
 export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -72,9 +72,25 @@ export const hasSvgAnimationSupport = (() => {
     const element = document.createElementNS(namespaceURI, 'animate');
 
     if (element) {
-      return element.toString().includes("SVGAnimate");
+      return element.toString().includes('SVGAnimate');
     }
   }
 
   return false;
 })();
+
+export function getHashOfObject(obj: object = {}): string {
+  const str = JSON.stringify(obj);
+  let hash = 0;
+  const characters = 'abcdefghij';
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = (hash & hash) >>> 0;
+  }
+  return hash
+    .toString(10)
+    .split('')
+    .map(n => characters[Number(n)])
+    .join('');
+}

--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -4,6 +4,8 @@ import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 
+import { overrideDefaultTheme } from './lib/theming/ThemeContext';
+
 process.env.enableReactTesting = true;
 
 configure({ adapter: new Adapter() });

--- a/packages/react-ui/typings/utility-types.d.ts
+++ b/packages/react-ui/typings/utility-types.d.ts
@@ -12,3 +12,5 @@ export type Override<T, U> = Pick<T, Diff<keyof T, keyof U>> & U;
 export type Entries<T, K> = (o: { [k: string]: K }) => Array<[T, K]>;
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+export type Constructor<T> = new (...args: any[]) => T;


### PR DESCRIPTION
### Суть проблемы
Суть в том, что некоторые классы (стили) могут "поменять" приоритет в процессе кастомизации. Т.к. мы используем каскад, и обходим предостережение `emotion` так не делать, то наша вёртка завязана на порядок вычисление этих классов.

### Кратко о способе решения
Получается, что проблему можно решить, если для каждой темы заново вычислять все классы, чтобы, независимо от стилей классов, порядок добавления их на страницу был всегда одинаковый. Это позволит не перевёрстывать все компоненты, и отделаться минимальными изменениями в коде.

### Подробное описание решения
`Emotion` позволяет создавать экземпляры [кэша](https://emotion.sh/docs/@emotion/cache), и манипулировать с его помощью стилями.
Для каждой темы, я решил создавать свой кэш, чтобы гарантировать порядок вычисления стилей.
Кэш создаётся не на каждый экземпяр темы, а зависит от её содержимого. Точнее от объекта переданного в `ThemeFactory.create`. Для него вычисляется строковый хэш, который можно использовать в качестве ключа для хранения кэша. Т.е. для дефолтной темы, например, везде будет использоваться один экземпляр кэша (ну и ещё потому, что ключ можно задать вручную).
Это позволяет переиспользовать стили из `<head>`, если приложение реализовано так, что может несколько раз вызвать `ThemeFactory.create` с одинаковым содержимым. Но есть недостаток - невозможно удалить стили, если тема перестала использоваться, т.к. это событие не отследить (идея есть, но пока, кажется, это преждевременно).

При таком подходе стили компонентов должны работать в контексте темы, а не "статически", как сейчас. Из-за этого пришлось превратить объект `styles` в класс `Styles`. А вместо функции `css` из `create-emotion`, использовать функцию `css` из `@emotion/core`, т.к. она работает с кэшем.
Также, скорее всего, мемоизация больше не понадобится, т.к. кэш валидируется вручную.

В итоге, в методе `ThemeFactory.create(theme)`, на каждое новое содержимое объекта `theme` в неком хранилище создаётся объект - с кэшем и набором экземпляров `Classes`. Т.е. для получения своего `jsStyles`, компонент должен передать тему, полученную из контекста. Вариант, когда для вычисления стиля тема не нужна в разработке.

---

Fixes #1952