### PR TITLE
Производительность Tooltip

### DIFF
--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -320,6 +320,10 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
 
       case 'closed':
         return {
+          layerProps: {
+            active: false,
+            onClickOutside: this.handleClickOutsideAnchor,
+          },
           popupProps: {
             opened: false,
             useWrapper,
@@ -329,6 +333,10 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       case 'hoverAnchor':
       case 'hover':
         return {
+          layerProps: {
+            active: false,
+            onClickOutside: this.handleClickOutsideAnchor,
+          },
           popupProps: {
             onMouseEnter: this.handleMouseEnter,
             onMouseLeave: this.handleMouseLeave,
@@ -350,6 +358,10 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
 
       case 'focus':
         return {
+          layerProps: {
+            active: this.state.opened,
+            onClickOutside: this.handleClickOutsideAnchor,
+          },
           popupProps: {
             onFocus: this.handleFocus,
             onBlur: this.handleBlur,
@@ -360,6 +372,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       case 'hover&focus':
         return {
           layerProps: {
+            active: this.state.opened,
             onClickOutside: this.handleClickOutsideAnchor,
           },
           popupProps: {

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -320,10 +320,6 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
 
       case 'closed':
         return {
-          layerProps: {
-            active: false,
-            onClickOutside: this.handleClickOutsideAnchor,
-          },
           popupProps: {
             opened: false,
             useWrapper,
@@ -333,10 +329,6 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       case 'hoverAnchor':
       case 'hover':
         return {
-          layerProps: {
-            active: false,
-            onClickOutside: this.handleClickOutsideAnchor,
-          },
           popupProps: {
             onMouseEnter: this.handleMouseEnter,
             onMouseLeave: this.handleMouseLeave,
@@ -358,10 +350,6 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
 
       case 'focus':
         return {
-          layerProps: {
-            active: this.state.opened,
-            onClickOutside: this.handleClickOutsideAnchor,
-          },
           popupProps: {
             onFocus: this.handleFocus,
             onBlur: this.handleBlur,


### PR DESCRIPTION
Раскопал проблему производительности с Tooltip-ом.

- Tooltip рендерит RenderLayer и в зависимости от `props.trigger` передает (или не передает) ему пропсы
- Если RenderLayer-у Tooltip не передает пропсы, то ему передается `{ active: true }`, если передает пропсы, но там нет `props.active`, то RenderLayer берет значение из `defaultProps.active = true`
- RenderLayer, когда `props.active = true` делает 3 глобальные подписки: на fous, blur и click на `document` (клик в любое место поджигает обработчик click)
- Проблема всплывает в ValidationWrapper, который рендерит Tooltip c `props.trigger = "hover&focuse"`. Раньше `active` не заполнялось Tooltip-ом, поэтому бралось из `dafualProps.active = true`. Получается, что даже если Tooltip валидации не появлялся, он все равно обрабатывает 3 эвента, который происходят в любом месте.
- Теперь представляем себе форму, в которой есть 300 сложных компонентов (это список), каждый из которых рендерит 3 ValidationWrapper-ов - это 900 тултипов  - это 2700 подписок. Клик в любое место (например на скрол) вызывает обработку массива из 900 элементов, что стопорит работу вкладки где-то на 3 секунды. А можно кликнуть на какое-нибудь поле ввода - тогда будет и клик и фокус.