### PR TITLE
chore: hold color of selection for screenshot tests

### DIFF
--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -1,5 +1,5 @@
-import { setFilter } from '@skbkontur/react-props2attrs';
 import React from 'react';
+import { setFilter } from '@skbkontur/react-props2attrs';
 import { findAmongParents } from '@skbkontur/react-sorge/lib';
 import { addDecorator, addParameters } from '@storybook/react';
 import { withCreevey } from 'creevey';

--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { setFilter } from '@skbkontur/react-props2attrs';
+import React from 'react';
 import { findAmongParents } from '@skbkontur/react-sorge/lib';
 import { addDecorator, addParameters } from '@storybook/react';
 import { withCreevey } from 'creevey';
@@ -68,3 +68,7 @@ addParameters({
     storySort: (a, b) => (a[1].kind === b[1].kind ? 0 : a[1].id.localeCompare(b[1].id, undefined, { numeric: true })),
   },
 });
+
+if (isTestEnv) {
+  import('../lib/styles/HoldSelectionColor');
+}

--- a/packages/react-ui/lib/styles/HoldSelectionColor.ts
+++ b/packages/react-ui/lib/styles/HoldSelectionColor.ts
@@ -1,8 +1,8 @@
 import { injectGlobal } from '../theming/Emotion';
-import { isChrome, isFirefox, isIE11 } from '../utils';
+import { isChrome } from '../utils';
 
 // This is for screenshot tests
-const Highlight = isIE11 || isFirefox ? '#3399ff' : isChrome ? '#3390ff' : 'Highlight';
+const Highlight = isChrome ? '#3390ff' : '#3399ff';
 
 injectGlobal`
   *::selection {

--- a/packages/react-ui/lib/styles/HoldSelectionColor.ts
+++ b/packages/react-ui/lib/styles/HoldSelectionColor.ts
@@ -1,0 +1,15 @@
+import { injectGlobal } from '../theming/Emotion';
+import { isChrome, isFirefox, isIE11 } from '../utils';
+
+// This is for screenshot tests
+const Highlight = isIE11 || isFirefox ? '#3399ff' : isChrome ? '#3390ff' : 'Highlight';
+
+injectGlobal`
+  *::selection {
+    background-color: ${Highlight};
+  }
+  input::selection,
+  textarea::selection {
+    color: white;
+  }
+`;


### PR DESCRIPTION
Зафиксировал фоновый цвет выделения текста для скриншотных тестов.
Прогнал скриншоты на разных агентах (на всякий).