### PR TITLE
fix(react-ui-testing): target netstandard2.0 instead of netcoreapp2.1

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -504,7 +504,7 @@ object SeleniumTesting_Test : BuildType({
             name = "Test"
             id = "RUNNER_4"
             projects = "packages/react-ui-testing/Tests/Tests.csproj"
-            framework = "netcoreapp2.1"
+            framework = "netcoreapp3.1"
             param("dotNetCoverage.dotCover.home.path", "%teamcity.tool.JetBrains.dotCover.CommandLineTools.DEFAULT%")
         }
     }

--- a/packages/react-ui-testing/SeleniumTesting.sln
+++ b/packages/react-ui-testing/SeleniumTesting.sln
@@ -10,27 +10,17 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		DebugCore|Any CPU = DebugCore|Any CPU
 		Release|Any CPU = Release|Any CPU
-		ReleaseCore|Any CPU = ReleaseCore|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{99A2553D-9B4E-410C-870B-665CADB13070}.Release|Any CPU.Build.0 = Release|Any CPU
-		{99A2553D-9B4E-410C-870B-665CADB13070}.DebugCore|Any CPU.ActiveCfg = DebugCore|Any CPU
-		{99A2553D-9B4E-410C-870B-665CADB13070}.DebugCore|Any CPU.Build.0 = DebugCore|Any CPU
-		{99A2553D-9B4E-410C-870B-665CADB13070}.ReleaseCore|Any CPU.ActiveCfg = ReleaseCore|Any CPU
-		{99A2553D-9B4E-410C-870B-665CADB13070}.ReleaseCore|Any CPU.Build.0 = ReleaseCore|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.DebugCore|Any CPU.ActiveCfg = DebugCore|Any CPU
-		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.DebugCore|Any CPU.Build.0 = DebugCore|Any CPU
-		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.ReleaseCore|Any CPU.ActiveCfg = ReleaseCore|Any CPU
-		{6F73A478-3FD4-46D4-9CD7-B178AEDC4EBC}.ReleaseCore|Any CPU.Build.0 = ReleaseCore|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -12,30 +12,24 @@
     <PackageLicenseUrl>https://github.com/skbkontur/react-ui-testing/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skbkontur/react-ui-testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skbkontur/react-ui-testing</RepositoryUrl>
-    <Configurations>Debug;Release;DebugCore;ReleaseCore</Configurations>
+    <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugCore|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseCore|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <OutputPath>bin\Release\</OutputPath>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <OutputPath>..\Output</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="10.0.0" />
-    <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.1" />
-    <PackageReference Include="Kontur.Selone" Version="0.0.4" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
+    <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.2-alpha" />
+    <PackageReference Include="Kontur.Selone" Version="0.0.6-alpha" />
     <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/KebabTests/KebabTest.cs
+++ b/packages/react-ui-testing/Tests/KebabTests/KebabTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-
+using FluentAssertions;
 using NUnit.Framework;
 
 using SKBKontur.SeleniumTesting.Tests.Helpers;
@@ -65,7 +65,7 @@ namespace SKBKontur.SeleniumTesting.Tests.KebabTests
         public void TestSelectItemByText()
         {
             page.Output.Text.Wait().That(Is.EqualTo("none"));
-            page.SimpleKebab.SelectItem(x => x.Text.Assert(Is.EqualTo("Second")));
+            page.SimpleKebab.SelectItem(x => x.Text.Get().Should().Be("Second"));
             page.Output.Text.Wait().That(Is.EqualTo("second"));
         }
 

--- a/packages/react-ui-testing/Tests/ListTests/ListTest.cs
+++ b/packages/react-ui-testing/Tests/ListTests/ListTest.cs
@@ -72,11 +72,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ListTests
         public void Test1()
         {
             page.InputWithoutTidList[1].ClearAndInputText("value 1");
-            Following.CodeFails(() =>
-                {
-                    // TODO
-                    // page.InputWithoutTidList.ExpectTo().AllItems().ExpectTo().Satisfy(x => x.Value == "value", "ожадалось значение 'value'");
-                });
+            Following.CodeFails(() => { page.InputWithoutTidList.ExpectTo().AllItems().ExpectTo().Satisfy(x => x.Value.Get() == "value", "ожадалось значение 'value'"); });
         }
 
         [Test]

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -7,37 +7,26 @@
     <RootNamespace>SKBKontur.SeleniumTesting.Tests</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <Configurations>Debug;Release;DebugCore;ReleaseCore</Configurations>
+    <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugCore|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseCore|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <OutputPath>bin\Release\</OutputPath>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SeleniumTesting\SeleniumTesting.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.4.1" />
-    <PackageReference Include="JetBrains.Annotations" Version="10.0.0" />
-    <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.1" />
-    <PackageReference Include="Kontur.Selone" Version="0.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NUnit" Version="3.8.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/package.json
+++ b/packages/react-ui-testing/package.json
@@ -6,8 +6,8 @@
   "main": "react-selenium-testing.js",
   "scripts": {
     "postinstall": "yarn --cwd ./TestPages install",
-    "build": "dotnet build -c ReleaseCore",
-    "test": "dotnet test ./Tests/Tests.csproj -c ReleaseCore -v detailed",
+    "build": "dotnet build --configuration Release",
+    "test": "dotnet test ./Tests/Tests.csproj --configuration Release --verbosity detailed --framework netcoreapp3.1",
     "start": "yarn --cwd ./TestPages start"
   },
   "author": "",


### PR DESCRIPTION
Хочется иметь возможность подключать SeleniumTesting в netstandard-сборку с тестовыми хелперами, сейчас возникают нелепые ворнинги если так делать

fixes #2085 