### PR TITLE
fix(ComboBox, SeleniumTesting): fix combobox methods stability

### DIFF
--- a/packages/react-ui-testing/SeleniumTesting/Controls/ComboBox.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/ComboBox.cs
@@ -32,7 +32,6 @@ namespace SKBKontur.SeleniumTesting.Controls
 
         public void InputTextAndSelectSingle(string inputText, Timings timings = null)
         {
-            Click();
             InputText(inputText);
             DoWithItems((x, y) => new Label(x, y), items =>
             {
@@ -51,7 +50,6 @@ namespace SKBKontur.SeleniumTesting.Controls
 
         public void InputTextAndSelectFirst(string inputText, Timings timings = null)
         {
-            Click();
             InputText(inputText);
             DoWithItems((x, y) => new Label(x, y), items =>
             {


### PR DESCRIPTION
PR на [issue](https://github.com/skbkontur/retail-ui/issues/2095)

Убрал ненужный клик в начале, который приводил к нестабильностям в некоторых ситуациях. До PR протестировано на 7 сборках подряд в kontur edi, падений как на скринах в PR замечено не было.