### PR TITLE
test(smoke): use latest cra version

### DIFF
--- a/packages/react-ui-smoke-test/smoke.test.ts
+++ b/packages/react-ui-smoke-test/smoke.test.ts
@@ -67,7 +67,7 @@ function buildReactUI(reactUIPackagePath: string) {
 }
 
 function initApplication(appDirectory: string, templateDirectory: string, reactUIPackagePath: string) {
-  execSync(`npx create-react-app@next ${appDirectory} --template file:${templateDirectory}`, { stdio: 'inherit' });
+  execSync(`npx create-react-app@latest ${appDirectory} --template file:${templateDirectory}`, { stdio: 'inherit' });
 
   execSync(`npm i @types/node @types/react @types/react-dom @types/jest -D`, { cwd: appDirectory, stdio: 'inherit' });
 


### PR DESCRIPTION
Стали [падать](https://tc.skbkontur.ru/buildConfiguration/FrontendInfrastructure_Packages_ReactUI_LintTest/19457641) smoke-тесты из-за использования create-react-app@next. Видимо там что-то [сломалось](https://github.com/facebook/create-react-app/issues/9910). Поменял на latest.