### PR TITLE
fix: Добавил babelrc в игнор, чтобы он не мешался при сборке

### DIFF
--- a/packages/retail-ui/.npmignore
+++ b/packages/retail-ui/.npmignore
@@ -17,3 +17,4 @@ __mocks__
 !/lib/**/*.d.ts
 !/testing/**/*.d.ts
 !/typings/**/*.d.ts
+.babelrc


### PR DESCRIPTION
Мы хотим перейти на lts. При этом у нас еще babel6. Если попытаться собрать retail-ui пакет, то бабель смотрит на локальный `babelrc` пакета. Там указаны плагины из babel7. В итоге получаем ошибку: 
```Requires Babel "^7.0.0-0", but was loaded with "6.26.3".```
Даже если это могло бы работать, этих плагинов нет в `dependencies` пакета.

Для babel7 этот файл будет бесполезен, бабел перестал смотреть на конфиги снаружи.