### PR TITLE
docs(react-ui): migration guide and customization docs fixes

### DIFF
--- a/packages/react-ui/MIGRATION.md
+++ b/packages/react-ui/MIGRATION.md
@@ -46,6 +46,8 @@ import Input from '@skbkontur/react-ui/Input';
 import { Button, Input } from '@skbkontur/react-ui;
 ```
 
+В случае использования typescript вам потребуется влючить опцию `compilerOptions.esModuleInterop` в своем `tsconfgi.json` для корректной работы типизации.
+
 Если вы загружаете компоненты библиотеки в nodejs, например, в unit тестах, вам необходимо настроить трансформацию в CommonJS модулей из `@skbkontur/react-ui`, чтобы избежать ошибки `Error [ERR_REQUIRE_ESM]: Must use import to load ES Module`. Для сборки бандла в webpack конфиге ничего дополнительно настраивать не нужно. В скором времени появится нативная поддержка [ES Modules в Jest](https://jestjs.io/blog/2020/01/21/jest-25.html#ecmascript-modules-support)
 
 Публичными компонентами называются те, для которых есть страница с документацией на [витрине компонентов](https://tech.skbkontur.ru/react-ui/). Компоненты, которые отсутствуют на витрине считаются внутренними и не рекомендуются к использованию, для них не гарантируется сохранение обратной совместимости в рамках одной мажорной версии. Но если вам всё же необходимо использовать внутренний компонент, импортировать его можно из `@skbkontur/react-ui/internal/<ComponentName>`.
@@ -79,6 +81,7 @@ const [name, setName] = useState('');
 ```
 
 Мы подготовили [кодмод `transformOnChange`](https://github.com/skbkontur/retail-ui/pull/1900#transformOnChange) для перехода на новое API, в тех местах, где нельзя автоматически преобразовать `onChange` в `onValueChange` будет выводится сообщение о неудачной попытке трансформации и необходимости внести изменения вручную.
+
 ### Отдельный пакет для Контур-специфичных компонентов
 
 Компоненты использующие фирменный стиль или api сервисов Контура с выпуском 2.0 переезжают в отдельный приватный [репозиторий](https://git.skbkontur.ru/ui/ui-parking) и пакет [@skbkontur/react-ui-addons](https://nexus.kontur.host/#browse/browse:kontur-npm:%40skbkontur%2Freact-ui-addons) в приватном npm-репозитории `nexus`.

--- a/packages/react-ui/MIGRATION.md
+++ b/packages/react-ui/MIGRATION.md
@@ -85,10 +85,10 @@ const [name, setName] = useState('');
 
 Чтобы начать использовать пакет `@skbkontur/react-ui-addons` из `nexus` необходимо:
 
-1. Выполнить в проекте команду
+1. Создать в корне проекта файл `.npmrc` со следующим содержимым:
 
-   ```shell
-   npm config set @skbkontur:registry https://nexus.kontur.host/repository/kontur-npm-group/
+   ```
+   @skbkontur:registry https://nexus.kontur.host/repository/kontur-npm-group/
    ```
 
 2. Применить [кодмод `moveToAddons`](https://github.com/skbkontur/retail-ui/pull/1900#moveToAddons), исправляющий импорты Контур-специфичных компонентов на импорты из `@skbkontur/react-ui-addons`

--- a/packages/react-ui/components/Fias/Fias.tsx
+++ b/packages/react-ui/components/Fias/Fias.tsx
@@ -130,7 +130,7 @@ function deepMerge<T>(dst: T, ...src: T[]): T {
 }
 
 /**
- * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+ * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
  */
 
 @locale('Fias', FiasLocaleHelper)
@@ -166,7 +166,7 @@ export class Fias extends React.Component<FiasProps, FiasState> {
     super(props);
     warning(
       true,
-      `Fias has been deprecated, use Fias from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)`,
+      `Fias has been deprecated, use Fias from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)`,
     );
     if (!props.baseUrl && !props.api) {
       FiasLogger.log(FiasLogger.warnings.baseUrlOrApiIsRequired);

--- a/packages/react-ui/components/Fias/FiasSearch/FiasSearch.tsx
+++ b/packages/react-ui/components/Fias/FiasSearch/FiasSearch.tsx
@@ -41,7 +41,7 @@ export interface FiasSearchProps extends Pick<FiasComboBoxProps, keyof typeof CO
 }
 
 /**
- * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+ * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
  */
 
 @locale('Fias', FiasLocaleHelper)
@@ -61,7 +61,7 @@ export class FiasSearch extends React.Component<FiasSearchProps> {
     super(props);
     warning(
       false,
-      `FiasSearch has been deprecated, use FiasSearch from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)`,
+      `FiasSearch has been deprecated, use FiasSearch from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)`,
     );
   }
 

--- a/packages/react-ui/components/Loader/Loader.tsx
+++ b/packages/react-ui/components/Loader/Loader.tsx
@@ -23,7 +23,7 @@ export interface LoaderProps {
   className?: string;
   type?: 'mini' | 'normal' | 'big';
   /**
-   * @deprecated Старое поведение спиннера - облачко при среднем и большом размере - исчезнет в 3.0 поведение пересено в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+   * @deprecated Старое поведение спиннера - облачко при среднем и большом размере - исчезнет в 3.0 поведение пересено в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
    *
    * @default false
    */

--- a/packages/react-ui/components/Logotype/Logotype.tsx
+++ b/packages/react-ui/components/Logotype/Logotype.tsx
@@ -65,7 +65,7 @@ export interface LogotypeProps {
 }
 
 /**
- * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+ * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
  */
 @locale('Logotype', LogotypeLocaleHelper)
 export class Logotype extends React.Component<LogotypeProps> {
@@ -101,7 +101,7 @@ export class Logotype extends React.Component<LogotypeProps> {
     super(props);
     warning(
       false,
-      `Logotype has been deprecated, use Logotype from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)`,
+      `Logotype has been deprecated, use Logotype from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)`,
     );
   }
 

--- a/packages/react-ui/components/Spinner/Spinner.tsx
+++ b/packages/react-ui/components/Spinner/Spinner.tsx
@@ -25,7 +25,7 @@ export interface SpinnerProps {
    */
   type: SpinnerType;
   /**
-   * @deprecated Старое поведение спиннера - облачко при среднем и большом размере - исчезнет в 3.0 поведение пересено в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+   * @deprecated Старое поведение спиннера - облачко при среднем и большом размере - исчезнет в 3.0 поведение пересено в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
    *
    * @default false
    */

--- a/packages/react-ui/components/TopBar/TopBar.tsx
+++ b/packages/react-ui/components/TopBar/TopBar.tsx
@@ -58,7 +58,7 @@ export interface TopBarDefaultProps {
  */
 
 /**
- * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+ * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
  */
 export class TopBar extends React.Component<TopBarProps> {
   public static __KONTUR_REACT_UI__ = 'TopBar';
@@ -145,7 +145,7 @@ export class TopBar extends React.Component<TopBarProps> {
     super(props);
     warning(
       false,
-      `TopBar has been deprecated, use TopBar from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)`,
+      `TopBar has been deprecated, use TopBar from @skbkontur/react-ui-addons instead, see [migration](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)`,
     );
   }
 

--- a/packages/react-ui/internal/SpinnerOld/SpinnerOld.tsx
+++ b/packages/react-ui/internal/SpinnerOld/SpinnerOld.tsx
@@ -25,7 +25,7 @@ export interface SpinnerOldProps {
 }
 
 /**
- * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/MIGRATION.md)
+ * @deprecated Контур-специфичный компонент, будет удален в 3.0.0, перенесен в `@skbkontur/react-ui-addons` смотри [миграцию](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MIGRATION.md)
  */
 @locale('Spinner', SpinnerLocaleHelper)
 export class SpinnerOld extends React.Component<SpinnerOldProps> {

--- a/packages/react-ui/lib/theming/ThemeContext.md
+++ b/packages/react-ui/lib/theming/ThemeContext.md
@@ -46,7 +46,7 @@ import { ShowcaseGroup } from '@skbkontur/react-ui/internal/ThemePlayground/Show
 </ThemeContext.Provider>;
 ```
 
