### PR TITLE
build: explicitly set npm registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .env
 .idea
 .DS_Store
-.npmrc
 *.code-workspace
 
 node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--registry "https://registry.npmjs.org"

--- a/packages/react-ui/.yarnrc
+++ b/packages/react-ui/.yarnrc
@@ -1,1 +1,0 @@
-registry "https://registry.npmjs.org"


### PR DESCRIPTION
На агентах TeamCity кто-то проставил кривоватый registry в конфиг yarn:
```
registry: '\'https://nexus.kontur.host/repository/kontur-npm-group/\''
```
Привело к тому, что перестала корректно работать команда `npx create-react-app@next ...` в smoke-тестах.

Явная установка регистра в наших конфигах должна оградить нас от такого в будущем.