### PR TITLE
test(react-ui): fix flacky screenshots

### DIFF
--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -234,6 +234,7 @@ SimpleComboboxStory.story = {
               bridge: true,
             })
             .click(this.browser.findElement({ css: 'body' }))
+            .pause(500)
             .perform();
           await this.browser
             .actions({

--- a/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
+++ b/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
@@ -150,6 +150,7 @@ WithMouseeventHandlers.story = {
     creevey: {
       tests: {
         async opened() {
+          await delay(1000);
           await this.browser
             .actions({
               bridge: true,
@@ -159,6 +160,7 @@ WithMouseeventHandlers.story = {
           await this.expect(await this.takeScreenshot()).to.matchImage('opened');
         },
         async ['DateSelect month']() {
+          await delay(1000);
           await this.browser
             .actions({
               bridge: true,
@@ -178,6 +180,7 @@ WithMouseeventHandlers.story = {
           await this.expect(await this.takeScreenshot()).to.matchImage('DateSelect month');
         },
         async ['DateSelect year']() {
+          await delay(1000);
           await this.browser
             .actions({
               bridge: true,
@@ -229,6 +232,7 @@ DatePickerWithMinMaxDate.story = {
     creevey: {
       tests: {
         async ['DateSelect months']() {
+          await delay(1000);
           await this.browser
             .actions({
               bridge: true,
@@ -248,6 +252,7 @@ DatePickerWithMinMaxDate.story = {
           await this.expect(await this.takeScreenshot()).to.matchImage('DateSelect months');
         },
         async ['DateSelect years']() {
+          await delay(1000);
           await this.browser
             .actions({
               bridge: true,


### PR DESCRIPTION
Пофиксил два постоянно мигающих теста:

| DatePicker | ComboBox |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/4607770/94770281-a8cb3200-03cd-11eb-8290-465268e010e6.png) | ![image](https://user-images.githubusercontent.com/4607770/94770337-d1532c00-03cd-11eb-9673-30fc8a9e68ab.png) |

