### PR TITLE
fix(Sticky): avoid margins collapsing

### DIFF
--- a/packages/retail-ui/.creevey/images/ZIndex/Sticky and Loader/Sticky covers sibling Loader/chrome/Sticky covers sibling Loader.png
+++ b/packages/retail-ui/.creevey/images/ZIndex/Sticky and Loader/Sticky covers sibling Loader/chrome/Sticky covers sibling Loader.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:493f69650f436e908cfb6dbd9ae2f4b8722dbf2e15cb12d2149fa4d62b3192a1
-size 49579
+oid sha256:e9005ce4ffc8fb28963ea43f5a0f115722bd2eb3503c149842f5d8a721006a0a
+size 49575

--- a/packages/retail-ui/.creevey/images/ZIndex/Sticky and Tooltips/Sticky covers outside Popup and DropdownContainer/chrome/Sticky covers outside Popup and DropdownContainer.png
+++ b/packages/retail-ui/.creevey/images/ZIndex/Sticky and Tooltips/Sticky covers outside Popup and DropdownContainer/chrome/Sticky covers outside Popup and DropdownContainer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9a3c639b5dfd658d58ea95ff8cd80c9467a4f3a82d80a830ff03c2d286ebf0e
-size 13809
+oid sha256:967316fb7fcea7bc335aa5758e9a00aed11d8de73ce1bde767c37216ca5ed79f
+size 13805

--- a/packages/retail-ui/components/Sticky/Sticky.module.less
+++ b/packages/retail-ui/components/Sticky/Sticky.module.less
@@ -1,6 +1,11 @@
 :local {
+  .wrapper {
+    display: flex;
+  }
+
   .inner {
     display: flex;
+    width: 100%;
 
     &.fixed {
       position: fixed;

--- a/packages/retail-ui/components/Sticky/Sticky.tsx
+++ b/packages/retail-ui/components/Sticky/Sticky.tsx
@@ -121,7 +121,7 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
     }
 
     return (
-      <div ref={this.refWrapper}>
+      <div ref={this.refWrapper} className={cx(styles.wrapper)}>
         <ZIndex
           priority="Sticky"
           applyZIndex={fixed}
@@ -177,7 +177,7 @@ export default class Sticky extends React.Component<StickyProps, StickyState> {
 
         if (side === 'top') {
           stopped = stopRect.top - outerHeight < 0;
-          relativeTop = stopRect.top - height - top;
+          relativeTop = stopRect.top - prevHeight - top;
         } else {
           stopped = stopRect.bottom + outerHeight > windowHeight;
           relativeTop = stopRect.bottom - top;


### PR DESCRIPTION
В Sticky размеры элемента до и после залипания могут отличаться. Но процесс залипания/отлипания должен происходить без скачков. Поэтому внутри предусмотрен механизм компенсации разницы через margin. Но у margin есть особенность, это возможность их [схлопывания](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) или передачи эффекта на родительские элементы. Это приводило к проблемам из 2291, когда margin ошибочно двигал не только нужный элемент, но и свой родительский контейнер вместе с со stop-элементом.

Проще всего починить через `display: flex` у контейнера, т.к. он в том числе отключает схлопывание.

Выпущена тестовая версия `0.0.0-a8072451c2` на основе 1.11.7 и [codesandbox](https://codesandbox.io/s/adoring-wood-7oiux) с ней. 

Незначительно изменилась пара скриншотов в хроме. 

fix #2291