### PR TITLE
fix(SidePage): add ignore clicks on scrollbars

### DIFF
--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -255,8 +255,12 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     });
   };
 
-  private handleClickOutside = () => {
+  private handleClickOutside = (e: Event) => {
     if (this.state.stackPosition === 0 && !this.props.ignoreBackgroundClick) {
+      // ignore mousedown on window scrollbar
+      if (e instanceof MouseEvent && e.clientX > document.documentElement.clientWidth) {
+        return;
+      }
       this.requestClose();
     }
   };


### PR DESCRIPTION
Не рискнул менять `mousedown` на `click`. А ну как прорвёт где-нибудь...
Оставил решение только для одного случая.

Fixes #1934

---
<details><summary>Старое решение</summary>

Поэтому вкинул хелпер для вычисления клика по скроллбару, если он есть.

### Проблемы

В разных браузерах и системах(`win10`/`macOS`) есть существенные отличия, касательно скроллбара, что не позволяет реализовать единое решение.
Все проблемы касаются `macOS` и браузеров `safari`, `chrome` и `firefox` (другие не проверял).
Уже реализованным способом, можно определить клик по скроллбару только на `html`/`body` и только при дефолтном значении `dir` - `ltr`.  В других `html`-элементах практически невозможно идентифицировать место клика.
Однако, в `firefox` не работает и этот сценарий.

| Detect...\OS(browser) | win10(all) | mac(safari) | mac(chrome) | mac(firefox) |
| --- | --- | --- | --- | --- |
| ...scroll on body | **`true`** (both) | **`true`** (`ltr`) | **`true`** (`ltr`) | ~~`false`~~ (both) |
| ...scroll not on body | **`true`** (both) | ~~`false`~~ (both) | ~~`false`~~ (both) | ~~`false`~~ (both) |

Гипотетически, можно определить и наличие скроллбара, и его размеры. Но не думаю, что стоит ещё тратить время на эту фичу.

### Решение

Предлагаю считать сценарий, при котором пользователь макоси мышкой пытается накликать скроллбар - маловероятным. Это действительно неудобно. Надо сильно постараться, чтобы поймать его курсором.

</details>