### PR TITLE
build(react-ui): revise publishing files

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -5,6 +5,7 @@
   "main": "cjs/index.js",
   "module": "index.js",
   "sideEffects": false,
+  "homepage": "https://tech.skbkontur.ru/react-ui",
   "repository": {
     "type": "git",
     "url": "git@github.com:skbkontur/retail-ui.git"

--- a/packages/react-ui/scripts/build/index.js
+++ b/packages/react-ui/scripts/build/index.js
@@ -25,7 +25,7 @@ function build() {
   });
 
   if (OutDir === RootDir) {
-    generatePackageJson();
+    copyPackageJson();
     copyReadme();
   }
 }
@@ -121,29 +121,9 @@ function handle(filename, dirName) {
   }
 }
 
-function generatePackageJson() {
-  const packageJson = require('../../package.json');
-  const result = {
-    name: '@skbkontur/react-ui',
-    version: packageJson.version,
-    license: 'MIT',
-    dependencies: packageJson.dependencies,
-    homepage: 'https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/README.md',
-    main: packageJson.main,
-    module: packageJson.module,
-    sideEffects: packageJson.sideEffects,
-    repository: {
-      type: 'git',
-      url: 'git@github.com:skbkontur/retail-ui.git',
-    },
-    bugs: {
-      url: 'https://github.com/skbkontur/retail-ui/issues',
-    },
-    peerDependencies: packageJson.peerDependencies,
-    publishConfig: packageJson.publishConfig,
-  };
-  const source = JSON.stringify(result, null, 2);
-  outputFileSync(path.join(OutDir, 'package.json'), source);
+function copyPackageJson() {
+  const packageJson = fs.readFileSync(path.join(process.cwd(), 'package.json'));
+  outputFileSync(path.join(OutDir, 'package.json'), packageJson);
 }
 
 function copyReadme() {

--- a/packages/react-ui/scripts/build/index.js
+++ b/packages/react-ui/scripts/build/index.js
@@ -131,6 +131,7 @@ function generatePackageJson() {
     homepage: 'https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/README.md',
     main: packageJson.main,
     module: packageJson.module,
+    sideEffects: packageJson.sideEffects,
     repository: {
       type: 'git',
       url: 'git@github.com:skbkontur/retail-ui.git',

--- a/packages/react-ui/scripts/build/index.js
+++ b/packages/react-ui/scripts/build/index.js
@@ -25,8 +25,7 @@ function build() {
   });
 
   if (OutDir === RootDir) {
-    copyPackageJson();
-    copyReadme();
+    copyFilesForPublish();
   }
 }
 
@@ -121,12 +120,11 @@ function handle(filename, dirName) {
   }
 }
 
-function copyPackageJson() {
-  const packageJson = fs.readFileSync(path.join(process.cwd(), 'package.json'));
-  outputFileSync(path.join(OutDir, 'package.json'), packageJson);
-}
-
-function copyReadme() {
-  const readmeFile = fs.readFileSync(path.join(process.cwd(), 'README.md'));
-  outputFileSync(path.join(OutDir, 'README.md'), readmeFile);
+function copyFilesForPublish() {
+  const files = ['package.json', 'README.md', 'CHANGELOG.md', 'LICENSE'];
+  files.forEach(filename => {
+    const src = path.join(process.cwd(), filename);
+    const dest = path.join(OutDir, filename);
+    fs.copyFileSync(src, dest)
+  });
 }


### PR DESCRIPTION
1. Сделал полное копирование `package.json` при паблише. Чтобы избежать такого, что, например, забыли скопировать `sideEffects: false` и tree-shaking не работал.
2. Добавил в паблиш традиционные файлы `LICENSE` и `CHANGELOG.md`.