### PR TITLE
feat: props forwarding [inputs]

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -45,8 +45,6 @@ export interface ButtonProps extends CommonProps, React.ButtonHTMLAttributes<HTM
   /** @ignore */
   corners?: number;
 
-  // disabled?: boolean;
-
   /** @ignore */
   disableFocus?: boolean;
 
@@ -65,9 +63,6 @@ export interface ButtonProps extends CommonProps, React.ButtonHTMLAttributes<HTM
 
   /** `type ButtonSize = "small" | "medium" | "large"` */
   size?: ButtonSize;
-
-  /** `type ButtonType = "button" | "submit" | "reset"` */
-  // type?: ButtonType;
 
   /**
    * Вариант использования. Влияет на цвет кнопки.

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -12,10 +12,9 @@ import { jsStyles } from './Button.styles';
 import { Corners } from './Corners';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
-export type ButtonType = 'button' | 'submit' | 'reset';
 export type ButtonUse = 'default' | 'primary' | 'success' | 'danger' | 'pay' | 'link';
 
-export interface ButtonProps extends CommonProps {
+export interface ButtonProps extends CommonProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** @ignore */
   _noPadding?: boolean;
 
@@ -37,8 +36,6 @@ export interface ButtonProps extends CommonProps {
    */
   arrow?: boolean | 'left';
 
-  autoFocus?: boolean;
-
   borderless?: boolean;
 
   checked?: boolean;
@@ -48,7 +45,7 @@ export interface ButtonProps extends CommonProps {
   /** @ignore */
   corners?: number;
 
-  disabled?: boolean;
+  // disabled?: boolean;
 
   /** @ignore */
   disableFocus?: boolean;
@@ -66,25 +63,11 @@ export interface ButtonProps extends CommonProps {
 
   narrow?: boolean;
 
-  onBlur?: React.FocusEventHandler<HTMLButtonElement>;
-
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-
-  onFocus?: React.FocusEventHandler<HTMLButtonElement>;
-
-  onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
-
-  onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
-
-  onMouseLeave?: React.MouseEventHandler<HTMLButtonElement>;
-
-  onMouseOver?: React.MouseEventHandler<HTMLButtonElement>;
-
   /** `type ButtonSize = "small" | "medium" | "large"` */
   size?: ButtonSize;
 
   /** `type ButtonType = "button" | "submit" | "reset"` */
-  type?: ButtonType;
+  // type?: ButtonType;
 
   /**
    * Вариант использования. Влияет на цвет кнопки.
@@ -99,7 +82,6 @@ export interface ButtonProps extends CommonProps {
   warning?: boolean;
 
   width?: number | string;
-  tabIndex?: number;
 }
 
 export interface ButtonState {

--- a/packages/react-ui/components/Button/__tests__/Button-test.tsx
+++ b/packages/react-ui/components/Button/__tests__/Button-test.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 
-import { Button, ButtonType } from '../Button';
+import { Button, ButtonProps } from '../Button';
 
 describe('Button', () => {
   it('has correct label', () => {
@@ -19,7 +19,7 @@ describe('Button', () => {
     expect(onClick.mock.calls.length).toBe(1);
   });
 
-  (['submit', 'button', 'reset'] as ButtonType[]).forEach(type => {
+  (['submit', 'button', 'reset'] as ButtonProps['type'][]).forEach(type => {
     it(`sets type ${type} when type=${type} specified`, () => {
       const wrapper = mount(<Button type={type} />);
       expect(wrapper.find('button').prop('type')).toBe(type);

--- a/packages/react-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/react-ui/components/ComboBox/ComboBox.tsx
@@ -1,155 +1,136 @@
 import React from 'react';
 
 import { CustomComboBox } from '../../internal/CustomComboBox';
-import { Nullable } from '../../typings/utility-types';
+import { Nullable, Override } from '../../typings/utility-types';
 import { MenuItemState } from '../MenuItem';
-import { InputIconType } from '../Input';
-import { CommonProps } from '../../internal/CommonWrapper';
+import { InputProps } from '../Input';
 
-export interface ComboBoxProps<T> extends CommonProps {
-  align?: 'left' | 'center' | 'right';
-  /**
-   * Вызывает функцию поиска `getItems` при фокусе и очистке поля ввода
-   * @default true
-   */
-  searchOnFocus?: boolean;
-  /**
-   * Рисует справа иконку в виде стрелки
-   * @default true
-   */
-  drawArrow?: boolean;
+export type ComboBoxProps<T> = Override<
+  InputProps,
+  {
+    /**
+     * Вызывает функцию поиска `getItems` при фокусе и очистке поля ввода
+     * @default true
+     */
+    searchOnFocus?: boolean;
+    /**
+     * Рисует справа иконку в виде стрелки
+     * @default true
+     */
+    drawArrow?: boolean;
 
-  autoFocus?: boolean;
+    /**
+     * Не использовать Portal для рендеринга меню.
+     * См. https://github.com/skbkontur/retail-ui/issues/15
+     * @default false
+     */
+    disablePortal?: boolean;
 
-  borderless?: boolean;
+    /**
+     * Функция поиска элементов, должна возвращать Promise с массивом элементов.
+     * По умолчанию ожидаются объекты с типом `{ value: string, label: string }`.
+     *
+     * Элементы могут быть любого типа. В этом случае необходимо определить
+     * свойства `itemToValue`, `renderValue`, `renderItem`, `valueToString`
+     */
+    getItems: (query: string) => Promise<T[]>;
 
-  /**
-   * Не использовать Portal для рендеринга меню.
-   * См. https://github.com/skbkontur/retail-ui/issues/15
-   * @default false
-   */
-  disablePortal?: boolean;
+    /**
+     * Необходим для сравнения полученных результатов с `value`
+     * @default item => item.label
+     */
+    itemToValue: (item: T) => string | number;
 
-  disabled?: boolean;
+    menuAlign?: 'left' | 'right';
 
-  error?: boolean;
+    onBlur?: () => void;
 
-  leftIcon?: InputIconType;
+    /** Вызывается при изменении `value` */
+    onValueChange?: (value: T) => void;
 
-  /**
-   * Функция поиска элементов, должна возвращать Promise с массивом элементов.
-   * По умолчанию ожидаются объекты с типом `{ value: string, label: string }`.
-   *
-   * Элементы могут быть любого типа. В этом случае необходимо определить
-   * свойства `itemToValue`, `renderValue`, `renderItem`, `valueToString`
-   */
-  getItems: (query: string) => Promise<T[]>;
+    onFocus?: () => void;
 
-  /**
-   * Необходим для сравнения полученных результатов с `value`
-   * @default item => item.label
-   */
-  itemToValue: (item: T) => string | number;
+    /**
+     * Вызывается при изменении текста в поле ввода,
+     * если результатом функции будет строка,
+     * то она станет следующим состояним полем ввода
+     */
+    onInputValueChange?: (value: string) => Nullable<string> | void;
 
-  maxLength?: number;
+    /**
+     * Функция для обработки ситуации, когда была введена
+     * строка в инпут и был потерян фокус с элемента.
+     *
+     * Если при потере фокуса в выпадающем списке будет только один
+     * элемент и  результат `renderValue` с этим элементом будет
+     * совпадать со значение в текстовом поле, то
+     * сработает onValueChange со значением данного элемента
+     *
+     * Сама функция также может вернуть значение,
+     * неравное `undefined`,
+     * с которым будет вызван onValueChange.
+     */
+    onUnexpectedInput?: (value: string) => void | null | T;
 
-  menuAlign?: 'left' | 'right';
+    /**
+     * Функция отрисовки элементов результата поиска.
+     * Не применяется если элемент является функцией или React-элементом
+     * @default item => item.label
+     */
+    renderItem: (item: T, state?: MenuItemState) => React.ReactNode;
 
-  onBlur?: () => void;
+    /**
+     * Функция для отрисовки сообщения о пустом результате поиска
+     * Если есть renderAddButton - не работает
+     */
+    renderNotFound?: () => React.ReactNode;
 
-  /** Вызывается при изменении `value` */
-  onValueChange?: (value: T) => void;
+    /**
+     * Функция отображающаяя сообщение об общем количестве элементов
+     */
+    renderTotalCount?: (found: number, total: number) => React.ReactNode;
 
-  onFocus?: () => void;
+    /**
+     * Функция отрисовки выбранного значения
+     * @default item => item.label
+     */
+    renderValue: (item: T) => React.ReactNode;
 
-  /**
-   * Вызывается при изменении текста в поле ввода,
-   * если результатом функции будет строка,
-   * то она станет следующим состояним полем ввода
-   */
-  onInputValueChange?: (value: string) => Nullable<string> | void;
+    /**
+     * Функция отрисовки кнопки добавления в выпадающем списке
+     */
+    renderAddButton?: (query?: string) => React.ReactNode;
 
-  /**
-   * Функция для обработки ситуации, когда была введена
-   * строка в инпут и был потерян фокус с элемента.
-   *
-   * Если при потере фокуса в выпадающем списке будет только один
-   * элемент и  результат `renderValue` с этим элементом будет
-   * совпадать со значение в текстовом поле, то
-   * сработает onValueChange со значением данного элемента
-   *
-   * Сама функция также может вернуть значение,
-   * неравное `undefined`,
-   * с которым будет вызван onValueChange.
-   */
-  onUnexpectedInput?: (value: string) => void | null | T;
+    /**
+     * Общее количество элементов.
+     * Необходим для работы `renderTotalCount`
+     */
+    totalCount?: number;
 
-  placeholder?: string;
+    /**
+     * Выбранное значение
+     * Ожидается, что `value` того же типа что и элементы в массиве,
+     * возвращаемом в `getItems`
+     */
+    value?: Nullable<T>;
 
-  /**
-   * Функция отрисовки элементов результата поиска.
-   * Не применяется если элемент является функцией или React-элементом
-   * @default item => item.label
-   */
-  renderItem: (item: T, state?: MenuItemState) => React.ReactNode;
+    /**
+     * Необходим для преобразования `value` в строку при фокусировке
+     * @default item => item.label
+     */
+    valueToString: (item: T) => string;
 
-  /**
-   * Функция для отрисовки сообщения о пустом результате поиска
-   * Если есть renderAddButton - не работает
-   */
-  renderNotFound?: () => React.ReactNode;
+    maxMenuHeight?: number | string;
 
-  /**
-   * Функция отображающаяя сообщение об общем количестве элементов
-   */
-  renderTotalCount?: (found: number, total: number) => React.ReactNode;
+    onMouseEnter?: (e: React.MouseEvent) => void;
 
-  /**
-   * Функция отрисовки выбранного значения
-   * @default item => item.label
-   */
-  renderValue: (item: T) => React.ReactNode;
+    onMouseOver?: (e: React.MouseEvent) => void;
 
-  /**
-   * Функция отрисовки кнопки добавления в выпадающем списке
-   */
-  renderAddButton?: (query?: string) => React.ReactNode;
+    onMouseLeave?: (e: React.MouseEvent) => void;
 
-  /**
-   * Общее количество элементов.
-   * Необходим для работы `renderTotalCount`
-   */
-  totalCount?: number;
-
-  /**
-   * Выбранное значение
-   * Ожидается, что `value` того же типа что и элементы в массиве,
-   * возвращаемом в `getItems`
-   */
-  value?: Nullable<T>;
-
-  /**
-   * Необходим для преобразования `value` в строку при фокусировке
-   * @default item => item.label
-   */
-  valueToString: (item: T) => string;
-
-  size?: 'small' | 'medium' | 'large';
-
-  warning?: boolean;
-
-  width?: string | number;
-
-  maxMenuHeight?: number | string;
-
-  onMouseEnter?: (e: React.MouseEvent) => void;
-
-  onMouseOver?: (e: React.MouseEvent) => void;
-
-  onMouseLeave?: (e: React.MouseEvent) => void;
-
-  onInputKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
-}
+    onInputKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
+  }
+>;
 
 export interface ComboBoxItem {
   value: string;

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -52,7 +52,7 @@ describe('ComboBox', () => {
 
     wrapper.find(ComboBoxView).prop('onFocus')?.();
     wrapper.update();
-    wrapper.find('input').simulate('change', { target: { value: 'world' } });
+    wrapper.find('input:not([readOnly])').simulate('change', { target: { value: 'world' } });
 
     expect(search).toBeCalled();
     expect(search).toHaveBeenCalledTimes(2);
@@ -121,7 +121,7 @@ describe('ComboBox', () => {
     await promise;
     wrapper.update();
 
-    wrapper.find('input').simulate('keydown', { key: 'Enter' });
+    wrapper.find('input:not([readOnly])').simulate('keydown', { key: 'Enter' });
 
     expect(onValueChange).toBeCalledWith('one');
     expect(onValueChange).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe('ComboBox', () => {
     await promise;
     wrapper.update();
 
-    wrapper.find('input').simulate('keydown', { key: 'Enter' });
+    wrapper.find('input:not([readOnly])').simulate('keydown', { key: 'Enter' });
 
     await delay(0);
 
@@ -150,7 +150,7 @@ describe('ComboBox', () => {
     await promise;
     wrapper.update();
 
-    const inputNode = wrapper.find('input').getDOMNode() as HTMLElement;
+    const inputNode = wrapper.find('input:not([readOnly])').getDOMNode() as HTMLElement;
 
     inputNode.blur(); // simulate blur from real click
     wrapper
@@ -171,7 +171,7 @@ describe('ComboBox', () => {
 
     wrapper.find(ComboBoxView).prop('onFocus')?.();
     wrapper.update();
-    wrapper.find('input').simulate('change', { target: { value: 'one' } });
+    wrapper.find('input:not([readOnly])').simulate('change', { target: { value: 'one' } });
 
     await promise;
 
@@ -196,7 +196,7 @@ describe('ComboBox', () => {
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
       await delay(0);
-      wrapper.find('input').simulate('change', { target: { value: values.pop() } });
+      wrapper.find('input:not([readOnly])').simulate('change', { target: { value: values.pop() } });
       clickOutside();
     }
 
@@ -245,7 +245,7 @@ describe('ComboBox', () => {
       expect(wrapper.find(CustomComboBox).instance().state).toMatchObject({
         opened: false,
       });
-      wrapper.find('input').simulate('blur');
+      wrapper.find('input:not([readOnly])').simulate('blur');
 
       expect(onBlur).toHaveBeenCalledTimes(1);
     });
@@ -316,7 +316,7 @@ describe('ComboBox', () => {
     await promise;
     wrapper.update();
 
-    const input = wrapper.find('input');
+    const input = wrapper.find('input:not([readOnly])');
     expect(input.prop('maxLength')).toBe(2);
   });
 
@@ -337,7 +337,7 @@ describe('ComboBox', () => {
     wrapper.find(ComboBoxView).prop('onFocus')?.();
     wrapper.update();
     await delay(0);
-    wrapper.find('input').simulate('change', { target: { value: 'foo' } });
+    wrapper.find('input:not([readOnly])').simulate('change', { target: { value: 'foo' } });
 
     clickOutside();
     wrapper.update();
@@ -412,19 +412,19 @@ describe('ComboBox', () => {
     const check = (wrapper: ReactWrapper<ComboBoxProps<any>, {}, ComboBox<any>>) => {
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
-      expect(wrapper.find('input').prop('value')).toBe(VALUES[0].label);
+      expect(wrapper.find('input:not([readOnly])').prop('value')).toBe(VALUES[0].label);
 
       wrapper.instance().blur();
       wrapper.setProps({ value: VALUES[1] });
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
-      expect(wrapper.find('input').prop('value')).toBe(VALUES[1].label);
+      expect(wrapper.find('input:not([readOnly])').prop('value')).toBe(VALUES[1].label);
 
       wrapper.instance().blur();
       wrapper.setProps({ value: null });
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
-      expect(wrapper.find('input').prop('value')).toBe('');
+      expect(wrapper.find('input:not([readOnly])').prop('value')).toBe('');
     };
 
     it('in default mode', () => {
@@ -450,14 +450,14 @@ describe('ComboBox', () => {
     const check = (wrapper: any) => {
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
-      wrapper.find('input').simulate('change', { target: { value: 'two' } });
+      wrapper.find('input:not([readOnly])').simulate('change', { target: { value: 'two' } });
 
       clickOutside();
       wrapper.setProps({ value: null });
 
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
-      expect(wrapper.find('input').prop('value')).toBe('two');
+      expect(wrapper.find('input:not([readOnly])').prop('value')).toBe('two');
     };
 
     it('in default mode', () => {
@@ -493,9 +493,9 @@ describe('ComboBox', () => {
 
     wrapper.find(ComboBoxView).prop('onFocus')?.();
     wrapper.update();
-    wrapper.find('input').simulate('change', { target: { value: 'foo' } });
+    wrapper.find('input:not([readOnly])').simulate('change', { target: { value: 'foo' } });
 
-    expect(wrapper.find('input').prop('value')).toBe('foo');
+    expect(wrapper.find('input:not([readOnly])').prop('value')).toBe('foo');
 
     clickOutside();
     wrapper.instance().reset();
@@ -530,7 +530,7 @@ describe('ComboBox', () => {
 
     wrapper.find(ComboBoxView).prop('onFocus')?.();
     wrapper.update();
-    wrapper.find('input').simulate('change', { target: { value: 'Two' } });
+    wrapper.find('input:not([readOnly])').simulate('change', { target: { value: 'Two' } });
 
     await delay(300);
 
@@ -621,7 +621,7 @@ describe('ComboBox', () => {
     });
 
     it('click on item', async () => {
-      const inputNode = wrapper.find('input').getDOMNode() as HTMLInputElement;
+      const inputNode = wrapper.find('input:not([readOnly])').getDOMNode() as HTMLInputElement;
 
       inputNode.blur(); // simulate blur from real click
 
@@ -643,14 +643,14 @@ describe('ComboBox', () => {
 
     it('Enter on item', async () => {
       wrapper
-        .find('input')
+        .find('input:not([readOnly])')
         .simulate('keydown', { key: 'ArrowDown' })
         .simulate('keydown', { key: 'Enter' });
 
       await delay(0);
       wrapper.update();
 
-      const inputNode = wrapper.find('input').getDOMNode() as HTMLInputElement;
+      const inputNode = wrapper.find('input:not([readOnly])').getDOMNode() as HTMLInputElement;
 
       expect(inputNode).toBeTruthy();
       expect(inputNode).toBe(document.activeElement); // input has focus
@@ -666,7 +666,7 @@ describe('ComboBox', () => {
     type TComboBoxWrapper = ReactWrapper<ComboBoxProps<typeof VALUE>, {}, ComboBox<typeof VALUE>>;
     const clickOnInput = (comboboxWrapper: TComboBoxWrapper) => {
       comboboxWrapper.update();
-      comboboxWrapper.find('input').simulate('click');
+      comboboxWrapper.find('input:not([readOnly])').simulate('click');
     };
     let getItems: jest.Mock<Promise<Array<typeof VALUE>>>;
     let promise: Promise<{}>;

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -209,7 +209,7 @@ describe('ComboBox', () => {
     const onFocus = jest.fn();
     const wrapper = mount<ComboBox<any>>(<ComboBox onFocus={onFocus} getItems={() => Promise.resolve([])} />);
 
-    wrapper.find('[tabIndex=0]').simulate('focus');
+    wrapper.find('span[tabIndex=0]').simulate('focus');
 
     expect(onFocus).toHaveBeenCalledTimes(1);
   });

--- a/packages/react-ui/components/DateInput/DateInput.tsx
+++ b/packages/react-ui/components/DateInput/DateInput.tsx
@@ -6,11 +6,13 @@ import { LENGTH_FULLDATE, MAX_FULLDATE, MIN_FULLDATE } from '../../lib/date/cons
 import { InternalDateComponentType } from '../../lib/date/types';
 import { Theme } from '../../lib/theming/Theme';
 import { DatePickerLocale, DatePickerLocaleHelper } from '../DatePicker/locale';
+import { InputProps } from '../Input';
 import { InputLikeText } from '../../internal/InputLikeText';
 import { locale } from '../../lib/locale/decorators';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { CalendarIcon } from '../../internal/icons/16px';
 import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { Override } from '../../typings/utility-types';
 
 import { DateFragmentsView } from './DateFragmentsView';
 import { jsStyles } from './DateInput.styles';
@@ -25,43 +27,43 @@ export interface DateInputState {
   dragged: boolean;
 }
 
-export interface DateInputProps extends CommonProps {
-  autoFocus?: boolean;
-  value: string;
-  error?: boolean;
-  warning?: boolean;
-  disabled?: boolean;
-  /**
-   * Минимальная дата.
-   * @default '01.01.1900'
-   */
-  minDate: string;
-  /**
-   * Максимальная дата
-   * @default '31.12.2099'
-   */
-  maxDate: string;
-  /**
-   * Ширина поля
-   * @default 125
-   */
-  width?: string | number;
-  withIcon?: boolean;
-  /**
-   * Размер поля
-   * @default 'small'
-   */
-  size: 'small' | 'large' | 'medium';
-  onBlur?: (x0: React.FocusEvent<HTMLElement>) => void;
-  onFocus?: (x0: React.FocusEvent<HTMLElement>) => void;
-  /**
-   * Вызывается при изменении `value`
-   *
-   * @param value - строка в формате `dd.mm.yyyy`.
-   */
-  onValueChange?: (value: string) => void;
-  onKeyDown?: (x0: React.KeyboardEvent<HTMLElement>) => void;
-}
+export interface DateInputProps
+  extends CommonProps,
+    Override<
+      InputProps,
+      {
+        value: string;
+        /**
+         * Минимальная дата.
+         * @default '01.01.1900'
+         */
+        minDate: string;
+        /**
+         * Максимальная дата
+         * @default '31.12.2099'
+         */
+        maxDate: string;
+        /**
+         * Ширина поля
+         * @default 125
+         */
+        width?: string | number;
+        withIcon?: boolean;
+        /**
+         * Размер поля
+         * @default 'small'
+         */
+        onBlur?: (x0: React.FocusEvent<HTMLElement>) => void;
+        onFocus?: (x0: React.FocusEvent<HTMLElement>) => void;
+        /**
+         * Вызывается при изменении `value`
+         *
+         * @param value - строка в формате `dd.mm.yyyy`.
+         */
+        onValueChange?: (value: string) => void;
+        onKeyDown?: (x0: React.KeyboardEvent<HTMLElement>) => void;
+      }
+    > {}
 
 @locale('DatePicker', DatePickerLocaleHelper)
 export class DateInput extends React.Component<DateInputProps, DateInputState> {

--- a/packages/react-ui/components/DateInput/DateInput.tsx
+++ b/packages/react-ui/components/DateInput/DateInput.tsx
@@ -10,7 +10,7 @@ import { InputLikeText } from '../../internal/InputLikeText';
 import { locale } from '../../lib/locale/decorators';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { CalendarIcon } from '../../internal/icons/16px';
-import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
+import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { DateFragmentsView } from './DateFragmentsView';
 import { jsStyles } from './DateInput.styles';
@@ -169,47 +169,42 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
       <ThemeContext.Consumer>
         {theme => {
           this.theme = theme;
-          return this.renderMain();
+          return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  private renderMain() {
+  private renderMain = (props: CommonWrapperRestProps<DateInputProps>) => {
     const { focused, selected, inputMode, valueFormatted } = this.state;
     const fragments = focused || valueFormatted !== '' ? this.iDateMediator.getFragments() : [];
+    const { onBlur, onFocus, onKeyDown, onValueChange, withIcon, minDate, maxDate, ...rest } = props;
 
     return (
-      <CommonWrapper {...this.props}>
-        <InputLikeText
-          width={this.props.width}
-          ref={this.inputLikeTextRef}
-          size={this.props.size}
-          disabled={this.props.disabled}
-          error={this.props.error}
-          warning={this.props.warning}
-          onBlur={this.handleBlur}
-          onFocus={this.handleFocus}
-          onKeyDown={this.handleKeyDown}
-          onMouseDownCapture={this.handleMouseDownCapture}
-          onPaste={this.handlePaste}
-          rightIcon={this.renderIcon()}
-          onDoubleClickCapture={this.handleDoubleClick}
-          onMouseDragStart={this.handleMouseDragStart}
-          onMouseDragEnd={this.handleMouseDragEnd}
-          value={this.iDateMediator.getInternalString()}
-        >
-          <DateFragmentsView
-            ref={this.dateFragmentsViewRef}
-            fragments={fragments}
-            onSelectDateComponent={this.handleSelectDateComponent}
-            selected={selected}
-            inputMode={inputMode}
-          />
-        </InputLikeText>
-      </CommonWrapper>
+      <InputLikeText
+        {...rest}
+        ref={this.inputLikeTextRef}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
+        onKeyDown={this.handleKeyDown}
+        onMouseDownCapture={this.handleMouseDownCapture}
+        onPaste={this.handlePaste}
+        rightIcon={this.renderIcon()}
+        onDoubleClickCapture={this.handleDoubleClick}
+        onMouseDragStart={this.handleMouseDragStart}
+        onMouseDragEnd={this.handleMouseDragEnd}
+        value={this.iDateMediator.getInternalString()}
+      >
+        <DateFragmentsView
+          ref={this.dateFragmentsViewRef}
+          fragments={fragments}
+          onSelectDateComponent={this.handleSelectDateComponent}
+          selected={selected}
+          inputMode={inputMode}
+        />
+      </InputLikeText>
     );
-  }
+  };
 
   private renderIcon = () => {
     const { withIcon, size, disabled = false } = this.props;

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -10,20 +10,10 @@ import { Nullable } from '../../typings/utility-types';
 import { CalendarDateShape } from '../../internal/Calendar';
 import { DateInput } from '../DateInput';
 import { DropdownContainer } from '../../internal/DropdownContainer';
-import { filterProps } from '../../lib/filterProps';
 import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { Picker } from './Picker';
 import { jsStyles } from './DatePicker.styles';
-
-const INPUT_PASS_PROPS = {
-  autoFocus: true,
-  disabled: true,
-  warning: true,
-  error: true,
-  size: true,
-  onKeyDown: true,
-};
 
 export interface DatePickerProps<T> extends CommonProps {
   autoFocus?: boolean;
@@ -213,18 +203,33 @@ export class DatePicker extends React.Component<DatePickerProps<DatePickerValue>
   }
 
   public renderMain = (props: CommonWrapperRestProps<DatePickerProps<DatePickerValue>>) => {
+    const {
+      width,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseOver,
+      enableTodayLink,
+      isHoliday,
+      menuAlign,
+      minDate,
+      maxDate,
+      value,
+      onValueChange,
+      ...rest
+    } = props;
+
     let picker = null;
     const date = this.internalDate ? this.internalDate.toNativeFormat() : null;
     if (this.state.opened) {
       picker = (
-        <DropdownContainer getParent={() => findDOMNode(this)} offsetY={2} align={this.props.menuAlign}>
+        <DropdownContainer getParent={() => findDOMNode(this)} offsetY={2} align={menuAlign}>
           <Picker
             value={date}
             minDate={(this.minDate && this.minDate.toNativeFormat()) || undefined}
             maxDate={(this.maxDate && this.maxDate.toNativeFormat()) || undefined}
             onPick={this.handlePick}
             onSelect={this.handleSelect}
-            enableTodayLink={this.props.enableTodayLink}
+            enableTodayLink={enableTodayLink}
             isHoliday={this.isHoliday}
           />
         </DropdownContainer>
@@ -234,22 +239,22 @@ export class DatePicker extends React.Component<DatePickerProps<DatePickerValue>
     return (
       <label
         className={jsStyles.root()}
-        style={{ width: this.props.width }}
-        onMouseEnter={this.props.onMouseEnter}
-        onMouseLeave={this.props.onMouseLeave}
-        onMouseOver={this.props.onMouseOver}
+        style={{ width }}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseOver={onMouseOver}
       >
         <DateInput
-          {...filterProps(props, INPUT_PASS_PROPS)}
+          {...rest}
           ref={this.getInputRef}
-          value={this.props.value || ''}
+          value={value || ''}
           width="100%"
           withIcon
-          minDate={this.props.minDate}
-          maxDate={this.props.maxDate}
+          minDate={minDate}
+          maxDate={maxDate}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
-          onValueChange={this.props.onValueChange}
+          onValueChange={onValueChange}
         />
         {picker}
       </label>

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -6,50 +6,48 @@ import { InternalDate } from '../../lib/date/InternalDate';
 import { InternalDateTransformer } from '../../lib/date/InternalDateTransformer';
 import { MAX_FULLDATE, MIN_FULLDATE } from '../../lib/date/constants';
 import { InternalDateOrder, InternalDateSeparator, InternalDateValidateCheck } from '../../lib/date/types';
-import { Nullable } from '../../typings/utility-types';
+import { Nullable, Override } from '../../typings/utility-types';
 import { CalendarDateShape } from '../../internal/Calendar';
-import { DateInput } from '../DateInput';
+import { DateInput, DateInputProps } from '../DateInput';
 import { DropdownContainer } from '../../internal/DropdownContainer';
 import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { Picker } from './Picker';
 import { jsStyles } from './DatePicker.styles';
 
-export interface DatePickerProps<T> extends CommonProps {
-  autoFocus?: boolean;
-  disabled?: boolean;
-  enableTodayLink?: boolean;
-  error?: boolean;
-  minDate: T;
-  maxDate: T;
-  menuAlign?: 'left' | 'right';
-  size?: 'small' | 'medium' | 'large';
-  value?: T | null;
-  warning?: boolean;
-  width: number | string;
-  onBlur?: () => void;
-  /**
-   * Вызывается при изменении `value`
-   *
-   * @param value - строка в формате `dd.mm.yyyy`.
-   */
-  onValueChange: (value: T) => void;
-  onFocus?: () => void;
-  onKeyDown?: (e: React.KeyboardEvent<any>) => void;
-  onMouseEnter?: (e: React.MouseEvent<any>) => void;
-  onMouseLeave?: (e: React.MouseEvent<any>) => void;
-  onMouseOver?: (e: React.MouseEvent<any>) => void;
+export interface DatePickerProps<T>
+  extends CommonProps,
+    Override<
+      DateInputProps,
+      {
+        enableTodayLink?: boolean;
+        minDate: T;
+        maxDate: T;
+        menuAlign?: 'left' | 'right';
+        value?: T | null;
+        onBlur?: () => void;
+        /**
+         * Вызывается при изменении `value`
+         *
+         * @param value - строка в формате `dd.mm.yyyy`.
+         */
+        onValueChange: (value: T) => void;
+        onFocus?: () => void;
+        onMouseEnter?: (e: React.MouseEvent<HTMLLabelElement>) => void;
+        onMouseLeave?: (e: React.MouseEvent<HTMLLabelElement>) => void;
+        onMouseOver?: (e: React.MouseEvent<HTMLLabelElement>) => void;
 
-  /**
-   * Функция для определения праздничных дней
-   * @default (_day, isWeekend) => isWeekend
-   * @param {T} day - строка в формате `dd.mm.yyyy`
-   * @param {boolean} isWeekend - флаг выходного (суббота или воскресенье)
-   *
-   * @returns {boolean} `true` для выходного или `false` для рабочего дня
-   */
-  isHoliday: (day: T, isWeekend: boolean) => boolean;
-}
+        /**
+         * Функция для определения праздничных дней
+         * @default (_day, isWeekend) => isWeekend
+         * @param {T} day - строка в формате `dd.mm.yyyy`
+         * @param {boolean} isWeekend - флаг выходного (суббота или воскресенье)
+         *
+         * @returns {boolean} `true` для выходного или `false` для рабочего дня
+         */
+        isHoliday: (day: T, isWeekend: boolean) => boolean;
+      }
+    > {}
 
 export interface DatePickerState {
   opened: boolean;

--- a/packages/react-ui/components/Fias/Form/__tests__/FiasComboBox-test.tsx
+++ b/packages/react-ui/components/Fias/Form/__tests__/FiasComboBox-test.tsx
@@ -34,7 +34,7 @@ describe('FiasComboBox', () => {
     const [search, promise] = searchFactory(Promise.resolve(items));
     const wrapper = mount<FiasComboBox>(<FiasComboBox getItems={search} renderItem={address => address.getText()} />);
     const setSearchQuery = async (searchQuery: string) => {
-      wrapper.find('input').simulate('change', { target: { value: searchQuery } });
+      wrapper.find('input:not([readOnly])').simulate('change', { target: { value: searchQuery } });
       await promise;
       await delay(0);
       wrapper.update();

--- a/packages/react-ui/components/Input/Input.md
+++ b/packages/react-ui/components/Input/Input.md
@@ -11,3 +11,27 @@ import SearchIcon from '@skbkontur/react-icons/Search';
 
 <Input width={400} prefix="https://kontur.ru/search?query=" rightIcon={<SearchIcon />} />;
 ```
+
+Различные значения пропа `type`:
+
+```jsx harmony
+import { Gapped } from '@skbkontur/react-ui';
+
+const onChange = e => console.log(e.target.value);
+
+<Gapped vertical>
+  <Input onChange={onChange} type="date" placeholder="date" />
+  <Input onChange={onChange} type="datetime-local" placeholder="datetime-local" />
+  <Input onChange={onChange} type="email" placeholder="email" />
+  <Input onChange={onChange} type="file" placeholder="file" />
+  <Input onChange={onChange} type="month" placeholder="month" />
+  <Input onChange={onChange} type="number" placeholder="number" />
+  <Input onChange={onChange} type="password" placeholder="password" />
+  <Input onChange={onChange} type="search" placeholder="search" />
+  <Input onChange={onChange} type="tel" placeholder="tel" />
+  <Input onChange={onChange} type="text" placeholder="text" />
+  <Input onChange={onChange} type="time" placeholder="time" />
+  <Input onChange={onChange} type="week" placeholder="week" />
+  <Input onChange={onChange} type="color" placeholder="color" />
+</Gapped>;
+```

--- a/packages/react-ui/components/Input/Input.md
+++ b/packages/react-ui/components/Input/Input.md
@@ -35,3 +35,18 @@ const onChange = e => console.log(e.target.value);
   <Input onChange={onChange} type="color" placeholder="color" />
 </Gapped>;
 ```
+
+Нативная валидация:
+
+```jsx harmony
+import { Gapped, Button } from '@skbkontur/react-ui';
+
+const onSubmit = e => e.preventDefault();
+
+<form onSubmit={onSubmit}>
+  <Gapped vertical>
+    <Input name="email" type="email" placeholder="email" required />
+    <Button type="submit">Submit</Button>
+  </Gapped>
+</form>;
+```

--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -16,7 +16,7 @@ import { jsStyles } from './Input.styles';
 
 export type InputSize = 'small' | 'medium' | 'large';
 export type InputAlign = 'left' | 'center' | 'right';
-export type InputType = 'password' | 'text';
+export type InputType = React.InputHTMLAttributes<HTMLInputElement>['type'];
 export type InputIconType = React.ReactNode | (() => React.ReactNode);
 
 export interface InputProps
@@ -109,10 +109,9 @@ export interface InputState {
 export class Input extends React.Component<InputProps, InputState> {
   public static __KONTUR_REACT_UI__ = 'Input';
 
-  public static defaultProps: {
-    size: InputSize;
-  } = {
+  public static defaultProps: InputProps = {
     size: 'small',
+    type: 'text',
   };
 
   public state: InputState = {
@@ -259,7 +258,6 @@ export class Input extends React.Component<InputProps, InputState> {
       borderless,
       value,
       align,
-      type,
       mask,
       maskChar,
       alwaysShowMask,
@@ -305,14 +303,9 @@ export class Input extends React.Component<InputProps, InputState> {
       onBlur: this.handleBlur,
       style: { textAlign: align },
       ref: this.refInput,
-      type: 'text',
       placeholder: !this.isMaskVisible && !polyfillPlaceholder ? placeholder : undefined,
       disabled,
     };
-
-    if (type === 'password') {
-      inputProps.type = type;
-    }
 
     const input = mask ? this.renderMaskedInput(inputProps, mask) : React.createElement('input', inputProps);
 

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { SelectHTMLAttributes } from 'react';
 import ReactDOM from 'react-dom';
 import invariant from 'invariant';
 import warning from 'warning';
@@ -24,7 +23,7 @@ import { MenuItem } from '../MenuItem';
 import { MenuSeparator } from '../MenuSeparator';
 import { RenderLayer } from '../../internal/RenderLayer';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { Nullable } from '../../typings/utility-types';
+import { Nullable, Override } from '../../typings/utility-types';
 import { isFunction } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -44,92 +43,94 @@ export interface ButtonParams {
   isPlaceholder: boolean;
 }
 
-export interface SelectProps<TValue, TItem> extends CommonProps {
-  /** @ignore */
-  _icon?: React.ReactElement<any>;
-  /** @ignore */
-  _renderButton?: (params: ButtonParams) => React.ReactNode;
-  defaultValue?: TValue;
-  /** @deprecated @ignore */
-  diadocLinkIcon?: React.ReactElement<any>;
-  /**
-   * Отключает использование портала
-   */
-  disablePortal?: boolean;
-  disabled?: boolean;
-  /**
-   * Визуально показать наличие ошибки.
-   */
-  error?: boolean;
-  filterItem?: (value: TValue, item: TItem, pattern: string) => boolean;
-  /**
-   * Набор значений. Поддерживаются любые перечисляемые типы, в том числе
-   * `Array`, `Map`, `Immutable.Map`.
-   *
-   * Элементы воспринимаются следующим образом: если элемент — это массив, то
-   * первый элемент является значением, второй — отображается в списке,
-   * а третий – комментарий;
-   * если элемент не является массивом, то он используется и для отображения,
-   * и для значения.
-   *
-   * Для вставки разделителя можно использовать `Select.SEP`.
-   *
-   * Вставить невыделяемый элемент со своей разметкой можно так:
-   * ```
-   * <Select ...
-   *   items={[Select.static(() => <div>My Element</div>)]}
-   * />
-   * ```
-   *
-   * Чтобы добавить стандартный отступ для статического элемента:
-   * ```
-   * <Select.Item>My Element</Select.Item>
-   * ```
-   */
-  items?: Array<[TValue, TItem, React.ReactNode?] | TItem | React.ReactElement | (() => React.ReactElement)>;
-  maxMenuHeight?: number;
-  maxWidth?: React.CSSProperties['maxWidth'];
-  menuAlign?: 'left' | 'right';
-  menuWidth?: React.CSSProperties['width'];
-  onValueChange?: (value: TValue) => void;
-  onClose?: () => void;
-  onMouseEnter?: (e: React.MouseEvent<HTMLElement>) => void;
-  onMouseLeave?: (e: React.MouseEvent<HTMLElement>) => void;
-  onMouseOver?: (e: React.MouseEvent<HTMLElement>) => void;
-  onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
-  onOpen?: () => void;
-  placeholder?: React.ReactNode;
-  /**
-   * Функция для отрисовки элемента в выпадающем списке. Аргументы — *value*,
-   * *item*.
-   */
-  renderItem?: (value: TValue, item?: TItem) => React.ReactNode;
-  /**
-   * Функция для отрисовки выбранного элемента. Аргументы — *value*, *item*.
-   */
-  renderValue?: (value: TValue, item?: TItem) => React.ReactNode;
-  /**
-   * Функция для сравнения `value` с элементом из `items`
-   */
-  areValuesEqual?: (value1: TValue, value2: TValue) => boolean;
-  /**
-   * Функция конвертации `value` в строку для передачи в нативный элемент формы
-   */
-  valueToString?: (value: TValue) => string;
-  /**
-   * Показывать строку поиска в списке.
-   */
-  search?: boolean;
-  value?: TValue;
-  width?: number | string;
-  warning?: boolean;
-  use?: ButtonUse;
-  size?: ButtonSize;
-  onFocus?: React.FocusEventHandler<HTMLElement>;
-  onBlur?: React.FocusEventHandler<HTMLElement>;
-  name?: string;
-  form?: string;
-}
+export interface SelectProps<TValue, TItem>
+  extends CommonProps,
+    Override<
+      Omit<SelectHTMLAttributes<HTMLButtonElement>, 'multiple'>,
+      {
+        /** @ignore */
+        _icon?: React.ReactElement<any>;
+        /** @ignore */
+        _renderButton?: (params: ButtonParams) => React.ReactNode;
+        defaultValue?: TValue;
+        /** @deprecated @ignore */
+        diadocLinkIcon?: React.ReactElement<any>;
+        /**
+         * Отключает использование портала
+         */
+        disablePortal?: boolean;
+        /**
+         * Визуально показать наличие ошибки.
+         */
+        error?: boolean;
+        filterItem?: (value: TValue, item: TItem, pattern: string) => boolean;
+        /**
+         * Набор значений. Поддерживаются любые перечисляемые типы, в том числе
+         * `Array`, `Map`, `Immutable.Map`.
+         *
+         * Элементы воспринимаются следующим образом: если элемент — это массив, то
+         * первый элемент является значением, второй — отображается в списке,
+         * а третий – комментарий;
+         * если элемент не является массивом, то он используется и для отображения,
+         * и для значения.
+         *
+         * Для вставки разделителя можно использовать `Select.SEP`.
+         *
+         * Вставить невыделяемый элемент со своей разметкой можно так:
+         * ```
+         * <Select ...
+         *   items={[Select.static(() => <div>My Element</div>)]}
+         * />
+         * ```
+         *
+         * Чтобы добавить стандартный отступ для статического элемента:
+         * ```
+         * <Select.Item>My Element</Select.Item>
+         * ```
+         */
+        items?: Array<[TValue, TItem, React.ReactNode?] | TItem | React.ReactElement | (() => React.ReactElement)>;
+        maxMenuHeight?: number;
+        maxWidth?: React.CSSProperties['maxWidth'];
+        menuAlign?: 'left' | 'right';
+        menuWidth?: React.CSSProperties['width'];
+        onValueChange?: (value: TValue) => void;
+        onClose?: () => void;
+        onMouseEnter?: (e: React.MouseEvent<HTMLElement>) => void;
+        onMouseLeave?: (e: React.MouseEvent<HTMLElement>) => void;
+        onMouseOver?: (e: React.MouseEvent<HTMLElement>) => void;
+        onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
+        onOpen?: () => void;
+        placeholder?: React.ReactNode;
+        /**
+         * Функция для отрисовки элемента в выпадающем списке. Аргументы — *value*,
+         * *item*.
+         */
+        renderItem?: (value: TValue, item?: TItem) => React.ReactNode;
+        /**
+         * Функция для отрисовки выбранного элемента. Аргументы — *value*, *item*.
+         */
+        renderValue?: (value: TValue, item?: TItem) => React.ReactNode;
+        /**
+         * Функция для сравнения `value` с элементом из `items`
+         */
+        areValuesEqual?: (value1: TValue, value2: TValue) => boolean;
+        /**
+         * Функция конвертации `value` в строку для передачи в нативный элемент формы
+         */
+        valueToString?: (value: TValue) => string;
+        /**
+         * Показывать строку поиска в списке.
+         */
+        search?: boolean;
+        value?: TValue;
+        width?: number | string;
+        warning?: boolean;
+        use?: ButtonUse;
+        size?: ButtonSize;
+        onFocus?: React.FocusEventHandler<HTMLElement>;
+        onBlur?: React.FocusEventHandler<HTMLElement>;
+      }
+    > {}
 
 export interface SelectState<TValue> {
   opened: boolean;
@@ -144,27 +145,6 @@ interface FocusableReactElement extends React.ReactElement<any> {
 @locale('Select', SelectLocaleHelper)
 export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps<TValue, TItem>, SelectState<TValue>> {
   public static __KONTUR_REACT_UI__ = 'Select';
-
-  public static propTypes = {
-    areValuesEqual: PropTypes.func,
-    disablePortal: PropTypes.bool,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    filterItem: PropTypes.func,
-    items: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-    maxMenuHeight: PropTypes.number,
-    maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    placeholder: PropTypes.node,
-    renderItem: PropTypes.func,
-    renderValue: PropTypes.func,
-    search: PropTypes.bool,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    onValueChange: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
-    onKeyDown: PropTypes.func,
-  };
 
   public static defaultProps = {
     renderValue,

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -113,6 +113,10 @@ export interface SelectProps<TValue, TItem> extends CommonProps {
    */
   areValuesEqual?: (value1: TValue, value2: TValue) => boolean;
   /**
+   * Функция конвертации `value` в строку для передачи в нативный элемент формы
+   */
+  valueToString?: (value: TValue) => string;
+  /**
    * Показывать строку поиска в списке.
    */
   search?: boolean;
@@ -123,6 +127,8 @@ export interface SelectProps<TValue, TItem> extends CommonProps {
   size?: ButtonSize;
   onFocus?: React.FocusEventHandler<HTMLElement>;
   onBlur?: React.FocusEventHandler<HTMLElement>;
+  name?: string;
+  form?: string;
 }
 
 export interface SelectState<TValue> {
@@ -141,7 +147,6 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
 
   public static propTypes = {
     areValuesEqual: PropTypes.func,
-    defaultValue: PropTypes.any,
     disablePortal: PropTypes.bool,
     disabled: PropTypes.bool,
     error: PropTypes.bool,
@@ -153,7 +158,6 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
     renderItem: PropTypes.func,
     renderValue: PropTypes.func,
     search: PropTypes.bool,
-    value: PropTypes.any,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     onValueChange: PropTypes.func,
     onMouseEnter: PropTypes.func,
@@ -166,6 +170,7 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
     renderValue,
     renderItem,
     areValuesEqual,
+    valueToString,
     filterItem,
     use: 'default',
   };
@@ -268,12 +273,20 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
 
     const button = this.getButton(buttonParams);
 
+    const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+      name: this.props.name,
+      disabled: this.props.disabled,
+      form: this.props.form,
+      value: this.getValueAsString(),
+    };
+
     return (
       <CommonWrapper {...this.props}>
         <RenderLayer onClickOutside={this.close} onFocusOutside={this.close} active={this.state.opened}>
           <span className={jsStyles.root(this.theme)} style={style}>
             {button}
             {!this.props.disabled && this.state.opened && this.renderMenu()}
+            <input {...inputProps} type="hidden" />
           </span>
         </RenderLayer>
       </CommonWrapper>
@@ -313,6 +326,7 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
       diadocLinkIcon,
       defaultValue,
       areValuesEqual,
+      valueToString,
       _renderButton,
       _icon,
       maxWidth,
@@ -324,6 +338,8 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
       renderItem,
       renderValue,
       search,
+      name,
+      form,
       value,
       width,
       ...rest
@@ -553,6 +569,14 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
     return this.state.value;
   }
 
+  private getValueAsString() {
+    const value = this.getValue();
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return this.getProps().valueToString(value);
+  }
+
   private mapItems(fn: (value: TValue, item: TItem, index: number, comment?: string) => React.ReactNode) {
     const { items } = this.props;
     if (!items) {
@@ -622,6 +646,10 @@ function renderItem(value: any, item: any) {
 
 function areValuesEqual(value1: any, value2: any) {
   return value1 === value2;
+}
+
+function valueToString(value: any): string {
+  return String(value);
 }
 
 function normalizeEntry(entry: any) {

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -17,7 +17,6 @@ import { locale } from '../../lib/locale/decorators';
 import { reactGetTextContent } from '../../lib/reactGetTextContent';
 import { Button, ButtonProps, ButtonSize, ButtonUse } from '../Button';
 import { DropdownContainer } from '../../internal/DropdownContainer';
-import { filterProps } from '../../lib/filterProps';
 import { Input } from '../Input';
 import { Link } from '../Link';
 import { Menu } from '../../internal/Menu';
@@ -29,7 +28,7 @@ import { Nullable } from '../../typings/utility-types';
 import { isFunction } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, extractCommonProps } from '../../internal/CommonWrapper';
 
 import { Item } from './Item';
 import { SelectLocale, SelectLocaleHelper } from './locale';
@@ -44,18 +43,6 @@ export interface ButtonParams {
   opened: boolean;
   isPlaceholder: boolean;
 }
-
-const PASS_BUTTON_PROPS = {
-  disabled: true,
-  error: true,
-  use: true,
-  size: true,
-  warning: true,
-
-  onMouseEnter: true,
-  onMouseLeave: true,
-  onMouseOver: true,
-};
 
 export interface SelectProps<TValue, TItem> extends CommonProps {
   /** @ignore */
@@ -316,8 +303,34 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
       return this.renderLinkButton(params);
     }
 
+    const [, notCommonProps] = extractCommonProps(this.props);
+    const {
+      filterItem,
+      children,
+      items,
+      maxMenuHeight,
+      disablePortal,
+      diadocLinkIcon,
+      defaultValue,
+      areValuesEqual,
+      _renderButton,
+      _icon,
+      maxWidth,
+      menuAlign,
+      onClose,
+      onOpen,
+      onValueChange,
+      placeholder,
+      renderItem,
+      renderValue,
+      search,
+      value,
+      width,
+      ...rest
+    } = notCommonProps;
+
     const buttonProps: ButtonProps = {
-      ...filterProps(this.props, PASS_BUTTON_PROPS),
+      ...rest,
       align: 'left' as React.CSSProperties['textAlign'],
       disabled: this.props.disabled,
       width: '100%',

--- a/packages/react-ui/components/Select/__stories__/Select.stories.tsx
+++ b/packages/react-ui/components/Select/__stories__/Select.stories.tsx
@@ -299,7 +299,7 @@ UsingOnKeyDown.story = {
 };
 
 export const WithSearchAndVariousWidth: CSFStory<JSX.Element> = () => {
-  let selectElem: Select | null = null;
+  let selectElem: Select<string, string> | null = null;
   const [width, setWidth] = useState();
   const changeWidth = (w: string) => {
     setWidth(w);
@@ -320,7 +320,7 @@ export const WithSearchAndVariousWidth: CSFStory<JSX.Element> = () => {
         100%
       </Button>
       <br />
-      <Select ref={ref => (selectElem = ref)} search width={width} items={['one', 'two', 'three']} />
+      <Select<string, string> ref={ref => (selectElem = ref)} search width={width} items={['one', 'two', 'three']} />
     </div>
   );
 };

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -8,7 +8,7 @@ import { Button, ButtonSize } from '../Button';
 import { Nullable } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { jsStyles } from './Switcher.styles';
 import { getSwitcherTheme } from './switcherTheme';
@@ -75,18 +75,25 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
       <ThemeContext.Consumer>
         {theme => {
           this.theme = getSwitcherTheme(theme);
-          return <ThemeContext.Provider value={this.theme}>{this.renderMain()}</ThemeContext.Provider>;
+          return (
+            <ThemeContext.Provider value={this.theme}>
+              <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>
+            </ThemeContext.Provider>
+          );
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  private renderMain() {
+  private renderMain = (props: CommonWrapperRestProps<SwitcherProps>) => {
+    const { value, items, onValueChange, label, error, size, ...rest } = props;
+
     const listClassName = cn({
       [jsStyles.error(this.theme)]: !!this.props.error,
     });
 
     const inputProps = {
+      ...rest,
       type: 'checkbox',
       onKeyDown: this.handleKey,
       onFocus: this._handleFocus,
@@ -97,19 +104,17 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     const lableClassName = cn(jsStyles.label(), this.getLabelSizeClassName());
 
     return (
-      <CommonWrapper {...this.props}>
-        <div>
-          {this.props.label ? <div className={lableClassName}>{this.props.label}</div> : null}
-          <div className={jsStyles.wrap()}>
-            <input {...inputProps} />
-            <div className={listClassName}>
-              <Group>{this._renderItems()}</Group>
-            </div>
+      <div>
+        {this.props.label ? <div className={lableClassName}>{this.props.label}</div> : null}
+        <div className={jsStyles.wrap()}>
+          <input {...inputProps} />
+          <div className={listClassName}>
+            <Group>{this._renderItems()}</Group>
           </div>
         </div>
-      </CommonWrapper>
+      </div>
     );
-  }
+  };
 
   private selectItem = (value: string) => {
     if (this.props.onValueChange) {

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -33,6 +33,8 @@ export interface SwitcherProps extends CommonProps {
   size?: SwitcherSize;
 
   disabled?: boolean;
+  name?: string;
+  form?: string;
 }
 
 export interface SwitcherState {
@@ -86,7 +88,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
   }
 
   private renderMain = (props: CommonWrapperRestProps<SwitcherProps>) => {
-    const { value, items, onValueChange, label, error, size, ...rest } = props;
+    const { items, onValueChange, label, error, size, ...rest } = props;
 
     const listClassName = cn({
       [jsStyles.error(this.theme)]: !!this.props.error,
@@ -99,6 +101,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
       onFocus: this._handleFocus,
       onBlur: this._handleBlur,
       className: jsStyles.input(),
+      checked: this.isChecked(),
     };
 
     const lableClassName = cn(jsStyles.label(), this.getLabelSizeClassName());
@@ -107,7 +110,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
       <div>
         {this.props.label ? <div className={lableClassName}>{this.props.label}</div> : null}
         <div className={jsStyles.wrap()}>
-          <input {...inputProps} />
+          <input {...inputProps} onChange={this.handleChange} />
           <div className={listClassName}>
             <Group>{this._renderItems()}</Group>
           </div>
@@ -131,6 +134,11 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
       const { value } = this._extractPropsFromItem(item);
       return value;
     });
+  };
+
+  private isChecked = (): boolean => {
+    const { value } = this.props;
+    return value !== undefined && this._extractValuesFromItems().includes(value);
   };
 
   private move = (step: number) => {
@@ -175,6 +183,10 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
       e.preventDefault();
       this.move(isKeyArrowLeft(e) ? -1 : 1);
     }
+  };
+
+  private handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.props.onChange?.(e);
   };
 
   private _handleFocus = () => {

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 import { isKeyArrowHorizontal, isKeyArrowLeft, isKeyEnter } from '../../lib/events/keyboard/identifiers';
 import { Group } from '../Group';
 import { Button, ButtonSize } from '../Button';
-import { Nullable } from '../../typings/utility-types';
+import { Nullable, Override } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
@@ -15,27 +15,28 @@ import { getSwitcherTheme } from './switcherTheme';
 
 export type SwitcherSize = ButtonSize;
 
-export interface SwitcherProps extends CommonProps {
-  /**
-   * Список строк или список элементов типа `{ label: string, value: string }`
-   */
-  items: Array<string | SwitcherItem>;
+export interface SwitcherProps
+  extends CommonProps,
+    Override<
+      InputHTMLAttributes<HTMLInputElement>,
+      {
+        /**
+         * Список строк или список элементов типа `{ label: string, value: string }`
+         */
+        items: Array<string | SwitcherItem>;
 
-  value?: string;
+        value?: string;
 
-  onValueChange?: (value: string) => void;
+        onValueChange?: (value: string) => void;
 
-  label?: string;
+        label?: string;
 
-  error?: boolean;
+        error?: boolean;
 
-  /** Размер */
-  size?: SwitcherSize;
-
-  disabled?: boolean;
-  name?: string;
-  form?: string;
-}
+        /** Размер */
+        size?: SwitcherSize;
+      }
+    > {}
 
 export interface SwitcherState {
   focusedIndex: Nullable<number>;

--- a/packages/react-ui/components/Toggle/Toggle.tsx
+++ b/packages/react-ui/components/Toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
@@ -6,29 +6,28 @@ import { tabListener } from '../../lib/events/tabListener';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { Override } from '../../typings/utility-types';
 
 import { jsStyles } from './Toggle.styles';
 
-export interface ToggleProps extends CommonProps {
-  children?: React.ReactNode;
-  /**
-   * Положение children справа или слева от переключателя
-   * @default 'right'
-   */
-  captionPosition: 'left' | 'right';
-  checked?: boolean;
-  defaultChecked?: boolean;
-  disabled?: boolean;
-  onValueChange?: (value: boolean) => void;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  warning?: boolean;
-  error?: boolean;
-  loading?: boolean;
-  autoFocus?: boolean;
-  onFocus?: React.FocusEventHandler<HTMLInputElement>;
-  onBlur?: React.FocusEventHandler<HTMLInputElement>;
-  color?: React.CSSProperties['color'];
-}
+export interface ToggleProps
+  extends CommonProps,
+    Override<
+      InputHTMLAttributes<HTMLInputElement>,
+      {
+        children?: React.ReactNode;
+        /**
+         * Положение children справа или слева от переключателя
+         * @default 'right'
+         */
+        captionPosition: 'left' | 'right';
+        onValueChange?: (value: boolean) => void;
+        warning?: boolean;
+        error?: boolean;
+        loading?: boolean;
+        color?: React.CSSProperties['color'];
+      }
+    > {}
 
 export interface ToggleState {
   checked?: boolean;

--- a/packages/react-ui/components/Toggle/Toggle.tsx
+++ b/packages/react-ui/components/Toggle/Toggle.tsx
@@ -5,7 +5,7 @@ import cn from 'classnames';
 import { tabListener } from '../../lib/events/tabListener';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { jsStyles } from './Toggle.styles';
 
@@ -88,14 +88,27 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
       <ThemeContext.Consumer>
         {theme => {
           this.theme = theme;
-          return this.renderMain();
+          return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  private renderMain() {
-    const { children, captionPosition, warning, error, loading, color } = this.props;
+  private renderMain = (props: CommonWrapperRestProps<ToggleProps>) => {
+    const {
+      captionPosition,
+      warning,
+      error,
+      loading,
+      color,
+      onChange,
+      defaultChecked,
+      onValueChange,
+      onFocus,
+      onBlur,
+      ...rest
+    } = props;
+
     const disabled = this.props.disabled || loading;
     const checked = this.isUncontrolled() ? this.state.checked : this.props.checked;
 
@@ -112,11 +125,11 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
     });
 
     let caption = null;
-    if (children) {
+    if (this.props.children) {
       const captionClass = cn(jsStyles.caption(this.theme), {
         [jsStyles.captionLeft(this.theme)]: captionPosition === 'left',
       });
-      caption = <span className={captionClass}>{children}</span>;
+      caption = <span className={captionClass}>{this.props.children}</span>;
     }
 
     return (
@@ -124,6 +137,7 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
         <label className={labelClassNames}>
           <span className={jsStyles.wrapper(this.theme)}>
             <input
+              {...rest}
               type="checkbox"
               checked={checked}
               onChange={this.handleChange}
@@ -156,7 +170,7 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
         </label>
       </CommonWrapper>
     );
-  }
+  };
 
   private inputRef = (element: HTMLInputElement) => {
     this.input = element;

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -24,7 +24,7 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { locale } from '../../lib/locale/decorators';
 import { MenuItem } from '../MenuItem/MenuItem';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { TokenInputLocale, TokenInputLocaleHelper } from './locale';
 import { jsStyles } from './TokenInput.styles';
@@ -195,13 +195,13 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       <ThemeContext.Consumer>
         {theme => {
           this.theme = theme;
-          return this.renderMain();
+          return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  private renderMain() {
+  private renderMain = (props: CommonWrapperRestProps<TokenInputProps<T>>) => {
     if (this.type !== TokenInputType.WithoutReference && !this.props.getItems) {
       throw Error('Missed getItems for type ' + this.type);
     }
@@ -219,7 +219,21 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       hideMenuIfEmptyInputValue,
       onMouseEnter,
       onMouseLeave,
-    } = this.props;
+      onBlur,
+      onFocus,
+      onValueChange,
+      onInputValueChange,
+      getItems,
+      renderValue,
+      valueToString,
+      valueToItem,
+      toKey,
+      renderToken,
+      delimiters,
+      renderAddButton,
+      type,
+      ...rest
+    } = props;
 
     const {
       activeTokens,
@@ -264,60 +278,59 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     });
 
     return (
-      <CommonWrapper {...this.props}>
-        <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-          <label
-            ref={this.wrapperRef}
-            style={{ width }}
-            className={labelClassName}
-            onMouseDown={this.handleWrapperMouseDown}
-            onMouseUp={this.handleWrapperMouseUp}
-          >
-            <TextWidthHelper
-              ref={this.textHelperRef}
-              classHelp={cn(jsStyles.helperText(theme), {
-                [jsStyles.helperTextEditing(theme)]: this.isEditingMode,
-              })}
-              text={inputValue}
-              theme={this.theme}
+      <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        <label
+          ref={this.wrapperRef}
+          style={{ width }}
+          className={labelClassName}
+          onMouseDown={this.handleWrapperMouseDown}
+          onMouseUp={this.handleWrapperMouseUp}
+        >
+          <TextWidthHelper
+            ref={this.textHelperRef}
+            classHelp={cn(jsStyles.helperText(theme), {
+              [jsStyles.helperTextEditing(theme)]: this.isEditingMode,
+            })}
+            text={inputValue}
+            theme={this.theme}
+          />
+          {this.renderTokensStart()}
+          <textarea
+            {...rest}
+            ref={this.inputRef}
+            value={inputValue}
+            style={inputInlineStyles}
+            // autoComplete="off"
+            spellCheck={false}
+            disabled={disabled}
+            className={inputClassName}
+            placeholder={selectedItems.length > 0 ? undefined : placeholder}
+            onFocus={this.handleInputFocus}
+            onBlur={this.handleInputBlur}
+            onChange={this.handleChangeInputValue}
+            onKeyDown={this.handleKeyDown}
+            onPaste={this.handleInputPaste}
+          />
+          {showMenu && (
+            <TokenInputMenu
+              ref={this.tokensInputMenuRef}
+              items={autocompleteItems}
+              loading={loading}
+              opened={showMenu}
+              maxMenuHeight={maxMenuHeight}
+              anchorElement={this.input!}
+              renderNotFound={renderNotFound}
+              renderItem={renderItem}
+              onValueChange={this.selectItem}
+              renderAddButton={this.renderAddButton}
             />
-            {this.renderTokensStart()}
-            <textarea
-              ref={this.inputRef}
-              value={inputValue}
-              style={inputInlineStyles}
-              autoComplete="off"
-              spellCheck={false}
-              disabled={disabled}
-              className={inputClassName}
-              placeholder={selectedItems.length > 0 ? undefined : placeholder}
-              onFocus={this.handleInputFocus}
-              onBlur={this.handleInputBlur}
-              onChange={this.handleChangeInputValue}
-              onKeyDown={this.handleKeyDown}
-              onPaste={this.handleInputPaste}
-            />
-            {showMenu && (
-              <TokenInputMenu
-                ref={this.tokensInputMenuRef}
-                items={autocompleteItems}
-                loading={loading}
-                opened={showMenu}
-                maxMenuHeight={maxMenuHeight}
-                anchorElement={this.input!}
-                renderNotFound={renderNotFound}
-                renderItem={renderItem}
-                onValueChange={this.selectItem}
-                renderAddButton={this.renderAddButton}
-              />
-            )}
-            {this.renderTokensEnd()}
-            {this.isEditingMode ? <span className={jsStyles.reservedInput(theme)}>{reservedInputValue}</span> : null}
-          </label>
-        </div>
-      </CommonWrapper>
+          )}
+          {this.renderTokensEnd()}
+          {this.isEditingMode ? <span className={jsStyles.reservedInput(theme)}>{reservedInputValue}</span> : null}
+        </label>
+      </div>
     );
-  }
+  };
 
   /**
    * Сбрасывает введенное пользователем значение

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEvent, FocusEventHandler, KeyboardEvent, MouseEventHandler, ReactNode } from 'react';
+import React, { ChangeEvent, FocusEvent, KeyboardEvent, MouseEventHandler, ReactNode } from 'react';
 import { findDOMNode } from 'react-dom';
 import isEqual from 'lodash.isequal';
 import cn from 'classnames';
@@ -25,6 +25,7 @@ import { Theme } from '../../lib/theming/Theme';
 import { locale } from '../../lib/locale/decorators';
 import { MenuItem } from '../MenuItem/MenuItem';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { Override } from '../../typings/utility-types';
 
 import { TokenInputLocale, TokenInputLocaleHelper } from './locale';
 import { jsStyles } from './TokenInput.styles';
@@ -38,14 +39,15 @@ export enum TokenInputType {
   Combined,
 }
 
-export interface TokenInputProps<T> extends CommonProps {
+export interface TokenInputProps<T>
+  extends CommonProps,
+    Override<
+      Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'value' | 'defaultValue'>,
+      {
   selectedItems: T[];
   onValueChange: (items: T[]) => void;
   onMouseEnter: MouseEventHandler<HTMLDivElement>;
   onMouseLeave: MouseEventHandler<HTMLDivElement>;
-  onFocus: FocusEventHandler<HTMLTextAreaElement>;
-  onBlur: FocusEventHandler<HTMLTextAreaElement>;
-  autoFocus?: boolean;
   type?: TokenInputType;
 
   /**
@@ -67,11 +69,9 @@ export interface TokenInputProps<T> extends CommonProps {
   renderNotFound?: () => React.ReactNode;
   valueToItem: (item: string) => T;
   toKey: (item: T) => string | number | undefined;
-  placeholder?: string;
   delimiters: string[];
   error?: boolean;
   warning?: boolean;
-  disabled?: boolean;
   width?: string | number;
   maxMenuHeight?: number | string;
   renderToken?: (item: T, props: Partial<TokenProps>) => ReactNode;
@@ -84,6 +84,7 @@ export interface TokenInputProps<T> extends CommonProps {
    */
   renderAddButton?: (query?: string, onAddItem?: () => void) => ReactNode;
 }
+    > {}
 
 export interface TokenInputState<T> {
   autocompleteItems?: T[];

--- a/packages/react-ui/components/__tests__/FormData-test.tsx
+++ b/packages/react-ui/components/__tests__/FormData-test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import {
+  Input,
+  ComboBox,
+  Checkbox,
+  Select,
+  Switcher,
+  FxInput,
+  CurrencyInput,
+  PasswordInput,
+  Autocomplete,
+  DateInput,
+  DatePicker,
+  TokenInput,
+  Radio,
+  Toggle,
+} from '../../index';
+
+const getFormData = (form: HTMLFormElement) => {
+  // @ts-ignore
+  return Object.fromEntries(new FormData(form));
+};
+
+// checks basic ability of components to work inside forms/FormData API
+// by providing names and values to native inputs
+describe('FormData API', () => {
+  it('works for all form components', () => {
+    const values = {
+      Input: 'value',
+      FxInput: 'value',
+      CurrencyInput: '0,00',
+      PasswordInput: 'value',
+      DateInput: '00.00.0000',
+      DatePicker: '00.00.0000',
+      ComboBox: '0',
+      Autocomplete: 'value',
+      TokenInput: 'one,two',
+      Select: 'one',
+      Checkbox: 'value',
+      Radio: 'value',
+      Toggle: 'value',
+      Switcher: 'value',
+    };
+
+    const form = mount(
+      <form>
+        <Input value={values['Input']} name="Input" />
+        <FxInput value={values['FxInput']} name="FxInput" onValueChange={jest.fn()} />
+        <CurrencyInput value={0} name="CurrencyInput" onValueChange={jest.fn()} />
+        <PasswordInput value={values['PasswordInput']} name="PasswordInput" />
+        <DateInput value={values['DateInput']} name="DateInput" />
+        <DatePicker value={values['DatePicker']} name="DatePicker" onValueChange={jest.fn()} />
+        <ComboBox value={{ value: 0 }} name="ComboBox" getItems={() => Promise.resolve([])} />
+        <Autocomplete
+          value={values['Autocomplete']}
+          name="Autocomplete"
+          source={() => Promise.resolve([])}
+          onValueChange={jest.fn()}
+        />
+        <TokenInput selectedItems={['one', 'two']} name="TokenInput" getItems={() => Promise.resolve([])} />
+
+        <Select value={values['Select']} name="Select" items={['one']} />
+
+        <Checkbox value={values['Checkbox']} name="Checkbox" checked />
+        <Radio value={values['Radio']} name="Radio" checked />
+        <Toggle value={values['Toggle']} name="Toggle" checked />
+
+        <Switcher value={values['Switcher']} name="Switcher" items={['value']} />
+      </form>,
+    );
+
+    expect(getFormData(form.getDOMNode())).toMatchObject(values);
+  });
+});

--- a/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
+++ b/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
@@ -80,23 +80,126 @@ describe('Props Forwarding', () => {
     it.each<[string, ReactWrapper]>(PUBLIC_COMPONENTS.map(name => [name, createWrapper(name)]))(
       '%s',
       (compName, wrapper) => {
-      const props = {
-        'data-tid': 'my-data-tid',
-        'data-testid': 'my-data-testid',
-        className: 'my-classname',
-        style: {
-          width: '95.5%',
-          color: 'red',
-        },
+        const props = {
+          'data-tid': 'my-data-tid',
+          'data-testid': 'my-data-testid',
+          className: 'my-classname',
+          style: {
+            width: '95.5%',
+            color: 'red',
+          },
+        };
+        wrapper.setProps(props);
+
+        const wrapperNode = getTestDOMNode(compName, wrapper);
+
+        expect(wrapperNode.getAttribute('data-tid')).toBe(props['data-tid']);
+        expect(wrapperNode.getAttribute('data-testid')).toBe(props['data-testid']);
+        expect(wrapperNode.classList.contains(props.className)).toBe(true);
+        expect(getComputedStyle(wrapperNode)).toMatchObject(props.style);
+      },
+    );
+  });
+
+  describe("Form Element's Props", () => {
+    const getTestWrapper = (compName: string, wrapper: ReactWrapper) => {
+      switch (compName) {
+        case 'TokenInput':
+        case 'Textarea':
+          return wrapper.find('textarea');
+        case 'Button':
+        case 'Select':
+          return wrapper.find('button');
+        default:
+          return wrapper.find('input');
+      }
+    };
+
+    it.each<string>([
+      'Input',
+      'FxInput',
+      'CurrencyInput',
+      'PasswordInput',
+      'Autocomplete',
+      'DateInput',
+      'DatePicker',
+      'ComboBox',
+      'TokenInput',
+      'Checkbox',
+      'Radio',
+      'Switcher',
+      'Toggle',
+      'Select',
+      'Button',
+    ])('%s', compName => {
+      const props: React.InputHTMLAttributes<HTMLInputElement> = {
+        // global attributes
+        id: 'my-id',
+        title: 'my-title',
+        tabIndex: 15,
+        inputMode: 'email',
+        spellCheck: false,
+
+        // form elements
+        autoComplete: 'my-autocomplete',
+        autoFocus: true,
+        disabled: true,
+        form: 'my-form',
+        formAction: '//example.com',
+        formEncType: 'text/plain',
+        formMethod: 'post',
+        formNoValidate: true,
+        formTarget: '_self',
+        name: 'my-name',
+
+        // accessibility
+        'aria-label': '',
+        'aria-labelledby': '',
       };
+      const wrapper = createWrapper(compName);
       wrapper.setProps(props);
 
-      const wrapperNode = getTestDOMNode(compName, wrapper);
+      const testWrapper = getTestWrapper(compName, wrapper);
 
-      expect(wrapperNode.getAttribute('data-tid')).toBe(props['data-tid']);
-      expect(wrapperNode.getAttribute('data-testid')).toBe(props['data-testid']);
-      expect(wrapperNode.classList.contains(props.className)).toBe(true);
-      expect(getComputedStyle(wrapperNode)).toMatchObject(props.style);
+      expect(testWrapper.props()).toMatchObject(props);
+    });
+  });
+
+  describe("Input's Specific Props", () => {
+    it.each<string>([
+      'Input',
+      'FxInput',
+      'Autocomplete',
+      'ComboBox',
+      // 'TokenInput', // uses <textarea /> instead of <input />
+    ])('%s', compName => {
+      const props: React.InputHTMLAttributes<HTMLInputElement> = {
+        accept: 'my-accept', //	          file
+        capture: 'my-capture', //	        file
+        list: 'my-list', //	              almost all
+        max: 15, //	                      numeric
+        maxLength: 15, //	                password, search, tel, text, url
+        min: 15, //	                      numeric
+        minLength: 15, //	                password, search, tel, text, url
+        multiple: true, //	              email, file
+        pattern: '*', //	                password, text, tel
+        placeholder: 'my-placeholder', //	password, search, tel, text, url
+        readOnly: true, //	              almost all
+        step: '15', //	                  numeric
+        type: 'my-type', //               all
+        required: true, //                all
+      };
+      const wrapper = createWrapper(compName);
+
+      if (compName === 'ComboBox') {
+        // ComboBox renders <InputLikeText />
+        // instead of <input /> while not it focus
+        wrapper.find('span[tabIndex]').simulate('focus');
+      }
+
+      wrapper.setProps(props);
+
+      expect(wrapper.find('input').props()).toMatchObject(props);
     });
   });
 

--- a/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
+++ b/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
@@ -52,9 +52,9 @@ jest.mock('invariant', () => (...args: any[]) => {
   }
 });
 
-const createWrapper = <T extends {}>(compName: string) => {
+const createWrapper = <T extends {}>(compName: string, initProps: object = {}) => {
   const component = (ReactUI as any)[compName];
-  const props: any = (DEFAULT_PROPS as any)[compName] || {};
+  const props = { ...(DEFAULT_PROPS as any)[compName], ...initProps };
   return mount<T>(React.createElement(component, props));
 };
 
@@ -156,8 +156,7 @@ describe('Props Forwarding', () => {
         'aria-label': '',
         'aria-labelledby': '',
       };
-      const wrapper = createWrapper(compName);
-      wrapper.setProps(props);
+      const wrapper = createWrapper(compName, props);
 
       const testWrapper = getTestWrapper(compName, wrapper);
 
@@ -186,18 +185,16 @@ describe('Props Forwarding', () => {
         placeholder: 'my-placeholder', //	password, search, tel, text, url
         readOnly: true, //	              almost all
         step: '15', //	                  numeric
-        type: 'my-type', //               all
+        type: 'tel', //                   all
         required: true, //                all
       };
-      const wrapper = createWrapper(compName);
+      const wrapper = createWrapper(compName, props);
 
       if (compName === 'ComboBox') {
         // ComboBox renders <InputLikeText />
         // instead of <input /> while not it focus
         wrapper.find('span[tabIndex]').simulate('focus');
       }
-
-      wrapper.setProps(props);
 
       expect(wrapper.find('input').props()).toMatchObject(props);
     });
@@ -235,9 +232,7 @@ describe('Props Forwarding', () => {
       'TokenInput',
     ])('%s', compName => {
       const width = '99px';
-      const component = (ReactUI as any)[compName];
-      const props = { ...(DEFAULT_PROPS as any)[compName], width };
-      const wrapper = mount(React.createElement(component, props));
+      const wrapper = createWrapper(compName, { width });
       const testDOMNode = getTestDOMNode(compName, wrapper);
 
       expect(getComputedStyle(testDOMNode).width).toBe(width);

--- a/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
+++ b/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
@@ -3,6 +3,7 @@ import { mount, ReactWrapper } from 'enzyme';
 
 import * as ReactUI from '../../index';
 
+// all components that are available for import from the react-ui
 const PUBLIC_COMPONENTS = Object.keys(ReactUI).filter(name => {
   return (
     isPublicComponent((ReactUI as any)[name]) &&
@@ -12,15 +13,21 @@ const PUBLIC_COMPONENTS = Object.keys(ReactUI).filter(name => {
 
 // some components have required props
 // so we need this in order to create them dynamically
+// also we pass values to inputs to check their forwarding
 const DEFAULT_PROPS = {
-  Autocomplete: { value: '', onValueChange: jest.fn() },
-  FxInput: { onValueChange: jest.fn() },
-  CurrencyInput: { onValueChange: jest.fn() },
+  Autocomplete: { value: 'value', onValueChange: jest.fn() },
+  FxInput: { value: 'value', onValueChange: jest.fn() },
+  CurrencyInput: { value: 0, onValueChange: jest.fn() },
   CurrencyLabel: { value: '' },
-  DatePicker: { onValueChange: jest.fn() },
-  ComboBox: { getItems: () => Promise.resolve([]) },
-  TokenInput: { type: ReactUI.TokenInputType.Combined, getItems: () => Promise.resolve([]), onValueChange: jest.fn() },
-  Radio: { value: '' },
+  DatePicker: { value: '00.00.0000', onValueChange: jest.fn() },
+  ComboBox: { value: { label: 'value', value: 0 }, getItems: () => Promise.resolve([]) },
+  TokenInput: {
+    type: ReactUI.TokenInputType.Combined,
+    getItems: () => Promise.resolve([]),
+    onValueChange: jest.fn(),
+    selectedItems: ['one', 'two'],
+  },
+  Radio: { value: 'value' },
   RadioGroup: { items: [] },
   Dropdown: { caption: 'caption' },
   DropdownMenu: { caption: 'caption' },
@@ -30,7 +37,7 @@ const DEFAULT_PROPS = {
   MenuHeader: { children: '' },
   Paging: { activePage: 0, onPageChange: jest.fn(), pagesCount: 0 },
   Sticky: { side: 'top' },
-  Switcher: { items: [] },
+  Switcher: { value: 'value', items: [] },
   Tabs: { value: '' },
   TooltipMenu: { caption: 'caption' },
   TopBarDropdown: { label: 'label' },
@@ -40,8 +47,13 @@ const DEFAULT_PROPS = {
   Tooltip: { trigger: 'opened', render: () => 'Tooltip', children: <i /> },
   Toast: { children: <i /> },
   Tab: { id: 'tab' },
-  // prevents Input from switching into controlled mode while setting test props
   Input: { value: 'value' },
+  Toggle: { value: 'value' },
+  Checkbox: { value: 'value' },
+  PasswordInput: { value: 'value' },
+  Select: { value: 'value' },
+  Button: { value: 'value' },
+  Textarea: { value: 'value' },
 };
 
 // allows rendering Tab not only inside Tabs
@@ -52,13 +64,15 @@ jest.mock('invariant', () => (...args: any[]) => {
   }
 });
 
-const createWrapper = <T extends {}>(compName: string, initProps: object = {}) => {
+const createWrapper = <T extends React.Component>(compName: string, initProps: object = {}) => {
   const component = (ReactUI as any)[compName];
   const props = { ...(DEFAULT_PROPS as any)[compName], ...initProps };
-  return mount<T>(React.createElement(component, props));
+  return mount<T, {}, {}>(React.createElement(component, props));
 };
 
 describe('Props Forwarding', () => {
+  // check that className, style and data-* are being forwarding
+  // correctly into all public components
   describe('Common Props', () => {
     const getTestDOMNode = (compName: string, wrapper: ReactWrapper) => {
       switch (compName) {
@@ -101,21 +115,35 @@ describe('Props Forwarding', () => {
     );
   });
 
+  // check props that are relevant for form elements
   describe("Form Element's Props", () => {
     const getTestWrapper = (compName: string, wrapper: ReactWrapper) => {
       switch (compName) {
-        case 'TokenInput':
-        case 'Textarea':
-          return wrapper.find('textarea');
         case 'Button':
-        case 'Select':
           return wrapper.find('button');
         default:
           return wrapper.find('input');
       }
     };
+    const getProps = (): React.InputHTMLAttributes<HTMLInputElement> => ({
+      // global attributes
+      id: 'my-id',
+      tabIndex: 15,
+      inputMode: 'email',
 
-    it.each<string>([
+      // form elements
+      autoComplete: 'my-autocomplete',
+      autoFocus: true,
+      disabled: true,
+      name: 'my-name',
+      form: 'my-form',
+
+      // accessibility
+      'aria-label': 'label',
+      'aria-labelledby': 'element',
+    });
+
+    it.each<keyof typeof ReactUI>([
       'Input',
       'FxInput',
       'CurrencyInput',
@@ -123,83 +151,131 @@ describe('Props Forwarding', () => {
       'Autocomplete',
       'DateInput',
       'DatePicker',
-      'ComboBox',
-      'TokenInput',
       'Checkbox',
       'Radio',
       'Switcher',
       'Toggle',
-      'Select',
       'Button',
     ])('%s', compName => {
-      const props: React.InputHTMLAttributes<HTMLInputElement> = {
-        // global attributes
-        id: 'my-id',
-        title: 'my-title',
-        tabIndex: 15,
-        inputMode: 'email',
-        spellCheck: false,
-
-        // form elements
-        autoComplete: 'my-autocomplete',
-        autoFocus: true,
-        disabled: true,
-        form: 'my-form',
-        formAction: '//example.com',
-        formEncType: 'text/plain',
-        formMethod: 'post',
-        formNoValidate: true,
-        formTarget: '_self',
-        name: 'my-name',
-
-        // accessibility
-        'aria-label': '',
-        'aria-labelledby': '',
-      };
+      const props = getProps();
       const wrapper = createWrapper(compName, props);
-
       const testWrapper = getTestWrapper(compName, wrapper);
 
       expect(testWrapper.props()).toMatchObject(props);
+      expect(testWrapper.prop('value')).toBeDefined();
+    });
+
+    it('Select', () => {
+      // Select contains separated Button and <input />.
+      // Button makes his look and process user's interactions.
+      // <input /> stores his value and operates with forms.
+
+      const props = getProps();
+
+      const wrapper = createWrapper('Select', props);
+      const input = wrapper.find('input');
+      const button = wrapper.find('button');
+
+      const { name, form, disabled } = props;
+      const inputProps = { name, form, disabled };
+
+      const buttonProps = getProps();
+      delete buttonProps.form;
+      delete buttonProps.name;
+
+      expect(button.props()).toMatchObject(buttonProps);
+      expect(input.props()).toMatchObject(inputProps);
+      expect(input.prop('value')).toBeDefined();
+    });
+
+    it('ComboBox', () => {
+      // Note: the autoFocus prop is set in true in test props
+
+      const props = getProps();
+      const wrapper = createWrapper('ComboBox', props);
+
+      const textInput = wrapper.find('input:not([readOnly])');
+      const valueInput = wrapper.find('input[readOnly]');
+
+      const { name, form, disabled } = props;
+      const valueInputProps = { name, form, disabled };
+
+      const textInputProps = getProps();
+      delete textInputProps.form;
+      delete textInputProps.name;
+
+      expect(textInput.props()).toMatchObject(textInputProps);
+      expect(valueInput.props()).toMatchObject(valueInputProps);
+      expect(valueInput.prop('value')).toBeDefined();
+    });
+
+    it('TokenInput', () => {
+      // TokenInput contains textarea to input text and separate
+      // hidden input that stores his value and operates with forms
+
+      const props = getProps();
+      const wrapper = createWrapper('TokenInput', props);
+      const textarea = wrapper.find('textarea');
+      const input = wrapper.find('input[readOnly]');
+
+      const { name, form, disabled } = props;
+      const inputProps = { name, form, disabled };
+
+      const textareaProps = getProps();
+      delete textareaProps.form;
+      delete textareaProps.name;
+
+      expect(textarea.props()).toMatchObject(textareaProps);
+      expect(input.props()).toMatchObject(inputProps);
+      expect(input.prop('value')).toBeDefined();
     });
   });
 
+  // check props that are input-specific only
   describe("Input's Specific Props", () => {
-    it.each<string>([
+    it.each<keyof typeof ReactUI>([
       'Input',
       'FxInput',
       'Autocomplete',
       'ComboBox',
-      // 'TokenInput', // uses <textarea /> instead of <input />
+      // 'TokenInput', // could be here but it uses <textarea /> instead of <input />
     ])('%s', compName => {
       const props: React.InputHTMLAttributes<HTMLInputElement> = {
-        accept: 'my-accept', //	          file
-        capture: 'my-capture', //	        file
-        list: 'my-list', //	              almost all
-        max: 15, //	                      numeric
-        maxLength: 15, //	                password, search, tel, text, url
-        min: 15, //	                      numeric
-        minLength: 15, //	                password, search, tel, text, url
-        multiple: true, //	              email, file
-        pattern: '*', //	                password, text, tel
-        placeholder: 'my-placeholder', //	password, search, tel, text, url
-        readOnly: true, //	              almost all
-        step: '15', //	                  numeric
-        type: 'tel', //                   all
-        required: true, //                all
+        list: 'my-list',
+        max: 15,
+        maxLength: 15,
+        min: 15,
+        minLength: 15,
+        multiple: true,
+        pattern: '*',
+        placeholder: 'my-placeholder',
+        readOnly: true,
+        step: '15',
+        type: 'tel',
+        required: true,
       };
       const wrapper = createWrapper(compName, props);
 
       if (compName === 'ComboBox') {
-        // ComboBox renders <InputLikeText />
-        // instead of <input /> while not it focus
-        wrapper.find('span[tabIndex]').simulate('focus');
-      }
+        // ComboBox renders <InputLikeText /> while not in focus
+        // and the real <input /> otherwise.
+        // Also it has a separate hidden input to store the value.
+        // Here we need the visible one.
 
-      expect(wrapper.find('input').props()).toMatchObject(props);
+        wrapper.find('span[tabIndex]').simulate('focus');
+        expect(
+          wrapper
+            .find('input')
+            .not('[type="hidden"]')
+            .props(),
+        ).toMatchObject(props);
+      } else {
+        expect(wrapper.find('input').props()).toMatchObject(props);
+      }
     });
   });
 
+  // check that the width prop still works
   describe('"width" Prop', () => {
     const getTestDOMNode = (compName: string, wrapper: ReactWrapper) => {
       switch (compName) {

--- a/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
+++ b/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
@@ -35,7 +35,7 @@ export class CommonWrapper<P extends CommonProps> extends React.Component<Common
   }
 }
 
-const extractCommonProps = <P extends CommonProps>(props: P): [CommonProps, NotCommonProps<P>] => {
+export const extractCommonProps = <P extends CommonProps>(props: P): [CommonProps, NotCommonProps<P>] => {
   const common = {} as CommonProps;
   const rest = {} as NotCommonProps<P>;
 

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
@@ -2,61 +2,35 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 
 import { DropdownContainer } from '../DropdownContainer';
-import { Input, InputIconType } from '../../components/Input';
+import { Input } from '../../components/Input';
 import { InputLikeText } from '../InputLikeText';
 import { Menu } from '../Menu';
-import { MenuItemState } from '../../components/MenuItem';
 import { RenderLayer } from '../RenderLayer';
 import { Spinner } from '../../components/Spinner';
 import { Nullable } from '../../typings/utility-types';
 import { ArrowTriangleDownIcon } from '../icons/16px';
-import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
+import { CustomComboBoxProps } from './CustomComboBox';
 import { ComboBoxMenu } from './ComboBoxMenu';
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { jsStyles } from './CustomComboBox.styles';
 
-interface ComboBoxViewProps<T> extends CommonProps {
-  align?: 'left' | 'center' | 'right';
-  autoFocus?: boolean;
-  borderless?: boolean;
-  disablePortal?: boolean;
-  disabled?: boolean;
+interface ComboBoxViewProps<T>
+  extends Omit<
+    CustomComboBoxProps<T>,
+    'getItems' | 'itemToValue' | 'valueToString' | 'searchOnFocus' | 'onUnexpectedInput'
+  > {
   editing?: boolean;
-  error?: boolean;
   items?: Nullable<T[]>;
   loading?: boolean;
-  menuAlign?: 'left' | 'right';
   opened?: boolean;
-  drawArrow?: boolean;
-  placeholder?: string;
-  size?: 'small' | 'medium' | 'large';
   textValue?: string;
-  totalCount?: number;
-  value?: Nullable<T>;
-  warning?: boolean;
-  width?: string | number;
-  maxLength?: number;
-  maxMenuHeight?: number | string;
-  leftIcon?: InputIconType;
-
-  onValueChange?: (value: T) => void;
   onClickOutside?: (e: Event) => void;
-  onFocus?: () => void;
   onFocusOutside?: () => void;
   onInputBlur?: () => void;
-  onInputValueChange?: (value: string) => void;
   onInputFocus?: () => void;
   onInputClick?: () => void;
-  onInputKeyDown?: (e: React.KeyboardEvent) => void;
-  onMouseEnter?: (e: React.MouseEvent) => void;
-  onMouseOver?: (e: React.MouseEvent) => void;
-  onMouseLeave?: (e: React.MouseEvent) => void;
-  renderItem?: (item: T, state: MenuItemState) => React.ReactNode;
-  renderNotFound?: () => React.ReactNode;
-  renderTotalCount?: (found: number, total: number) => React.ReactNode;
-  renderValue?: (item: T) => React.ReactNode;
-  renderAddButton: (query?: string) => React.ReactNode;
   repeatRequest?: () => void;
   requestStatus?: ComboBoxRequestStatus;
   refInput?: (input: Nullable<Input>) => void;
@@ -179,7 +153,7 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
   };
 
   private renderAddButton = (): React.ReactNode => {
-    return this.props.renderAddButton(this.props.textValue);
+    return this.props.renderAddButton?.(this.props.textValue);
   };
 
   private renderInput(props: CommonWrapperRestProps<ComboBoxViewProps<T>>): React.ReactNode {

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
@@ -10,7 +10,7 @@ import { RenderLayer } from '../RenderLayer';
 import { Spinner } from '../../components/Spinner';
 import { Nullable } from '../../typings/utility-types';
 import { ArrowTriangleDownIcon } from '../icons/16px';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { ComboBoxMenu } from './ComboBoxMenu';
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
@@ -99,6 +99,10 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
   }
 
   public render() {
+    return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
+  }
+
+  public renderMain = (props: CommonWrapperRestProps<ComboBoxViewProps<T>>) => {
     const {
       items,
       loading,
@@ -117,135 +121,126 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
       repeatRequest,
       requestStatus,
       totalCount,
-      size,
       width,
-    } = this.props;
+    } = props;
 
-    const input = this.renderInput();
+    const input = this.renderInput(props);
 
     const topOffsets = {
       spinner: 6,
       arrow: 15,
     };
-    if (size === 'medium') {
+    if (props.size === 'medium') {
       topOffsets.spinner += 4;
       topOffsets.arrow += 4;
     }
-    if (size === 'large') {
+    if (props.size === 'large') {
       topOffsets.spinner += 6;
       topOffsets.arrow += 6;
     }
 
     return (
-      <CommonWrapper {...this.props}>
-        <RenderLayer onClickOutside={onClickOutside} onFocusOutside={onFocusOutside} active={opened}>
-          <span
-            style={{ width }}
-            className={jsStyles.root()}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onMouseOver={onMouseOver}
-          >
-            {input}
-            {opened && (
-              <DropdownContainer
-                align={menuAlign}
-                getParent={() => findDOMNode(this)}
-                offsetY={1}
-                disablePortal={this.props.disablePortal}
-              >
-                <ComboBoxMenu
-                  items={items}
-                  loading={loading}
-                  maxMenuHeight={maxMenuHeight}
-                  onValueChange={this.handleItemSelect}
-                  opened={opened}
-                  refMenu={refMenu}
-                  renderTotalCount={renderTotalCount}
-                  renderItem={renderItem!}
-                  renderNotFound={renderNotFound}
-                  renderAddButton={this.renderAddButton}
-                  repeatRequest={repeatRequest}
-                  requestStatus={requestStatus}
-                  totalCount={totalCount}
-                />
-              </DropdownContainer>
-            )}
-          </span>
-        </RenderLayer>
-      </CommonWrapper>
+      <RenderLayer onClickOutside={onClickOutside} onFocusOutside={onFocusOutside} active={opened}>
+        <span
+          style={{ width }}
+          className={jsStyles.root()}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          onMouseOver={onMouseOver}
+        >
+          {input}
+          {opened && (
+            <DropdownContainer
+              align={menuAlign}
+              getParent={() => findDOMNode(this)}
+              offsetY={1}
+              disablePortal={this.props.disablePortal}
+            >
+              <ComboBoxMenu
+                items={items}
+                loading={loading}
+                maxMenuHeight={maxMenuHeight}
+                onValueChange={this.handleItemSelect}
+                opened={opened}
+                refMenu={refMenu}
+                renderTotalCount={renderTotalCount}
+                renderItem={renderItem!}
+                renderNotFound={renderNotFound}
+                renderAddButton={this.renderAddButton}
+                repeatRequest={repeatRequest}
+                requestStatus={requestStatus}
+                totalCount={totalCount}
+              />
+            </DropdownContainer>
+          )}
+        </span>
+      </RenderLayer>
     );
-  }
+  };
 
   private renderAddButton = (): React.ReactNode => {
     return this.props.renderAddButton(this.props.textValue);
   };
 
-  private renderInput(): React.ReactNode {
+  private renderInput(props: CommonWrapperRestProps<ComboBoxViewProps<T>>): React.ReactNode {
     const {
-      align,
-      borderless,
-      disabled,
       editing,
-      error,
       onFocus,
       onInputBlur,
       onInputValueChange,
       onInputFocus,
       onInputClick,
       onInputKeyDown,
-      placeholder,
+      onValueChange,
       renderValue,
-      size,
       textValue,
       value,
-      warning,
       refInputLikeText,
-      leftIcon,
-    } = this.props;
+      renderAddButton,
+      items,
+      loading,
+      menuAlign,
+      onClickOutside,
+      onFocusOutside,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseOver,
+      opened,
+      refMenu,
+      maxMenuHeight,
+      renderTotalCount,
+      renderItem,
+      renderNotFound,
+      repeatRequest,
+      requestStatus,
+      totalCount,
+      disablePortal,
+      drawArrow,
+      refInput,
+      ...rest
+    } = props;
 
     const rightIcon = this.getRightIcon();
 
     if (editing) {
       return (
         <Input
-          align={align}
-          borderless={borderless}
-          disabled={disabled}
-          error={error}
-          maxLength={this.props.maxLength}
+          {...rest}
           onBlur={onInputBlur}
           onValueChange={onInputValueChange}
           onFocus={onInputFocus}
           onClick={onInputClick}
-          leftIcon={leftIcon}
-          rightIcon={rightIcon}
           value={textValue || ''}
           onKeyDown={onInputKeyDown}
-          placeholder={placeholder}
           width="100%"
-          size={size}
           ref={this.refInput}
-          warning={warning}
+          rightIcon={rightIcon}
         />
       );
     }
 
     return (
-      <InputLikeText
-        align={align}
-        borderless={borderless}
-        error={error}
-        onFocus={onFocus}
-        leftIcon={leftIcon}
-        rightIcon={rightIcon}
-        disabled={disabled}
-        warning={warning}
-        placeholder={placeholder}
-        size={size}
-        width="100%"
-        ref={refInputLikeText}
-      >
+      <InputLikeText {...rest} onFocus={onFocus} width="100%" ref={refInputLikeText} rightIcon={rightIcon}>
         {value ? renderValue!(value) : null}
       </InputLikeText>
     );

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
@@ -17,10 +17,7 @@ import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { jsStyles } from './CustomComboBox.styles';
 
 interface ComboBoxViewProps<T>
-  extends Omit<
-    CustomComboBoxProps<T>,
-    'getItems' | 'itemToValue' | 'valueToString' | 'searchOnFocus' | 'onUnexpectedInput'
-  > {
+  extends Omit<CustomComboBoxProps<T>, 'getItems' | 'valueToString' | 'searchOnFocus' | 'onUnexpectedInput'> {
   editing?: boolean;
   items?: Nullable<T[]>;
   loading?: boolean;
@@ -42,6 +39,8 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
   public static __KONTUR_REACT_UI__ = 'ComboBoxView';
 
   public static defaultProps = {
+    // TODO: use defaultProps from ComboBox
+    itemToValue: (item: any) => item.value,
     renderItem: (item: any) => item,
     renderValue: (item: any) => item,
     renderAddButton: () => null,
@@ -191,32 +190,54 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
       disablePortal,
       drawArrow,
       refInput,
+      itemToValue,
+      name,
+      form,
+      disabled,
       ...rest
     } = props;
 
     const rightIcon = this.getRightIcon();
 
-    if (editing) {
-      return (
-        <Input
-          {...rest}
-          onBlur={onInputBlur}
-          onValueChange={onInputValueChange}
-          onFocus={onInputFocus}
-          onClick={onInputClick}
-          value={textValue || ''}
-          onKeyDown={onInputKeyDown}
-          width="100%"
-          ref={this.refInput}
-          rightIcon={rightIcon}
-        />
-      );
-    }
+    const hiddenInputProps = {
+      name,
+      form,
+      disabled,
+      value: this.getValueAsString(),
+    };
 
-    return (
-      <InputLikeText {...rest} onFocus={onFocus} width="100%" ref={refInputLikeText} rightIcon={rightIcon}>
+    const input = editing ? (
+      <Input
+        {...rest}
+        onBlur={onInputBlur}
+        onValueChange={onInputValueChange}
+        onFocus={onInputFocus}
+        onClick={onInputClick}
+        value={textValue || ''}
+        onKeyDown={onInputKeyDown}
+        width="100%"
+        ref={this.refInput}
+        rightIcon={rightIcon}
+        disabled={disabled}
+      />
+    ) : (
+      <InputLikeText
+        {...rest}
+        onFocus={onFocus}
+        width="100%"
+        ref={refInputLikeText}
+        rightIcon={rightIcon}
+        disabled={disabled}
+      >
         {value ? renderValue!(value) : null}
       </InputLikeText>
+    );
+
+    return (
+      <>
+        {input}
+        <input {...hiddenInputProps} type="hidden" readOnly />
+      </>
     );
   }
 
@@ -255,5 +276,10 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
     }
 
     return null;
+  };
+
+  private getValueAsString = (): string => {
+    const { value, itemToValue } = this.props;
+    return value !== undefined && value !== null ? String(itemToValue(value)) : '';
   };
 }

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -179,7 +179,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   }
 
   public render() {
-    const { getItems, itemToValue, valueToString, searchOnFocus, onUnexpectedInput, ...rest } = this.props;
+    const { getItems, valueToString, searchOnFocus, onUnexpectedInput, ...rest } = this.props;
 
     const viewProps = {
       ...rest,

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -7,13 +7,12 @@ import { InputLikeText } from '../InputLikeText';
 import { MenuItemState } from '../../components/MenuItem';
 import { CancelationError, taskWithDelay } from '../../lib/utils';
 import { fixClickFocusIE } from '../../lib/events/fixClickFocusIE';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { CustomComboBoxAction, CustomComboBoxEffect, reducer } from './CustomComboBoxReducer';
 import { ComboBoxView } from './ComboBoxView';
 
-export interface CustomComboBoxProps<T> extends CommonProps {
+export interface CustomComboBoxProps<T> {
   align?: 'left' | 'center' | 'right';
   autoFocus?: boolean;
   borderless?: boolean;
@@ -216,28 +215,16 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   }
 
   public render() {
+    const { getItems, itemToValue, valueToString, searchOnFocus, onUnexpectedInput, ...rest } = this.props;
+
     const viewProps = {
-      align: this.props.align,
-      borderless: this.props.borderless,
-      disabled: this.props.disabled,
-      disablePortal: this.props.disablePortal,
+      ...rest,
+
       editing: this.state.editing,
-      error: this.props.error,
       items: this.state.items,
       loading: this.state.loading,
-      menuAlign: this.props.menuAlign,
       opened: this.state.opened,
-      drawArrow: this.props.drawArrow,
-      placeholder: this.props.placeholder,
-      size: this.props.size,
       textValue: this.state.textValue,
-      totalCount: this.props.totalCount,
-      value: this.props.value,
-      warning: this.props.warning,
-      width: this.props.width,
-      maxLength: this.props.maxLength,
-      maxMenuHeight: this.props.maxMenuHeight,
-      leftIcon: this.props.leftIcon,
 
       onValueChange: this.handleValueChange,
       onClickOutside: this.handleClickOutside,
@@ -251,14 +238,6 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
         event.persist();
         this.dispatch({ type: 'KeyPress', event });
       },
-      onMouseEnter: this.props.onMouseEnter,
-      onMouseOver: this.props.onMouseOver,
-      onMouseLeave: this.props.onMouseLeave,
-      renderItem: this.props.renderItem,
-      renderNotFound: this.props.renderNotFound,
-      renderValue: this.props.renderValue,
-      renderTotalCount: this.props.renderTotalCount,
-      renderAddButton: this.props.renderAddButton,
       repeatRequest: this.state.repeatRequest,
       requestStatus: this.state.requestStatus,
 
@@ -273,11 +252,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       },
     };
 
-    return (
-      <CommonWrapper {...this.props}>
-        <ComboBoxView {...viewProps} />
-      </CommonWrapper>
-    );
+    return <ComboBoxView {...viewProps} />;
   }
 
   public componentDidMount() {

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { Nullable } from '../../typings/utility-types';
-import { Input, InputIconType } from '../../components/Input';
+import { Input } from '../../components/Input';
+import { ComboBoxProps } from '../../components/ComboBox';
 import { Menu } from '../Menu';
 import { InputLikeText } from '../InputLikeText';
-import { MenuItemState } from '../../components/MenuItem';
 import { CancelationError, taskWithDelay } from '../../lib/utils';
 import { fixClickFocusIE } from '../../lib/events/fixClickFocusIE';
 
@@ -12,43 +12,7 @@ import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { CustomComboBoxAction, CustomComboBoxEffect, reducer } from './CustomComboBoxReducer';
 import { ComboBoxView } from './ComboBoxView';
 
-export interface CustomComboBoxProps<T> {
-  align?: 'left' | 'center' | 'right';
-  autoFocus?: boolean;
-  borderless?: boolean;
-  disablePortal?: boolean;
-  disabled?: boolean;
-  error?: boolean;
-  maxLength?: number;
-  menuAlign?: 'left' | 'right';
-  drawArrow?: boolean;
-  leftIcon?: InputIconType;
-  searchOnFocus?: boolean;
-  onValueChange?: (value: T) => void;
-  onInputValueChange?: (value: string) => Nullable<string> | void;
-  onUnexpectedInput?: (value: string) => void | null | T;
-  onFocus?: () => void;
-  onBlur?: () => void;
-  onMouseEnter?: (e: React.MouseEvent) => void;
-  onMouseOver?: (e: React.MouseEvent) => void;
-  onMouseLeave?: (e: React.MouseEvent) => void;
-  onInputKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
-  placeholder?: string;
-  size?: 'small' | 'medium' | 'large';
-  totalCount?: number;
-  value?: Nullable<T>;
-  warning?: boolean;
-  width?: string | number;
-  maxMenuHeight?: number | string;
-  renderNotFound?: () => React.ReactNode;
-  renderTotalCount?: (found: number, total: number) => React.ReactNode;
-  renderItem: (item: T, state?: MenuItemState) => React.ReactNode;
-  renderValue: (value: T) => React.ReactNode;
-  renderAddButton?: (query?: string) => React.ReactNode;
-  valueToString: (value: T) => string;
-  itemToValue: (item: T) => string | number;
-  getItems: (query: string) => Promise<T[]>;
-}
+export type CustomComboBoxProps<T> = ComboBoxProps<T>;
 
 export interface CustomComboBoxState<T> {
   editing: boolean;

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -29,7 +29,7 @@ export type InputLikeTextState = Omit<InputState, 'polyfillPlaceholder'>;
 export class InputLikeText extends React.Component<InputLikeTextProps, InputLikeTextState> {
   public static __KONTUR_REACT_UI__ = 'InputLikeText';
 
-  public static defaultProps = { size: 'small' };
+  public static defaultProps = { size: 'small', tabIndex: 0 };
 
   public state = { blinking: false, focused: false };
 
@@ -142,6 +142,10 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
       value,
       onMouseDragStart,
       onMouseDragEnd,
+      onMouseEnter,
+      onMouseLeave,
+      onMouseOver,
+
       ...rest
     } = props;
 
@@ -157,7 +161,7 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
       [jsInputStyles.blink(this.theme)]: blinking,
       [jsInputStyles.warning(this.theme)]: !!warning,
       [jsInputStyles.error(this.theme)]: !!error,
-      [jsInputStyles.disabled(this.theme)]: !!disabled,
+      [jsInputStyles.disabled(this.theme)]: !!props.disabled,
       [jsInputStyles.focusFallback(this.theme)]: focused && (isIE11 || isEdge),
       [jsInputStyles.warningFallback(this.theme)]: !!warning && (isIE11 || isEdge),
       [jsInputStyles.errorFallback(this.theme)]: !!error && (isIE11 || isEdge),
@@ -167,19 +171,23 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
       [jsStyles.userSelectContain()]: focused,
     });
 
+    // TODO: use label with real input instead of <span tabIndex /> (related #1679)
     return (
       <span
         {...rest}
         className={className}
         style={{ width, textAlign: align }}
-        tabIndex={disabled ? undefined : 0}
+        tabIndex={disabled ? undefined : tabIndex}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         ref={this.innerRef}
         onKeyDown={this.handleKeyDown}
         onMouseDown={this.handleMouseDown}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseOver={onMouseOver}
       >
-        <input type="hidden" value={value} />
+        <input {...rest} type="hidden" value={value} tabIndex={tabIndex} disabled={disabled} readOnly />
         {leftSide}
         <span className={wrapperClass}>
           <span data-tid="InputLikeText__input" className={cn(jsStyles.input(), jsInputStyles.input(this.theme))}>


### PR DESCRIPTION
Вторая часть #2107, реализующая проброс недостающих пропов до нативных инпутов в некоторые компоненты. 

<details>
<summary>Ситуация по компонентам до ПРа</summary>

| Компонент | Проброс всех пропов до `<input />` или `<button />`
| - | - |
| Input | ✔ |
| FxInput | ✔ |
| CurrencyInput | ✔ |
| PasswordInput | ✔ |
| Autocomplete | ✔ |
| DateInput | ❌ |
| DatePicker | ❌ |
| ComboBox | ❌ |
| TokenInput | ❌ |
| Checkbox | ✔ |
| Radio | ✔ |
| Switcher | ❌ |
| Toggle | ❌ |
| Select | ❌ |
| Button | ❌ |
</details>

#### TL;DR 

Ситуация в том, что не все компоненты, основанные на нативных input/textarea/button, сейчас принимают полный набор релевантных для них пропов. Хотя кажется, что могли бы.

Проброс всех пропов позволяет, например, улучшить взаимодействие с формами (пропы `form`, `name`), открывать соответствующую клавиатуру на мобильных (`type`, `inputMode`), управлять фокусом (`tabIndex`, `autoFocus`), автодополнением (`autoComplete`) и др.

В том числе, речь идет и о всевозможных обработчиках событий, некоторых из которых иногда не хватает (например, `onPaste`, `onKeyDownCapture`  в ComboBox и тд). Также в ComboBox возможно стоит добавить все пропы из Input.

Запросы на подобный функционал то и дело поступают от пользователей (см. #2107). Это попытка закрыть их все, комплексно, через возможность передавать вообще любые пропы, характерные для нативных инпутов.

Однако, у этого решения есть и минусы, о которых ниже.

Примеры новых сценариев:

```jsx
<Input type="number" max="15 />
<ComboBox onPaste={handlePaste} mask="***" />
<Button type="submit" form="my-form" />
<Toggle tabIndex="-1" />
<DatePicker name="date" />
<TokenInput inputMode="email" />
```

Demo: [https://tech.skbkontur.ru](https://tech.skbkontur.ru/react-ui/0.0.0-a56ed1062c/#/Components/Input), [https://codesandbox.com](https://codesandbox.io/s/zen-monad-hp5th?file=/src/App.tsx)

close #2107 #1643 

<details>
<summary>Другие связанные issue</summary>
Связано, но не полностью решает #675. Нужно попробовать расширить тип value до number. И проверить, корректно ли работают остальные сценарии Input (mask и др).

Также, можно прописать дефолтный `inputMode` для #1678.

Но это уже лучше сделать в отдельном ПР. 
</details>

---

# Но ...

Далее более детально раскрыта изначальная проблема, суть решения, его плюсы, минусы и альтернативы.

### Решаемая проблема
От пользователей то и дело поступают отдельные запросы на добавление функционала, характерного для нативных инпутов в наши кастомные контролы (ComboBox, Toggle и др). Основные из них перечислены выше и собраны в #2107. 

Текущий же API этих компонентов видимо основан на принципе строгого контроля и ограничения доступных сценариев. Т.е. к использованию предлагается лишь узкий, заранее определенный набор пропов. Новые пропы при необходимости добавляется вручную в каждый компонент.

Хотя кажется, что все перечисленные выше компоненты являются по сути кастомными аналогами соответствующих нативных элементов форм (инпутов, чекбоксов, селектов и др). И могут полноценно поддерживать тот же набор функций что и они. В том числе:

1. все релевантные пропы (type, inputMode, autoComplete, name, tabIndex, form и тд)
2. все доступные обработчики событий (onCopy/onPaste, onKeyDownCapture и др)
3. полноценную работу с формами (в том числе через [FormData API](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData)), [пример](https://codesandbox.io/s/zen-monad-hp5th?file=/src/App.tsx)
4. [нативную валидацию](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation) (через type, require, min/max и др), [пример](https://input-props.vercel.app/#!/Components/Input/Input/6)
5. [uncontrolled-режим](https://reactjs.org/docs/uncontrolled-components.html)

В связи с чем напрашивается следующее комплексное решение.

### Предлагаемое решение

Если отойти от политики контроля и ограничений, то представляется вполне возможным реализация перечисленного функционала через проброс и поддержку всех существующих пропов, доступных для нативных инпутов. Что также логичным образом включает в себя:

1. Наследование интерфейса пропов от InputHTMLAttributes
2. Поддержка всеми Input-подобными компонентами всех пропов из InputProps (ComboBox, DateInput, DatePicker). А также ButtonProps в Select.

### Минусы решения

1. Актуально для пользователей typescript. Немного ухудшается DX из-за переизбытка пропов в подсказках IDE. Будет сложно искать собственные пропы например ComboBox'а или Toggle'а среди 250+ нативных пропов инпута. Хотя, другим компонентам, в которых уже есть полная поддержка нативных пропов (Input и подобные) это похоже не мешает. В документации по прежнему останется короткий список из кастомных пропов.
2. Теряется полный контроль над всеми сценариями. Невозможно будет протестировать поведение и внешний вид при всех возможных комбинациях новых пропов. Придется оставить их использование полностью на усмотрение пользователей и рассчитывать на здравый смысл.
Например, в `DatePicker`, `DateInput`, `ComboBox` автоматически попадут такие пропы из `Input`, как type, mask, иконки и префиксы. В `Select` станут доступны arrow, active, checked, icon, loading из `Button`. Такие случаи конечно можно предварительно отфильтровывать. Но это не убережет от автоматического проброса новых пропов, которые будут появляться в будущем.
3. Если идти до конца (см. раздел "Дополнительно"), то в некоторой степени усложняется внутренне устройство компонентов. 

<details>
<summary>Полный список пропов нативного инпута, который попадет в ComboBox, DateInput, DatePicker, Toggle, Switcher, TokenInput. Похожая ситуация с Button и Select.</summary>

about
accept
accessKey
alt
aria-activedescendant
aria-atomic
aria-autocomplete
aria-busy
aria-checked
aria-colcount
aria-colindex
aria-colspan
aria-controls
aria-current
aria-describedby
aria-details
aria-disabled
aria-dropeffect
aria-errormessage
aria-expanded
aria-flowto
aria-grabbed
aria-haspopup
aria-hidden
aria-invalid
aria-keyshortcuts
aria-label
aria-labelledby
aria-level
aria-live
aria-modal
aria-multiline
aria-multiselectable
aria-orientation
aria-owns
aria-placeholder
aria-posinset
aria-pressed
aria-readonly
aria-relevant
aria-required
aria-roledescription
aria-rowcount
aria-rowindex
aria-rowspan
aria-selected
aria-setsize
aria-sort
aria-valuemax
aria-valuemin
aria-valuenow
aria-valuetext
autoCapitalize
autoComplete
autoCorrect
autoFocus
autoSave
checked
color
contentEditable
contextMenu
crossOrigin
dangerouslySetInnerHTML
datatype
defaultChecked
defaultValue
dir
disabled
draggable
form
formAction
formEncType
formMethod
formNoValidate
formTarget
height
hidden
id
inlist
inputMode
is
itemID
itemProp
itemRef
itemScope
itemType
lang
list
max
maxLength
min
minLength
multiple
name
onAbort
onAbortCapture
onAnimationEnd
onAnimationEndCapture
onAnimationIteration
onAnimationIterationCapture
onAnimationStart
onAnimationStartCapture
onAuxClick
onAuxClickCapture
onBeforeInput
onBeforeInputCapture
onBlur
onBlurCapture
onCanPlay
onCanPlayCapture
onCanPlayThrough
onCanPlayThroughCapture
onChange
onChangeCapture
onClick
onClickCapture
onCompositionEnd
onCompositionEndCapture
onCompositionStart
onCompositionStartCapture
onCompositionUpdate
onCompositionUpdateCapture
onContextMenu
onContextMenuCapture
onCopy
onCopyCapture
onCut
onCutCapture
onDoubleClick
onDoubleClickCapture
onDrag
onDragCapture
onDragEnd
onDragEndCapture
onDragEnter
onDragEnterCapture
onDragExit
onDragExitCapture
onDragLeave
onDragLeaveCapture
onDragOver
onDragOverCapture
onDragStart
onDragStartCapture
onDrop
onDropCapture
onDurationChange
onDurationChangeCapture
onEmptied
onEmptiedCapture
onEncrypted
onEncryptedCapture
onEnded
onEndedCapture
onError
onErrorCapture
onFocus
onFocusCapture
onGotPointerCapture
onGotPointerCaptureCapture
onInput
onInputCapture
onInvalid
onInvalidCapture
onKeyDown
onKeyDownCapture
onKeyPress
onKeyPressCapture
onKeyUp
onKeyUpCapture
onLoad
onLoadCapture
onLoadStart
onLoadStartCapture
onLoadedData
onLoadedDataCapture
onLoadedMetadata
onLoadedMetadataCapture
onLostPointerCapture
onLostPointerCaptureCapture
onMouseDown
onMouseDownCapture
onMouseMove
onMouseMoveCapture
onMouseOut
onMouseOutCapture
onMouseOverCapture
onMouseUp
onMouseUpCapture
onPaste
onPasteCapture
onPause
onPauseCapture
onPlay
onPlayCapture
onPlaying
onPlayingCapture
onPointerCancel
onPointerCancelCapture
onPointerDown
onPointerDownCapture
onPointerEnter
onPointerEnterCapture
onPointerLeave
onPointerLeaveCapture
onPointerMove
onPointerMoveCapture
onPointerOut
onPointerOutCapture
onPointerOver
onPointerOverCapture
onPointerUp
onPointerUpCapture
onProgress
onProgressCapture
onRateChange
onRateChangeCapture
onReset
onResetCapture
onScroll
onScrollCapture
onSeeked
onSeekedCapture
onSeeking
onSeekingCapture
onSelect
onSelectCapture
onStalled
onStalledCapture
onSubmit
onSubmitCapture
onSuspend
onSuspendCapture
onTimeUpdate
onTimeUpdateCapture
onTouchCancel
onTouchCancelCapture
onTouchEnd
onTouchEndCapture
onTouchMove
onTouchMoveCapture
onTouchStart
onTouchStartCapture
onTransitionEnd
onTransitionEndCapture
onVolumeChange
onVolumeChangeCapture
onWaiting
onWaitingCapture
onWheel
onWheelCapture
pattern
placeholder
property
radioGroup
readOnly
required
resource
results
role
security
slot
spellCheck
src
step
suppressContentEditableWarning
suppressHydrationWarning
tabIndex
title
translate
typeof
unselectable
vocab
width

</details>

### Плюсы решения

1. Проблемы с недостающими пропами решаются комплексно. Исключается перспектива вновь и вновь добавлять поддержку пропов по одному при возникновении потребности. 
2. Интерфейсы контролов становятся более консистентными.

### Альтернативы

Добавить необходимые пропы точечно вручную (проследить, чтобы везде работали `name`, `tabIndex` и тд). Вероятно делать это и дальше. А недостающие обработчики событий можно еще использовать на обертках.

### Дополнительно

Для полноценной поддержки нативного функционала в кастомных контралах также необходимо:

1. Хранить стринговый value внутри каждого контрола, где-то в скрытом `<input />`. Сейчас это не везде присутствует. Нужно для работы с формами. (ComboBox, Select, TokenInput и тд)
2. Обеспечить работу всех компонентов в uncontrolled режиме. В данных момент тоже не все компоненты поддерживают.
3. Для поддержки нативной валидации потребуется немного переверстать некоторые компоненты.

### Итоговые вопросы

1. Являются ли Toggle, Switcher, Select, ComboBox, TokenInput, DateInput, DatePicker полноценными элементами форм?
2. Насколько вообще сценарии с FormData API, uncontrolled-режимом и нативной валидацией нужны? Будут ли они использоваться? Стоит ли за них заморачиваться?
2. Перевешивают ли плюсы предлагаемого решения его минусы?

Иными словами, каким путем следует пойти и насколько далеко?

*P.S.:* в этом ПРе реализованы только проброс пропов и работа с FormData API. Поддержка нативной валидации и uncontrolled-режима могут быть добавлены позже.