### PR TITLE
docs(react-ui-validations): fix source code examples

### DIFF
--- a/packages/react-ui-validations/loaders/markdown-loader.js
+++ b/packages/react-ui-validations/loaders/markdown-loader.js
@@ -34,7 +34,7 @@ class Renderer {
         const code = content[0];
         if (code && code.startsWith('!!DemoWithCode!!')) {
           const path = './' + code.replace('!!DemoWithCode!!', '') + '.demo.tsx';
-          return `<Demo demo={require('${path}').default} source={require('!raw-loader!${path}')} />`;
+          return `<Demo demo={require('${path}').default} source={require('!raw-loader!${path}').default} />`;
         }
         return `<SourceCode source={\`${code}\`}/>`;
       }


### PR DESCRIPTION
Обновили raw-loader с 0.5.1 до 4.0.0. А он c 1.0.0 стал возвращать es-модули.

На сайте доку я уже передеплоил.

fix #1975