### PR TITLE
Передавать состояние Элемента меню

### DIFF
--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -124,6 +124,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
     return (
       <Component
         {...rest}
+        state={state}
         onMouseOver={this.handleMouseEnterFix}
         onMouseLeave={this.handleMouseLeave}
         className={className}


### PR DESCRIPTION
Если я пытаюсь кастомизировать `MenuItem` через свойство `component`, то не могу пробросить состояние наведения или выбора.
Мне эта фича нужна в 0.х версии, мы еще не успели перейти на новый lts