### PR TITLE
feat(react-ui-validations): optimize ReactUiDetection, inc min react-ui to 0.53.7

### DIFF
--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "react": ">=16.9",
     "react-dom": ">=16.9",
-    "retail-ui": ">=0.53.7 <2.0.0"
+    "retail-ui": ">=0.53.7 <3.0.0"
   },
   "dependencies": {
     "prop-types": "^15.7.2",

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "react": ">=16.9",
     "react-dom": ">=16.9",
-    "retail-ui": ">=0.52.0 <2.0.0"
+    "retail-ui": ">=0.53.7 <2.0.0"
   },
   "dependencies": {
     "prop-types": "^15.7.2",

--- a/packages/react-ui-validations/src/ReactUiDetection.ts
+++ b/packages/react-ui-validations/src/ReactUiDetection.ts
@@ -5,23 +5,20 @@ declare function require(name: string): any;
 const defaultOrNamed = (module: any, component: string) =>
   module && module.__esModule && module.default ? module.default : module[component];
 
-const DatePicker = defaultOrNamed(require(REACT_UI_PACKAGE + '/components/DatePicker'), 'DatePicker');
-const RadioGroup = defaultOrNamed(require(REACT_UI_PACKAGE + '/components/RadioGroup'), 'RadioGroup');
-const TokenInput = defaultOrNamed(require(REACT_UI_PACKAGE + '/components/TokenInput'), 'TokenInput');
 const Tooltip = defaultOrNamed(require(REACT_UI_PACKAGE + '/components/Tooltip'), 'Tooltip');
 
 export { Tooltip };
 
 export class ReactUiDetection {
   public static isDatePicker(childrenArray: any): boolean {
-    return childrenArray != null && childrenArray.type === DatePicker;
+    return childrenArray != null && childrenArray.type?.__KONTUR_REACT_UI__ === 'DatePicker';
   }
 
   public static isRadioGroup(childrenArray: any): boolean {
-    return childrenArray != null && childrenArray.type === RadioGroup;
+    return childrenArray != null && childrenArray.type?.__KONTUR_REACT_UI__ === 'RadioGroup';
   }
 
   public static isTokenInput(childrenArray: any): boolean {
-    return childrenArray != null && childrenArray.type === TokenInput;
+    return childrenArray != null && childrenArray.type?.__KONTUR_REACT_UI__ === 'TokenInput';
   }
 }


### PR DESCRIPTION
Убрал лишний импорт компонентов. Актуализировал версию react-ui в peerDependencies.

Немного повысилась минимальная поддерживаемая версия контролов, но не так, чтобы breaking change. Поэтому пометил как `feat`.

fix #2150