### PR TITLE
fix(Autocomplete): use prop `active` from `RenderLayer`

### DIFF
--- a/packages/retail-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/retail-ui/components/Autocomplete/Autocomplete.tsx
@@ -144,8 +144,10 @@ class Autocomplete extends React.Component<AutocompleteProps, AutocomplpeteState
       onFocus: this.handleFocus,
       ref: this.refInput,
     };
+    const active = this.state.items !== null;
+
     return (
-      <RenderLayer onFocusOutside={this.handleBlur} onClickOutside={this.handleClickOutside}>
+      <RenderLayer onFocusOutside={this.handleBlur} onClickOutside={this.handleClickOutside} active={active}>
         <span style={{ display: 'inline-block' }}>
           <Input {...inputProps} />
           {this.renderMenu()}


### PR DESCRIPTION
`RenderLayer` не прекращал прослушивать страницу и дергать колбэки. Из-за чего, после установки `Autocomplete` на страницу, при каждом клике дергался специальный фолбэк для IE11 и Edge - `fixClickFocusIE`.

Даты в календаре датапикера реализованы кнопками. Из-за чего, используемый пакет `tabbable.isFocusable` возвращает `true`. Хоть на этих кнопках и установлено `tabIndex={-1}`, они всё равно могут быть [фокусируемыми](https://github.com/focus-trap/tabbable#isfocusable).

> All tabbable elements are focusable, but not all focusable elements are tabbable. For example, elements with tabindex="-1" are focusable but not tabbable.

Для решения проблемы, я решил использовать проп `active` у `RenderLayer`, как это делает `ComboBox`. Он тоже использует этот фолбэк, но таких проблем не вызывает.

Fix #2267