### PR TITLE
fix(Select.styles): fix span width with left icon

### DIFF
--- a/packages/react-ui/components/Select/Select.styles.ts
+++ b/packages/react-ui/components/Select/Select.styles.ts
@@ -64,7 +64,7 @@ const styles = {
       box-sizing: border-box;
       display: inline-block;
       max-width: 100%;
-      width: 100%;
+      width: auto;
       position: relative;
     `;
   },


### PR DESCRIPTION
Для тега span указана ширина 100%. Если мы добавляем иконку, то ширина иконки+span(100%) выходят за границы кнопки. Задание with: auto при наличии иконки решает эту проблему

![image](https://user-images.githubusercontent.com/14909082/91784168-ab463a80-ec1b-11ea-8039-8899e91dcf15.png)
