### PR TITLE
feat(Switcher): Добавляет disabled состояние в Switcher. fix #1370

### DIFF
--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -621,6 +621,13 @@ const styles = {
         }
       }
 
+      &:not(${cssName(styles.link(t))})${cssName(styles.disabled(t))} {
+        box-shadow: ${t.btnCheckedShadow} !important;
+        background: ${t.btnCheckedBg} !important;
+        color: ${t.btnCheckedTextColor} !important;
+        border: ${t.btnDefaultCheckedBorder} !important;
+      }
+
       &,
       &:not(${cssName(styles.focus(t))}) {
         ${cssName(styles.arrow())} {

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -178,7 +178,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
         [sizeClass]: true,
         [jsStyles.borderless(this.theme)]: !!this.props.borderless,
         [jsStyles.focus(this.theme)]: this.state.focusedByTab || !!this.props.visuallyFocused,
-        [jsStyles.checked(this.theme)]: !!this.props.checked && !this.props.disabled,
+        [jsStyles.checked(this.theme)]: !!this.props.checked,
         [jsStyles.disabled(this.theme)]: !!this.props.disabled || !!this.props.loading,
         [jsStyles.fallback(this.theme)]: isIE11 || isEdge,
       }),

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -30,6 +30,8 @@ export interface SwitcherProps {
 
   /** Размер */
   size?: SwitcherSize;
+
+  disabled?: boolean;
 }
 
 export interface SwitcherState {
@@ -46,6 +48,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
 
   public static propTypes = {
     error: PropTypes.bool,
+    disabled: PropTypes.bool,
     items: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.arrayOf(
@@ -191,6 +194,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         },
         disableFocus: true,
         size: this.props.size,
+        disabled: this.props.disabled,
       };
       return (
         <Button key={value} {...buttonProps}>

--- a/packages/react-ui/components/Switcher/__stories__/Switcher.stories.tsx
+++ b/packages/react-ui/components/Switcher/__stories__/Switcher.stories.tsx
@@ -56,3 +56,9 @@ export const Errored = () => {
   return <Component error items={['One', 'Two', 'Three']} />;
 };
 Errored.story = { name: 'errored', parameters: { creevey: { skip: [{ in: 'chromeFlat' }] } } };
+
+export const Disabled = () => {
+  return <Switcher disabled value={'One'} label={'Label for Switcher'} items={['One', 'Two', 'Three']} />;
+};
+
+Disabled.story = { name: 'disabled', parameters: { creevey: { skip: [{ in: 'chromeFlat' }] } } };


### PR DESCRIPTION
Попытался добавить disabled состояние в Switcher

Что сделано:
- Добавлен prop disabled в Switcher. Switcher прокидывает его во все Button внутри себя
- Button в состоянии checked + disabled выглядит как checked
- Добавил историю в сторибук

Где я вероятно накосячил:
- Я не уверен что я сделал корректные правки в стилях кнопки
- Вероятно я сломал кейс использования `<Button checked disabled/>`. Если вдруг кто-то ожидает, что такая комбинация пропсов рисует disabled кнопку - этот кто-то будет неприятно удивлен.
- Надо запустить скриншот-тесты