### PR TITLE
fix(MaskedInput): add specific property of the IE/Edge

### DIFF
--- a/packages/react-ui/internal/MaskedInput/MaskedInput.tsx
+++ b/packages/react-ui/internal/MaskedInput/MaskedInput.tsx
@@ -80,7 +80,7 @@ export class MaskedInput extends React.Component<MaskedInputProps, MaskedInputSt
     } = this.props;
 
     return (
-      <span className={jsStyles.container()}>
+      <span className={jsStyles.container()} x-ms-format-detection="none">
         <ReactInputMask
           {...inputProps}
           maskChar={null}


### PR DESCRIPTION
`Edge` пытался создать ссылку из набора цифр, похожих на номер телефона.
Отключил такое поведение специальным атрибутом - [`x-ms-format-detection`](https://docs.microsoft.com/en-us/previous-versions/dn337007(v=vs.85)
).

Fixes #1911