### PR TITLE
fix(Tooltip): set default value for `box-sizing`, due to `reset.css`

### DIFF
--- a/packages/react-ui/components/Tooltip/Tooltip.styles.ts
+++ b/packages/react-ui/components/Tooltip/Tooltip.styles.ts
@@ -13,6 +13,7 @@ const styles = {
       right: 4px;
       top: 4px;
       width: 8px;
+      box-sizing: content-box;
 
       &:hover {
         color: ${t.tooltipCloseBtnHoverColor};


### PR DESCRIPTION
Fixes #2008