### PR TITLE
fix(smoke-test): fix server launch on ci

### DIFF
--- a/packages/react-ui-smoke-test/package.json
+++ b/packages/react-ui-smoke-test/package.json
@@ -16,6 +16,7 @@
     "jest-teamcity-reporter": "^0.9.0",
     "puppeteer": "^2.1.1",
     "rimraf": "^3.0.2",
+    "serve": "^11.3.0",
     "wait-on": "^4.0.0"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15207,6 +15207,21 @@ serve@^11.2.0:
     serve-handler "6.1.2"
     update-check "1.5.2"
 
+serve@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.npmjs.org/serve/-/serve-11.3.0.tgz#1d342e13e310501ecf17b6602f1f35da640d6448"
+  integrity sha512-AU0g50Q1y5EVFX56bl0YX5OtVjUX1N737/Htj93dQGKuHiuLvVB45PD8Muar70W6Kpdlz8aNJfoUqTyAq9EE/A==
+  dependencies:
+    "@zeit/schemas" "2.6.0"
+    ajv "6.5.3"
+    arg "2.0.0"
+    boxen "1.3.0"
+    chalk "2.4.1"
+    clipboardy "1.2.3"
+    compression "1.7.3"
+    serve-handler "6.1.2"
+    update-check "1.5.2"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
Починка смок-тестов.

На TeamCity стали завершаться процессы, ранее подвешиваемые инструкцией `process.stdin.resume()`. Из-за чего WebpackDevServer стал вырубаться [сразу после запуска](https://github.com/react-workspaces/create-react-app/blob/473b8200f5fa3c57920533622a2fabd401e2dc75/packages/react-scripts/scripts/start.js#L175).

Причину до конца выяснить пока не удалось. Единственное отличие с локальным запуском в том, что на TC в stdin процессу приходит Socket, а не TTY. Видимо, что-то кроется в этом. Девопсы говорят, что на агентах обновился только .net core sdk 3.1.200.

Как вариант, можно перейти на запуск сбилженного приложения пакетом `serve`. Но CRA из коробки позволяет билдить только для прода. Соответственно, в ходе смок-теста мы теряем варнинги, которые выводятся только в dev-режиме. Но другого простого решения у меня пока нет.