### PR TITLE
fix(8px): various bugs

### DIFF
--- a/packages/react-ui/components/Input/Input.styles.ts
+++ b/packages/react-ui/components/Input/Input.styles.ts
@@ -179,7 +179,7 @@ const styles = {
 
   disabled(t: Theme) {
     return css`
-      background: ${t.inputDisabledBg};
+      background: ${t.inputDisabledBg} !important;
       border-color: ${t.inputDisabledBorderColor} !important;
       box-shadow: none;
 

--- a/packages/react-ui/components/Switcher/Switcher.styles.ts
+++ b/packages/react-ui/components/Switcher/Switcher.styles.ts
@@ -20,16 +20,39 @@ const styles = {
 
   label() {
     return css`
-      margin-right: 15px;
       vertical-align: middle;
       display: inline-block;
+    `;
+  },
+
+  labelSmall(t: Theme) {
+    return css`
+      margin-right: ${t.switcherLabelGapSmall};
+      font-size: ${t.switcherLabelFontSizeSmall};
+      line-height: ${t.switcherLabelLineHeightSmall};
+    `;
+  },
+
+  labelMedium(t: Theme) {
+    return css`
+      margin-right: ${t.switcherLabelGapMedium};
+      font-size: ${t.switcherLabelFontSizeMedium};
+      line-height: ${t.switcherLabelLineHeightMedium};
+    `;
+  },
+
+  labelLarge(t: Theme) {
+    return css`
+      margin-right: ${t.switcherLabelGapLarge};
+      font-size: ${t.switcherLabelFontSizeLarge};
+      line-height: ${t.switcherLabelLineHeightLarge};
     `;
   },
 
   error(t: Theme) {
     return css`
       border-radius: 2px;
-      box-shadow: 0 0 0 2px ${t.borderColorError};
+      box-shadow: 0 0 0 ${t.switcherOutlineWidth} ${t.borderColorError};
     `;
   },
 };

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -89,9 +89,11 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
       className: jsStyles.input(),
     };
 
+    const lableClassName = cn(jsStyles.label(), this.getLabelSizeClassName());
+
     return (
       <div>
-        {this.props.label ? <div className={jsStyles.label()}>{this.props.label}</div> : null}
+        {this.props.label ? <div className={lableClassName}>{this.props.label}</div> : null}
         <div className={jsStyles.wrap()}>
           <input {...inputProps} />
           <div className={listClassName}>
@@ -195,5 +197,17 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         </Button>
       );
     });
+  };
+
+  private getLabelSizeClassName = (): string => {
+    switch (this.props.size) {
+      case 'large':
+        return jsStyles.labelLarge(this.theme);
+      case 'medium':
+        return jsStyles.labelMedium(this.theme);
+      case 'small':
+      default:
+        return jsStyles.labelSmall(this.theme);
+    }
   };
 }

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -10,6 +10,7 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 
 import { jsStyles } from './Switcher.styles';
+import { getSwitcherTheme } from './switcherTheme';
 
 export type SwitcherSize = ButtonSize;
 
@@ -69,8 +70,8 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     return (
       <ThemeContext.Consumer>
         {theme => {
-          this.theme = theme;
-          return this.renderMain();
+          this.theme = getSwitcherTheme(theme);
+          return <ThemeContext.Provider value={this.theme}>{this.renderMain()}</ThemeContext.Provider>;
         }}
       </ThemeContext.Consumer>
     );

--- a/packages/react-ui/components/Switcher/switcherTheme.ts
+++ b/packages/react-ui/components/Switcher/switcherTheme.ts
@@ -1,0 +1,29 @@
+import { ThemeFactory } from '../../lib/theming/ThemeFactory';
+import { Theme } from '../../lib/theming/Theme';
+
+export const getSwitcherTheme = (theme: Theme): Theme => {
+  return ThemeFactory.create(
+    {
+      btnBorderWidth: theme.switcherButtonBorderWidth,
+
+      btnLineHeightSmall: theme.switcherButtonLineHeightSmall,
+      btnFontSizeSmall: theme.switcherButtonFontSizeSmall,
+      btnPaddingXSmall: theme.switcherButtonPaddingXSmall,
+      btnPaddingYSmall: theme.switcherButtonPaddingYSmall,
+      btnBorderRadiusSmall: theme.switcherButtonBorderRadiusSmall,
+
+      btnLineHeightMedium: theme.switcherButtonLineHeightMedium,
+      btnFontSizeMedium: theme.switcherButtonFontSizeMedium,
+      btnPaddingXMedium: theme.switcherButtonPaddingXMedium,
+      btnPaddingYMedium: theme.switcherButtonPaddingYMedium,
+      btnBorderRadiusMedium: theme.switcherButtonBorderRadiusMedium,
+
+      btnLineHeightLarge: theme.switcherButtonLineHeightLarge,
+      btnFontSizeLarge: theme.switcherButtonFontSizeLarge,
+      btnPaddingXLarge: theme.switcherButtonPaddingXLarge,
+      btnPaddingYLarge: theme.switcherButtonPaddingYLarge,
+      btnBorderRadiusLarge: theme.switcherButtonBorderRadiusLarge,
+    },
+    theme,
+  );
+};

--- a/packages/react-ui/components/Tabs/Indicator.tsx
+++ b/packages/react-ui/components/Tabs/Indicator.tsx
@@ -127,9 +127,10 @@ export class Indicator extends React.Component<IndicatorProps, IndicatorState> {
         };
       }
 
+      const tabBorderWidth = parseInt(this.theme.tabBorderWidth, 10) || 0;
       return {
         left: node.offsetLeft,
-        top: node.offsetHeight + node.offsetTop - 3,
+        top: node.offsetHeight + node.offsetTop - tabBorderWidth,
         width: rect.right - rect.left,
       };
     }

--- a/packages/react-ui/components/TokenInput/TokenInput.styles.ts
+++ b/packages/react-ui/components/TokenInput/TokenInput.styles.ts
@@ -20,30 +20,30 @@ const styles = {
 
   warning(t: Theme) {
     return css`
-      border: ${t.tokenInputBorderWidth} solid ${t.tokenInputBorderColorWarning};
-      box-shadow: 0 0 0 ${t.tokenInputOutlineWidth} ${t.tokenInputBorderColorWarning};
+      border: ${t.tokenInputBorderWidth} solid ${t.tokenInputBorderColorWarning} !important;
+      box-shadow: 0 0 0 ${t.tokenInputOutlineWidth} ${t.tokenInputBorderColorWarning} !important;
     `;
   },
 
   error(t: Theme) {
     return css`
-      border: ${t.tokenInputBorderWidth} solid ${t.tokenInputBorderColorError};
-      box-shadow: 0 0 0 ${t.tokenInputOutlineWidth} ${t.tokenInputBorderColorError};
+      border: ${t.tokenInputBorderWidth} solid ${t.tokenInputBorderColorError} !important;
+      box-shadow: 0 0 0 ${t.tokenInputOutlineWidth} ${t.tokenInputBorderColorError} !important;
     `;
   },
 
   labelFocused(t: Theme) {
     return css`
-      border: ${t.tokenInputBorderWidth} solid ${t.tokenInputBorderColorFocus};
-      box-shadow: 0 0 0 ${t.tokenInputOutlineWidth} ${t.tokenInputBorderColorFocus};
+      border: ${t.tokenInputBorderWidth} solid ${t.tokenInputBorderColorFocus} !important;
+      box-shadow: 0 0 0 ${t.tokenInputOutlineWidth} ${t.tokenInputBorderColorFocus} !important;
     `;
   },
 
   labelDisabled(t: Theme) {
     return css`
-      background: ${t.tokenInputDisabledBg};
-      border-color: ${t.tokenInputDisabledBorderColor};
-      box-shadow: none;
+      background: ${t.tokenInputDisabledBg} !important;
+      border-color: ${t.tokenInputDisabledBorderColor} !important;
+      box-shadow: none !important;
     `;
   },
 

--- a/packages/react-ui/components/TokenInput/TokenInput.styles.ts
+++ b/packages/react-ui/components/TokenInput/TokenInput.styles.ts
@@ -13,6 +13,7 @@ const styles = {
       padding: ${t.tokenInputPaddingY} ${t.tokenInputPaddingX};
       display: flex;
       flex-wrap: wrap;
+      align-items: start;
       outline: none;
     `;
   },
@@ -56,10 +57,10 @@ const styles = {
       box-shadow: none;
       outline: none;
       font-family: inherit;
-      font-size: 14px;
       padding: 0 0 0 5px;
-      height: ${t.tokenInputInnerHeight};
-      line-height: ${t.tokenInputInnerHeight};
+      font-size: ${t.tokenInputFontSize};
+      height: ${t.tokenInputLineHeight};
+      line-height: ${t.tokenInputLineHeight};
       -webkit-appearance: none;
       white-space: nowrap;
       text-overflow: clip;

--- a/packages/react-ui/internal/ThemePlayground/constants.ts
+++ b/packages/react-ui/internal/ThemePlayground/constants.ts
@@ -33,6 +33,7 @@ export const VARIABLES_GROUPS = [
   { title: 'TokenInput', prefix: 'tokenInput' },
   { title: 'Select', prefix: 'select' },
   { title: 'Spinner', prefix: 'spinner' },
+  { title: 'Switcher', prefix: 'switcher' },
   { title: 'Legacy', prefix: 'chb slt' },
 ];
 

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1318,6 +1318,54 @@ export class DefaultTheme {
   public static switcherLabelGapSmall = '15px';
   public static switcherLabelGapMedium = '15px';
   public static switcherLabelGapLarge = '15px';
+  public static get switcherButtonPaddingXSmall() {
+    return this.btnPaddingXSmall;
+  }
+  public static get switcherButtonPaddingXMedium() {
+    return this.btnPaddingXMedium;
+  }
+  public static get switcherButtonPaddingXLarge() {
+    return this.btnPaddingXLarge;
+  }
+  public static get switcherButtonPaddingYSmall() {
+    return this.btnPaddingYSmall;
+  }
+  public static get switcherButtonPaddingYMedium() {
+    return this.btnPaddingYMedium;
+  }
+  public static get switcherButtonPaddingYLarge() {
+    return this.btnPaddingYLarge;
+  }
+  public static get switcherButtonLineHeightSmall() {
+    return this.btnLineHeightSmall;
+  }
+  public static get switcherButtonLineHeightMedium() {
+    return this.btnLineHeightMedium;
+  }
+  public static get switcherButtonLineHeightLarge() {
+    return this.btnLineHeightLarge;
+  }
+  public static get switcherButtonFontSizeSmall() {
+    return this.btnFontSizeSmall;
+  }
+  public static get switcherButtonFontSizeMedium() {
+    return this.btnFontSizeMedium;
+  }
+  public static get switcherButtonFontSizeLarge() {
+    return this.btnFontSizeLarge;
+  }
+  public static get switcherButtonBorderRadiusSmall() {
+    return this.btnBorderRadiusSmall;
+  }
+  public static get switcherButtonBorderRadiusMedium() {
+    return this.btnBorderRadiusMedium;
+  }
+  public static get switcherButtonBorderRadiusLarge() {
+    return this.btnBorderRadiusLarge;
+  }
+  public static get switcherButtonBorderWidth() {
+    return this.btnBorderWidth;
+  }
   //#endregion
 }
 

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -71,9 +71,24 @@ export class DefaultTheme {
   public static get borderColorWarning() {
     return this.warningMain;
   }
-  public static controlHeightSmall = '34px';
-  public static controlHeightMedium = '40px';
-  public static controlHeightLarge = '44px';
+  public static get controlHeightSmall() {
+    const borderWidth = parseInt(this.controlBorderWidth, 10) || 0;
+    const paddingYSmall = parseInt(this.controlPaddingYSmall, 10) || 0;
+    const lineHeightSmall = parseInt(this.controlLineHeightSmall, 10) || 0;
+    return `${2 * borderWidth + 2 * paddingYSmall + lineHeightSmall}px`;
+  }
+  public static get controlHeightMedium() {
+    const borderWidth = parseInt(this.controlBorderWidth, 10) || 0;
+    const paddingYMedium = parseInt(this.controlPaddingYMedium, 10) || 0;
+    const lineHeightMedium = parseInt(this.controlLineHeightMedium, 10) || 0;
+    return `${2 * borderWidth + 2 * paddingYMedium + lineHeightMedium}px`;
+  }
+  public static get controlHeightLarge() {
+    const borderWidth = parseInt(this.controlBorderWidth, 10) || 0;
+    const paddingYLarge = parseInt(this.controlPaddingYLarge, 10) || 0;
+    const lineHeightLarge = parseInt(this.controlLineHeightLarge, 10) || 0;
+    return `${2 * borderWidth + 2 * paddingYLarge + lineHeightLarge}px`;
+  }
 
   //#endregion
   //#region Link
@@ -520,22 +535,13 @@ export class DefaultTheme {
     return this.borderColorError;
   }
   public static get btnHeightSmall() {
-    const borderWidth = parseInt(this.btnBorderWidth, 10) || 0;
-    const padding = parseInt(this.btnPaddingYSmall, 10) || 0;
-    const lineHeigh = parseInt(this.btnLineHeightSmall, 10) || 0;
-    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+    return this.controlHeightSmall;
   }
   public static get btnHeightMedium() {
-    const borderWidth = parseInt(this.btnBorderWidth, 10) || 0;
-    const padding = parseInt(this.btnPaddingYMedium, 10) || 0;
-    const lineHeigh = parseInt(this.btnLineHeightMedium, 10) || 0;
-    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+    return this.controlHeightMedium;
   }
   public static get btnHeightLarge() {
-    const borderWidth = parseInt(this.btnBorderWidth, 10) || 0;
-    const padding = parseInt(this.btnPaddingYLarge, 10) || 0;
-    const lineHeigh = parseInt(this.btnLineHeightLarge, 10) || 0;
-    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+    return this.controlHeightLarge;
   }
   public static get btnLinkColor() {
     return this.linkColor;
@@ -819,22 +825,13 @@ export class DefaultTheme {
     return this.controlLineHeightLarge;
   }
   public static get inputHeightSmall() {
-    const borderWidth = parseInt(this.inputBorderWidth, 10) || 0;
-    const padding = parseInt(this.inputPaddingYSmall, 10) || 0;
-    const lineHeigh = parseInt(this.inputLineHeightSmall, 10) || 0;
-    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+    return this.controlHeightSmall;
   }
   public static get inputHeightMedium() {
-    const borderWidth = parseInt(this.inputBorderWidth, 10) || 0;
-    const padding = parseInt(this.inputPaddingYMedium, 10) || 0;
-    const lineHeigh = parseInt(this.inputLineHeightMedium, 10) || 0;
-    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+    return this.controlHeightMedium;
   }
   public static get inputHeightLarge() {
-    const borderWidth = parseInt(this.inputBorderWidth, 10) || 0;
-    const padding = parseInt(this.inputPaddingYLarge, 10) || 0;
-    const lineHeigh = parseInt(this.inputLineHeightLarge, 10) || 0;
-    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+    return this.controlHeightLarge;
   }
   public static get inputPaddingYSmall() {
     return this.controlPaddingYSmall;

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1309,6 +1309,18 @@ export class DefaultTheme {
   public static spinnerOldCaptionGapMedium = '0px';
   public static spinnerOldCaptionGapLarge = '0px';
   //#endregion
+  //#region Switcher
+  public static switcherOutlineWidth = '2px';
+  public static switcherLabelFontSizeSmall = 'inherit';
+  public static switcherLabelFontSizeMedium = 'inherit';
+  public static switcherLabelFontSizeLarge = 'inherit';
+  public static switcherLabelLineHeightSmall = 'inherit';
+  public static switcherLabelLineHeightMedium = 'inherit';
+  public static switcherLabelLineHeightLarge = 'inherit';
+  public static switcherLabelGapSmall = '15px';
+  public static switcherLabelGapMedium = '15px';
+  public static switcherLabelGapLarge = '15px';
+  //#endregion
 }
 
 export const DefaultThemeInternal = exposeGetters(markAsFullTheme(DefaultTheme));

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -244,12 +244,10 @@ export class DefaultTheme {
   }
   public static tokenInputPaddingY = '2px';
   public static tokenInputPaddingX = '4px';
-  public static get tokenInputInnerHeight() {
-    return `calc(${this.controlHeightSmall} - 2 * ${this.tokenInputPaddingY} - 2 * ${this.tokenInputBorderWidth})`;
+  public static get tokenInputFontSize() {
+    return this.inputFontSizeSmall;
   }
-  public static get tokenInputLineHeight() {
-    return this.controlLineHeightSmall;
-  }
+  public static tokenInputLineHeight = '28px';
   //#endregion
   //#region Loader
   public static loaderBg = 'rgba(255, 255, 255, 0.8)';

--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -425,6 +425,37 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
   }
   public static radioVerticalAlign = 'top';
   //#endregion
+  //#region Switcher
+  public static get switcherOutlineWidth() {
+    return this.btnOutlineWidth;
+  }
+  public static get switcherLabelFontSizeSmall() {
+    return this.btnFontSizeSmall;
+  }
+  public static get switcherLabelFontSizeMedium() {
+    return this.btnFontSizeMedium;
+  }
+  public static get switcherLabelFontSizeLarge() {
+    return this.btnFontSizeLarge;
+  }
+  public static get switcherLabelLineHeightSmall() {
+    return this.btnLineHeightSmall;
+  }
+  public static get switcherLabelLineHeightMedium() {
+    return this.btnLineHeightMedium;
+  }
+  public static get switcherLabelLineHeightLarge() {
+    return this.btnLineHeightLarge;
+  }
+  public static get switcherLabelGapSmall() {
+    return this.btnPaddingXSmall;
+  }
+  public static get switcherLabelGapMedium() {
+    return this.btnPaddingXMedium;
+  }
+  public static get switcherLabelGapLarge() {
+    return this.btnPaddingXLarge;
+  }
 }
 
 export const Theme8pxInternal = exposeGetters(markAs8pxTheme(Theme8px));

--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -237,21 +237,21 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
 
   //#endregion
   //#region Tab
-  public static tabPaddingX = '8px';
+  public static tabPaddingX = '12px';
   public static get tabsMarginX() {
     return this.tabPaddingX;
   }
   public static get tabPaddingY() {
-    const paddingYSmall = parseInt(this.controlPaddingYSmall, 10) || 0;
+    const paddingY = parseInt(this.controlPaddingYLarge, 10) || 0;
     const borderWidth = parseInt(this.controlBorderWidth, 10) || 0;
 
-    return `${paddingYSmall + borderWidth}px`;
+    return `${paddingY + borderWidth}px`;
   }
   public static get tabFontSize() {
-    return this.fontSizeSmall;
+    return this.fontSizeLarge;
   }
   public static get tabLineHeight() {
-    return this.controlLineHeightSmall;
+    return this.controlLineHeightLarge;
   }
   public static tabBorderWidth = '2px';
   public static get tabOutlineWidth() {

--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -16,6 +16,24 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
   public static controlPaddingYMedium = '8px';
   public static controlPaddingYLarge = '11px';
   //#region Button
+  public static get btnHeightSmall() {
+    const borderWidth = parseInt(this.btnBorderWidth, 10) || 0;
+    const padding = parseInt(this.btnPaddingYSmall, 10) || 0;
+    const lineHeigh = parseInt(this.btnLineHeightSmall, 10) || 0;
+    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+  }
+  public static get btnHeightMedium() {
+    const borderWidth = parseInt(this.btnBorderWidth, 10) || 0;
+    const padding = parseInt(this.btnPaddingYMedium, 10) || 0;
+    const lineHeigh = parseInt(this.btnLineHeightMedium, 10) || 0;
+    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+  }
+  public static get btnHeightLarge() {
+    const borderWidth = parseInt(this.btnBorderWidth, 10) || 0;
+    const padding = parseInt(this.btnPaddingYLarge, 10) || 0;
+    const lineHeigh = parseInt(this.btnLineHeightLarge, 10) || 0;
+    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+  }
   public static get btnBorderWidth() {
     return this.controlBorderWidth;
   }
@@ -75,6 +93,24 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
 
   //#endregion
   //#region Input
+  public static get inputHeightSmall() {
+    const borderWidth = parseInt(this.inputBorderWidth, 10) || 0;
+    const padding = parseInt(this.inputPaddingYSmall, 10) || 0;
+    const lineHeigh = parseInt(this.inputLineHeightSmall, 10) || 0;
+    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+  }
+  public static get inputHeightMedium() {
+    const borderWidth = parseInt(this.inputBorderWidth, 10) || 0;
+    const padding = parseInt(this.inputPaddingYMedium, 10) || 0;
+    const lineHeigh = parseInt(this.inputLineHeightMedium, 10) || 0;
+    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+  }
+  public static get inputHeightLarge() {
+    const borderWidth = parseInt(this.inputBorderWidth, 10) || 0;
+    const padding = parseInt(this.inputPaddingYLarge, 10) || 0;
+    const lineHeigh = parseInt(this.inputLineHeightLarge, 10) || 0;
+    return `${2 * borderWidth + 2 * padding + lineHeigh}px`;
+  }
   public static inputWidth = '200px';
   public static get inputBorderWidth() {
     return this.controlBorderWidth;

--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -458,6 +458,9 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
   public static get switcherLabelGapLarge() {
     return this.btnPaddingXLarge;
   }
+  public static switcherButtonPaddingXSmall = '7px';
+  public static switcherButtonPaddingXMedium = '11px';
+  public static switcherButtonPaddingXLarge = '15px';
 }
 
 export const Theme8pxInternal = exposeGetters(markAs8pxTheme(Theme8px));

--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -306,7 +306,9 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
   public static get tokenShadowDisabled() {
     return `0 0 0 ${this.tokenBorderWidth} ${this.tokenBorderColorDisabled}`;
   }
-
+  //#endregion
+  //#region TokenInput
+  public static tokenInputLineHeight = '26px';
   //#endregion
   //#region Spinner
 

--- a/packages/react-ui/lib/theming/ThemeContext.md
+++ b/packages/react-ui/lib/theming/ThemeContext.md
@@ -33,6 +33,15 @@ public static contextType = ThemeContext;
 public context: Theme = this.context;
 ```
 
+Список существующих тем:
+
+| Имя                 | Описание          |
+| ------------------- | ----------------- |
+| `DEFAULT_THEME`     | Тема по умолчанию |
+| `FLAT_THEME`        | Плоская тема      |
+| `DEFAULT_THEME_8PX` | 8px тема          |
+| `FLAT_THEME_8PX`    | Плоская 8px тема  |
+
 ## Примеры использования
 
 ### Подключение плоской темы


### PR DESCRIPTION
Общий PR с доработками 8px темы:

- Починен цвет disabled `Input`
- Восстановлена работа переменных `controlHeight*` в старых темах. В новых логика останется измененной.
- Табы в 8px по умолчанию стали `large`. Плюс настроил правильное позиционирование индикатора активного таба.
- В `Switcher` шрифт, высота строки и отступ label стали зависеть от размера. А отступы в кнопках пришли в соответсвие с 8px-макетами.
- В TokenInput заработали `tokenInputFontSize` и `tokenInputLineHeight`. Токены нужно настраивать отдельно.

Обновил ссылки:

| Default  | Default 8px | Flat  | Flat 8px |
| ------------- | ------------- |------------- | ------------- |
| [default-rust.vercel.app](https://default-rust.vercel.app/) | [default8px.vercel.app](https://default8px.vercel.app/)  | [flat-navy.vercel.app](https://flat-navy.vercel.app/) | [flat8px.vercel.app](https://flat8px.vercel.app/) |

fix #2087