### PR TITLE
fix(Kladr): add filter for "empty" addresses from backend

### DIFF
--- a/packages/retail-ui/components/Kladr/KladrAPI.js
+++ b/packages/retail-ui/components/Kladr/KladrAPI.js
@@ -17,7 +17,12 @@ export function search(searchText: string, levels: string, parentCode: ?string):
   });
   return fetch(`${kladrUrl}suggest?${data}`)
     .then(res => res.json())
-    .then(toJS);
+    .then(toJS)
+    .then(removeEmpty);
+}
+
+export function removeEmpty(address: Array<Address>): Array<Address> {
+  return address.filter(a => !Object.values(a).every(i => i === null));
 }
 
 export function searchIndex(code: string, house: ?string) {


### PR DESCRIPTION
С сервера могут приходить полностью `null`-евые объекты.
Добавил фильтр на уровне апи для таких пустышек.

|  `null`-евой объект с сервера |
| --- |
| ![image](https://user-images.githubusercontent.com/2708211/86314942-5f3e4000-bc42-11ea-83a7-250690f70588.png) |

---
Fixes https://yt.skbkontur.ru/issue/keforms-4079