### PR TITLE
fix(Autocomplete): move `onKeyDown` on `span`, instead of `Input`

### DIFF
--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -339,11 +339,9 @@ export class Input extends React.Component<InputProps, InputState> {
     },
     mask: string,
   ) {
-    const { onChange, onKeyDown, onKeyPress, ...maskedProps } = inputProps;
-
     return (
       <MaskedInput
-        {...maskedProps}
+        {...inputProps}
         mask={mask}
         maskChar={this.props.maskChar === undefined ? '_' : this.props.maskChar}
         alwaysShowMask={this.props.alwaysShowMask}

--- a/packages/react-ui/internal/MaskedInput/MaskedInput.tsx
+++ b/packages/react-ui/internal/MaskedInput/MaskedInput.tsx
@@ -125,10 +125,9 @@ export class MaskedInput extends React.Component<MaskedInputProps, MaskedInputSt
       if (this.props.onValueChange) {
         this.props.onValueChange(event.target.value);
       }
-    }
-
-    if (this.props.onChange) {
-      this.props.onChange(event);
+      if (this.props.onChange) {
+        this.props.onChange(event);
+      }
     }
   };
 


### PR DESCRIPTION
Проблема в том, что в инпуте, при наличии маски, подключается `MaskedInput`, и вырезается обработчик `onKeyDown`.
Перенёс обработчик горячих клавиш с инпута на его обёртку.

Fixes #1938