### PR TITLE
fix(SeleniumTesting): set up correct platform for webdriver

### DIFF
--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -71,7 +71,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
                 var wdHub = "http://screen:shot@grid.testkontur.ru/wd/hub";
                 ChromeOptions options = new ChromeOptions();
 
-                options.AddAdditionalCapability(CapabilityType.Platform, "Windows 10", true);
+                options.AddAdditionalCapability(CapabilityType.Platform, "windows", true);
                 options.AddAdditionalCapability("name", TestContext.CurrentContext.Test.Name, true);
                 options.AddAdditionalCapability("tunnel-identifier", this.tunnelIdentifier, true);
                 options.AddAdditionalCapability("maxDuration", 10800, true);


### PR DESCRIPTION
На гриде перестали проходить селениумные тесты, с ошибкой:
"OpenQA.Selenium.WebDriverException : unsupported browser: chrome-70-Windows 10"

idevops:
> указывайте в качестве платформы "windows", а не "Windows 10"
> раньше у нас были только виндовые ноды потому поле платформа просто игнорилась
но недавно мы стали заводить линуксовые ноды, потому поле стало выполнять свою функцию

