### PR TITLE
fix(TokenInput): don't call onBlur until focus is really lost

### DIFF
--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -435,10 +435,7 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       this.dispatch({ type: 'SET_PREVENT_BLUR', payload: false });
     } else {
       this.dispatch({ type: 'BLUR' });
-    }
-
-    if (this.props.onBlur) {
-      this.props.onBlur(event);
+      this.props.onBlur?.(event);
     }
   };
 


### PR DESCRIPTION
Вдогонку к #2279. Происходят лишние вызовы `onBlur`, в том числе когда фокус в реальности остается в ТокенИнпуте. Это может преждевременно запускать валидацию и также влиять на другие пользовательские сценарии.