### PR TITLE
feat(ValidationContainer): added new prop disableSmoothScroll

### DIFF
--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -13,10 +13,15 @@ export interface ValidationContainerProps {
   children?: React.ReactNode;
   onValidationUpdated?: (isValid?: Nullable<boolean>) => void;
   scrollOffset?: number | ScrollOffset;
+  disableSmoothScroll: boolean;
 }
 
 export class ValidationContainer extends React.Component<ValidationContainerProps> {
   public static __KONTUR_REACT_UI__ = 'ValidationContainer';
+
+  public static defaultProps = {
+    disableSmoothScroll: false
+  };
 
   public static propTypes = {
     scrollOffset(props: ValidationContainerProps, propName: keyof ValidationContainerProps, componentName: string) {
@@ -50,6 +55,7 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
       <ValidationContext
         ref={this.refChildContext}
         scrollOffset={this.props.scrollOffset}
+        disableSmoothScroll={this.props.disableSmoothScroll}
         onValidationUpdated={this.props.onValidationUpdated}
       >
         {this.props.children}

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -20,7 +20,7 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
   public static __KONTUR_REACT_UI__ = 'ValidationContainer';
 
   public static defaultProps = {
-    disableSmoothScroll: false
+    disableSmoothScroll: process.env.NODE_ENV === 'test'
   };
 
   public static propTypes = {

--- a/packages/react-ui-validations/src/ValidationContext.tsx
+++ b/packages/react-ui-validations/src/ValidationContext.tsx
@@ -6,6 +6,7 @@ import { ScrollOffset } from './ValidationContainer';
 
 export interface ValidationContextSettings {
   scrollOffset: ScrollOffset;
+  disableSmoothScroll: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
@@ -22,6 +23,7 @@ export interface ValidationContextProps {
   children?: React.ReactNode;
   onValidationUpdated?: (isValid?: boolean) => void;
   scrollOffset?: number | ScrollOffset;
+  disableSmoothScroll: boolean;
 }
 
 export class ValidationContext extends React.Component<ValidationContextProps> implements IValidationContext {
@@ -51,6 +53,7 @@ export class ValidationContext extends React.Component<ValidationContextProps> i
         top,
         bottom,
       },
+      disableSmoothScroll: this.props.disableSmoothScroll
     };
   }
 

--- a/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
+++ b/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
@@ -90,7 +90,10 @@ export class ValidationWrapperInternal extends React.Component<
   public async focus(): Promise<void> {
     const htmlElement = ReactDom.findDOMNode(this);
     if (htmlElement instanceof HTMLElement) {
-      await smoothScrollIntoView(htmlElement, this.context.validationContext.getSettings().scrollOffset);
+      const {disableSmoothScroll, scrollOffset} = this.context.validationContext.getSettings();
+      if (!disableSmoothScroll) {
+        await smoothScrollIntoView(htmlElement, scrollOffset);
+      }
       if (this.child && typeof this.child.focus === 'function') {
         this.child.focus();
       }


### PR DESCRIPTION
Проблема: падают e2e тесты, при проверке валидаций.
Поведение:
1) есть большая форма в модальном окне на несколько экранов, в самом низу, соответственно, `submit`;
2) вводим невалидные данные в инпуты, нажимаем на `submit`, проверяем валидацию;
3) вьюпорт плавно скроллится наверх к невалидному полю;
4) тест падает, потому что пытается сразу проверить валидацию в тултипе, а вьюпорт еще не поднялся до нужного поля. Сейчас, в проекте, это костыльно решено при помощи ожидания в секунду-две;

Что сделал в этом PR: добавил проп в `ValidationContainer`, который позволяет отключить плавный скролл. На основании пропа и переменной окружения `NODE_ENV` определяем, юзать плавный скролл или нет. Это необходимо, чтобы не собирать отдельную сборку для фронта, при прогоне селениумных тестов локально.
Нашел в проекте переменную `isTestEnv`, но она в другом пакете, поэтому заюзал просто `process.evn.NODE_ENV`.