### PR TITLE
fix(ModalStack): add fallback for `eventemitter3` from latest versions

### DIFF
--- a/packages/retail-ui/components/Modal/Modal.tsx
+++ b/packages/retail-ui/components/Modal/Modal.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import FocusLock from 'react-focus-lock';
-import { EventSubscription } from 'fbemitter';
 import { isKeyEscape } from '../../lib/events/keyboard/identifiers';
 import LayoutEvents from '../../lib/LayoutEvents';
+import { ModalStackSubscription } from '../ModalStack/ModalStack';
 import RenderContainer from '../RenderContainer/RenderContainer';
 import ZIndex from '../ZIndex/ZIndex';
 import stopPropagation from '../../lib/events/stopPropagation';
@@ -103,7 +103,7 @@ export default class Modal extends React.Component<ModalProps, ModalState> {
   };
 
   private theme!: ITheme;
-  private stackSubscription: EventSubscription | null = null;
+  private stackSubscription: ModalStackSubscription | null = null;
   private containerNode: HTMLDivElement | null = null;
   private mouseDownTarget: EventTarget | null = null;
   private mouseUpTarget: EventTarget | null = null;

--- a/packages/retail-ui/components/ModalStack/ModalStack.ts
+++ b/packages/retail-ui/components/ModalStack/ModalStack.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EventEmitter, EventSubscription } from 'fbemitter';
+import { EventEmitter } from 'fbemitter';
 
 interface StackInfo {
   emitter: EventEmitter;
@@ -10,16 +10,32 @@ interface GlobalWithStackInfo {
   __ReactUIStackInfo?: StackInfo;
 }
 
+export interface ModalStackSubscription {
+  remove: () => void;
+}
+
 export default class ModalStack {
   public static add(
     component: React.Component,
     onChange: (stack: ReadonlyArray<React.Component>) => void,
-  ): EventSubscription {
+  ): ModalStackSubscription {
     const { emitter, mounted } = ModalStack.getStackInfo();
     mounted.unshift(component);
-    const subscription = emitter.addListener('change', () => onChange([...mounted]));
+    const changeHandler = () => onChange([...mounted]);
+    const subscription = emitter.addListener('change', changeHandler);
     emitter.emit('change');
-    return subscription;
+    return {
+      remove(): void {
+        // Forwards compatible with versions 2.x which using the eventemitter3 package
+        if ('removeListener' in subscription) {
+          // @ts-ignore
+          emitter.removeListener('change', changeHandler);
+          return;
+        }
+
+        subscription.remove();
+      },
+    };
   }
 
   public static remove(component: React.Component) {

--- a/packages/retail-ui/components/SidePage/SidePage.tsx
+++ b/packages/retail-ui/components/SidePage/SidePage.tsx
@@ -1,10 +1,10 @@
-import { EventSubscription } from 'fbemitter';
 import * as React from 'react';
 import { isKeyEscape } from '../../lib/events/keyboard/identifiers';
 import LayoutEvents from '../../lib/LayoutEvents';
 import stopPropagation from '../../lib/events/stopPropagation';
 import HideBodyVerticalScroll from '../HideBodyVerticalScroll/HideBodyVerticalScroll';
 import ModalStack from '../ModalStack';
+import { ModalStackSubscription } from '../ModalStack/ModalStack';
 import RenderContainer from '../RenderContainer/RenderContainer';
 import RenderLayer from '../RenderLayer';
 import ZIndex from '../ZIndex';
@@ -92,7 +92,7 @@ class SidePage extends React.Component<SidePageProps, SidePageState> {
   public static Container = SidePageContainer;
   public state: SidePageState = {};
   private theme!: ITheme;
-  private stackSubscription: EventSubscription | null = null;
+  private stackSubscription: ModalStackSubscription | null = null;
   private layoutRef: HTMLElement | null = null;
   private footer: SidePageFooter | null = null;
 


### PR DESCRIPTION
Fixes #2197

#### Таблица совместимости компонента `ModalStack` в различных версиях.
| 1\2 | `0.53.12` | `>1.11.6` | `>2.7` |
| --- | :---: | :---: | :---: |
| `0.53.12` | ✅ | ✅ | ✅ |
| `>1.11.6` | ✅ | ✅ | ✅ |
| `>2.7` | ❌ | ✅ | ✅ |

Сейчас ошибка возникает в единственном случае, когда сначала используется `ModalStack@2.x`, а затем `ModalStack@0.x`.