### PR TITLE
fix(SidePage): don't block the page

### DIFF
--- a/packages/react-ui/.creevey/images/SidePage/Simple/open side-page/chrome/open side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Simple/open side-page/chrome/open side-page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5634ea27ea501db3ea0b2c79434892a4c4613ee19d1317010be5f6e59f300b66
-size 68329
+oid sha256:55578b46ccb16583409fd3aefdcd2a743d98fe7460b26a3dbb6a38c983411ab0
+size 68368

--- a/packages/react-ui/.creevey/images/SidePage/Simple/open side-page/firefox/open side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Simple/open side-page/firefox/open side-page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1329c60137dea0daf1217845f6431f4ddaf7d7db265738615aa433264dbfe7e8
-size 43475
+oid sha256:bd0451d1a4b86cb893585a7598995715c0638672379e4ab6284a3dbfa23ae4e9
+size 43467

--- a/packages/react-ui/components/SidePage/SidePage.styles.ts
+++ b/packages/react-ui/components/SidePage/SidePage.styles.ts
@@ -5,10 +5,19 @@ const styles = {
   root() {
     return css`
       height: 100%;
-      width: 100%;
       position: fixed;
       right: 0;
       top: 0;
+    `;
+  },
+
+  overlay() {
+    return css`
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
     `;
   },
 
@@ -31,6 +40,7 @@ const styles = {
       background: ${t.bgDefault};
       float: right;
       height: 100%;
+      width: 100%;
       overflow-y: auto;
       position: relative;
       white-space: normal;

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -126,12 +126,12 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   }
 
   private renderMain() {
-    const { disableAnimations } = this.props;
+    const { blockBackground, disableAnimations } = this.props;
 
     return (
       <RenderContainer>
         <div>
-          {this.renderShadow()}
+          {blockBackground && this.renderShadow()}
           <CSSTransition
             in
             classNames={this.getTransitionNames()}
@@ -151,7 +151,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   }
 
   private renderContainer(): JSX.Element {
-    const { fromLeft } = this.props;
+    const { width, blockBackground, fromLeft } = this.props;
 
     return (
       <ZIndex
@@ -163,6 +163,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
         })}
         onScroll={LayoutEvents.emit}
         createStackingContext
+        style={{ width: width || (blockBackground ? 800 : 500) }}
       >
         <RenderLayer onClickOutside={this.handleClickOutside} active>
           <div
@@ -196,35 +197,22 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   };
 
   private renderShadow(): JSX.Element {
-    const { blockBackground, fromLeft } = this.props;
-
     return (
-      <ZIndex
-        priority={'Sidepage'}
-        className={cn({
-          [jsStyles.root()]: true,
-          [jsStyles.leftSide(this.theme)]: Boolean(fromLeft),
-        })}
-        onScroll={LayoutEvents.emit}
-      >
-        {blockBackground && [
-          <HideBodyVerticalScroll key="hbvs" />,
-          <div
-            key="overlay"
-            className={cn({
-              [jsStyles.background()]: true,
-              [jsStyles.backgroundGray()]: this.state.hasBackground,
-            })}
-          />,
-        ]}
+      <ZIndex priority={'Sidepage'} className={jsStyles.overlay()} onScroll={LayoutEvents.emit}>
+        <HideBodyVerticalScroll key="hbvs" />
+        <div
+          key="overlay"
+          className={cn({
+            [jsStyles.background()]: true,
+            [jsStyles.backgroundGray()]: this.state.hasBackground,
+          })}
+        />
       </ZIndex>
     );
   }
 
   private getSidebarStyle(): React.CSSProperties {
-    const sidePageStyle: React.CSSProperties = {
-      width: this.props.width || (this.props.blockBackground ? 800 : 500),
-    };
+    const sidePageStyle: React.CSSProperties = {};
 
     if (this.state.hasMargin) {
       if (this.props.fromLeft) {

--- a/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
+++ b/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
@@ -787,8 +787,6 @@ LoaderInSidePageBody.story = {
     creevey: {
       tests: {
         async ['is covered by Header and Footer']() {
-          const element = await this.browser.findElement({ css: `[data-tid='SidePage__root']` });
-
           await this.browser.executeScript(function() {
             const sidePage = window.document.querySelector(`[data-tid='SidePage__container']`) as HTMLElement;
 
@@ -799,7 +797,7 @@ LoaderInSidePageBody.story = {
 
           await delay(500);
 
-          await this.expect(await element.takeScreenshot()).to.matchImage('is covered by Header and Footer');
+          await this.expect(await this.browser.takeScreenshot()).to.matchImage('is covered by Header and Footer');
         },
       },
     },


### PR DESCRIPTION
Поменял элемент, который управлял шириной SidePage, на самый корневой. Теперь он не блокирует страницу.

Контейнер тени рисуется только при необходимости, чтобы тоже не блокировал.

Немного отрефакторил стили оверлея.

fix #1949 