-### Создание собственной темы на основе темы по умолчанию
+### Создание собственной темы
 
 Собственные значения нужно передать в `ThemeFactory.create` и получившуюся тему можно использовать в `ThemeContext.Provider`. `ThemeFactory` расширяет переданный объект, задавая в качестве прототипа объект темы по умолчанию.
 
@@ -63,7 +63,7 @@ const myTheme = ThemeFactory.create({ btnSmallBorderRadius: '10px' });
 
 Вторым аргументом `ThemeFactory.create` может принимать объект, который будет использован в качестве базовой темы.
 
-```jsx harmony
+```jsx static
 import { ThemeFactory } from '@skbkontur/react-ui';
 import { FLAT_THEME } from '@skbkontur/react-ui/lib/theming/themes/FlatTheme';
 
@@ -96,7 +96,7 @@ function ButtonLinkWrapper(props) {
 
 ```jsx harmony
 import { useContext } from 'react';
-import { ThemeFactory } from '@skbkontur/react-ui';
+import { ThemeFactory, Button } from '@skbkontur/react-ui';
 
 const MyThemeContext = React.createContext(ThemeFactory.create({ myTextColor: 'orange' }));
 


### PR DESCRIPTION
Поправил ссылки на migration guide и дополнил его. Поправил примерчики про ThemeContext.

fix #1978 