### PR TITLE
fix(react-ui): fix className forwarding

### DIFF
--- a/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/chrome.png
+++ b/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b6462d9c9260469b24ed765d2116cf55497fa5325ec91fd82ce15e39bd82b4c
+size 6851

--- a/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/chrome.png
+++ b/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b6462d9c9260469b24ed765d2116cf55497fa5325ec91fd82ce15e39bd82b4c
-size 6851
+oid sha256:ffbc891ec3552855908e698f41ebe4cd5c655985afbc1abd77928978cc9ed7de
+size 5875

--- a/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/firefox.png
+++ b/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c5f5005503731dcfaffdeea972450f282cb6375039d1620a6bdc184e777233c
+size 2705

--- a/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/firefox.png
+++ b/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c5f5005503731dcfaffdeea972450f282cb6375039d1620a6bdc184e777233c
-size 2705
+oid sha256:33e983c50f84bdf7c03ab1fb652470212c15cb3b36a72bd4c743e28c797d017c
+size 2428

--- a/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/ie11.png
+++ b/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34805b2b73c16d25e3fbafb343a0af09b3aaf0f0540626fb1162e0b61be9e199
+size 3840

--- a/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/ie11.png
+++ b/packages/react-ui/.creevey/images/Toast/complex notification/toastShown/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34805b2b73c16d25e3fbafb343a0af09b3aaf0f0540626fb1162e0b61be9e199
-size 3840
+oid sha256:8327189b2c7874e3d29945fd0d82a26ce208830f1207c5d3562bb278c975b1ab
+size 3112

--- a/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/chrome.png
+++ b/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1aafc136371af3f6056fe53342015d87a4baa0b08e9a448a0874e7462c91cb5
-size 5710
+oid sha256:876311c63c775f42a4dad9a04f167d27b55ce7f723a5b89f71bf65da38d96fa8
+size 4814

--- a/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/chrome.png
+++ b/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1aafc136371af3f6056fe53342015d87a4baa0b08e9a448a0874e7462c91cb5
+size 5710

--- a/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/firefox.png
+++ b/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e992e99edce2041a866d0784c6af8f586bbe33e6277a9a6cff3d56cc60861f1c
+size 2279

--- a/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/firefox.png
+++ b/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/firefox.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e992e99edce2041a866d0784c6af8f586bbe33e6277a9a6cff3d56cc60861f1c
-size 2279
+oid sha256:2e80df65dbdc53dc03dd40f29d59c2a0243a5d044d17c19647e0bb0191840178
+size 2011

--- a/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/ie11.png
+++ b/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/ie11.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ddb8f1b9ac3a89b5d7f03311546ceaa129dbd0847d505d542e2367e6e680d47
-size 3357
+oid sha256:346fcb2d23483d65b95016cb972c4c592c13f81ddf6f3228da08ff0ed0d3da38
+size 2632

--- a/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/ie11.png
+++ b/packages/react-ui/.creevey/images/Toast/simple notification/toastShown/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ddb8f1b9ac3a89b5d7f03311546ceaa129dbd0847d505d542e2367e6e680d47
+size 3357

--- a/packages/react-ui/.creevey/images/Toast/static method/toastShown/chrome.png
+++ b/packages/react-ui/.creevey/images/Toast/static method/toastShown/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2be5c64389aced28018c15b21de7169e26727db2ee389d418fc1ad4f481c4e93
+size 4363

--- a/packages/react-ui/.creevey/images/Toast/static method/toastShown/firefox.png
+++ b/packages/react-ui/.creevey/images/Toast/static method/toastShown/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2c5acea1e6e68760feb80b627f7b1879623d7732e281001bbc8ee386888bcf1
+size 1964

--- a/packages/react-ui/.creevey/images/Toast/static method/toastShown/ie11.png
+++ b/packages/react-ui/.creevey/images/Toast/static method/toastShown/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9279800ecd416911ef6bf2e7f33b53c52f73509d3c20757e764eabdc99e93b4f
+size 2555

--- a/packages/react-ui/.creevey/images/ToastView/simple toast/chrome.png
+++ b/packages/react-ui/.creevey/images/ToastView/simple toast/chrome.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65e4135bc9d5ff7d702ab58a0471965ecfb434aeca087fe8a809710f7d917b02
-size 2000

--- a/packages/react-ui/.creevey/images/ToastView/simple toast/firefox.png
+++ b/packages/react-ui/.creevey/images/ToastView/simple toast/firefox.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f992f2b547bc6b18f976fd6d19b7b25360a6367c94c3095569c82ec46f93b80
-size 638

--- a/packages/react-ui/.creevey/images/ToastView/simple toast/ie11.png
+++ b/packages/react-ui/.creevey/images/ToastView/simple toast/ie11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62cd44140ce8a0b73cfd652a516c86569b93e2a2061cbfe21aa2c811a9b5a050
-size 785

--- a/packages/react-ui/.creevey/images/ToastView/with action/chrome.png
+++ b/packages/react-ui/.creevey/images/ToastView/with action/chrome.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa6ed2151030fb1c2af99fadc4b6fd069c77fc5f92b493e884581acd61007529
-size 2970

--- a/packages/react-ui/.creevey/images/ToastView/with action/firefox.png
+++ b/packages/react-ui/.creevey/images/ToastView/with action/firefox.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c189f55eb3197d716f0520554f04335c7c2e63bbc690ee1e69574b5246cfc3a
-size 1035

--- a/packages/react-ui/.creevey/images/ToastView/with action/ie11.png
+++ b/packages/react-ui/.creevey/images/ToastView/with action/ie11.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a1526de7c4be1464b37f92d3074936354fc30b87c8bad134e770530c69474bf
-size 1205

--- a/packages/react-ui/.creevey/images/ZIndex/Modal And Toast/toastShown/chrome.png
+++ b/packages/react-ui/.creevey/images/ZIndex/Modal And Toast/toastShown/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5aed24f2e2f28a3d47bd46c1207e8d40786af52f74ae8a0b7bf1516a72bb1eab
+size 9892

--- a/packages/react-ui/.creevey/images/ZIndex/Modal And Toast/toastShown/firefox.png
+++ b/packages/react-ui/.creevey/images/ZIndex/Modal And Toast/toastShown/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eac0d072d413605293cfb2c937942f95578292c1f1d8b67ee2b2fc191ea12c89
+size 8888

--- a/packages/react-ui/.creevey/images/ZIndex/Modal And Toast/toastShown/ie11.png
+++ b/packages/react-ui/.creevey/images/ZIndex/Modal And Toast/toastShown/ie11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4812a4c3d4b6df1935d3b2c82de2955070491cd6ce715bc994183f89968537d9
+size 8858

--- a/packages/react-ui/components/Center/Center.tsx
+++ b/packages/react-ui/components/Center/Center.tsx
@@ -43,12 +43,12 @@ export class Center extends React.Component<CenterProps> {
     return (
       <CommonWrapper {...this.props}>
         <div
+          {...rest}
           className={cn({
             [jsStyles.root()]: true,
             [jsStyles.rootAlignLeft()]: align === 'left',
             [jsStyles.rootAlignRight()]: align === 'right',
           })}
-          {...rest}
         >
           <span className={jsStyles.spring()} />
           <span className={jsStyles.container()}>{children}</span>

--- a/packages/react-ui/components/Center/Center.tsx
+++ b/packages/react-ui/components/Center/Center.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 
 import { Override } from '../../typings/utility-types';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { jsStyles } from './Center.styles';
 
@@ -38,22 +38,23 @@ export class Center extends React.Component<CenterProps> {
   };
 
   public render() {
-    const { align, children, ...rest } = this.props;
+    return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
+  }
+  private renderMain = (props: CommonWrapperRestProps<CenterProps>) => {
+    const { align, ...rest } = props;
 
     return (
-      <CommonWrapper {...this.props}>
-        <div
-          {...rest}
-          className={cn({
-            [jsStyles.root()]: true,
-            [jsStyles.rootAlignLeft()]: align === 'left',
-            [jsStyles.rootAlignRight()]: align === 'right',
-          })}
-        >
-          <span className={jsStyles.spring()} />
-          <span className={jsStyles.container()}>{children}</span>
-        </div>
-      </CommonWrapper>
+      <div
+        {...rest}
+        className={cn({
+          [jsStyles.root()]: true,
+          [jsStyles.rootAlignLeft()]: align === 'left',
+          [jsStyles.rootAlignRight()]: align === 'right',
+        })}
+      >
+        <span className={jsStyles.spring()} />
+        <span className={jsStyles.container()}>{this.props.children}</span>
+      </div>
     );
-  }
+  };
 }

--- a/packages/react-ui/components/Toast/Toast.tsx
+++ b/packages/react-ui/components/Toast/Toast.tsx
@@ -4,6 +4,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { RenderContainer } from '../../internal/RenderContainer';
 import { Nullable } from '../../typings/utility-types';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { isTestEnv } from '../../lib/currentEnvironment';
 
 import { jsStyles } from './Toast.styles';
 import { ToastView, ToastViewProps } from './ToastView';
@@ -123,6 +124,8 @@ export class Toast extends React.Component<ToastProps, ToastState> {
           enter: 200,
           exit: 150,
         }}
+        enter={!isTestEnv}
+        exit={!isTestEnv}
       >
         <CommonWrapper {...this.props}>
           <ToastView ref={this._refToast} {...toastProps} />

--- a/packages/react-ui/components/Toast/ToastView.tsx
+++ b/packages/react-ui/components/Toast/ToastView.tsx
@@ -5,7 +5,7 @@ import { CrossIcon } from '../../internal/icons/CrossIcon';
 import { ZIndex } from '../../internal/ZIndex';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { jsStyles } from './ToastView.styles';
 
@@ -49,14 +49,14 @@ export class ToastView extends React.Component<ToastViewProps> {
       <ThemeContext.Consumer>
         {theme => {
           this.theme = theme;
-          return this.renderMain();
+          return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  private renderMain() {
-    const { children, action, onClose, ...rest } = this.props;
+  private renderMain = (props: CommonWrapperRestProps<ToastViewProps>) => {
+    const { action, onClose, ...rest } = props;
 
     const link = action ? (
       <span className={jsStyles.link(this.theme)} onClick={action.handler}>
@@ -73,15 +73,13 @@ export class ToastView extends React.Component<ToastViewProps> {
     ) : null;
 
     return (
-      <CommonWrapper {...this.props}>
-        <ZIndex priority="Toast" className={jsStyles.wrapper()}>
-          <div data-tid="ToastView__root" className={jsStyles.root(this.theme)} {...rest}>
-            <span>{children}</span>
-            {link}
-            {close}
-          </div>
-        </ZIndex>
-      </CommonWrapper>
+      <ZIndex priority="Toast" className={jsStyles.wrapper()}>
+        <div data-tid="ToastView__root" {...rest} className={jsStyles.root(this.theme)}>
+          <span>{this.props.children}</span>
+          {link}
+          {close}
+        </div>
+      </ZIndex>
     );
-  }
+  };
 }

--- a/packages/react-ui/components/Toast/__stories__/Toast.stories.tsx
+++ b/packages/react-ui/components/Toast/__stories__/Toast.stories.tsx
@@ -4,67 +4,30 @@ import { CreeveyStoryParams } from 'creevey';
 import { StoryFn } from '@storybook/addons';
 
 import { Toast } from '../Toast';
-import { Button } from '../../Button';
-import { Modal } from '../../Modal';
-import { Nullable } from '../../../typings/utility-types';
 
-class TestNotifier extends React.Component<any, any> {
-  public state = {
-    modal: false,
-  };
-
-  private notifier: Nullable<Toast>;
-
-  public render() {
-    return (
-      <div>
-        <Toast ref={el => (this.notifier = el)} onClose={action('close')} onPush={action('push')} />
-        <button data-tid="show-toast" onClick={this.showNotification}>
-          Show Toast
-        </button>
-        <button onClick={() => this.setState({ modal: true })}>Show Modal</button>
-        {this.state.modal && this.renderModal()}
-      </div>
-    );
-  }
-
-  private showNotification = () => {
-    if (this.props.complex) {
-      this.showComplexNotification();
-    } else {
-      this.showSimpleNotification();
+const TestNotifier = ({ complex }: { complex?: boolean }) => {
+  const toastRef = React.useRef<Toast>(null);
+  const showNotification = () => {
+    const { current: toast } = toastRef;
+    if (toast) {
+      complex
+        ? toast.push('Successfully saved', {
+            label: 'Cancel',
+            handler: action('cancel_save'),
+          })
+        : toast.push('Successfully saved');
     }
   };
 
-  private showSimpleNotification() {
-    if (this.notifier) {
-      this.notifier.push('Successfully saved');
-    }
-  }
-
-  private showComplexNotification() {
-    if (this.notifier) {
-      this.notifier.push('Successfully saved', {
-        label: 'Cancel',
-        handler: action('cancel_save'),
-      });
-    }
-  }
-
-  private renderModal() {
-    return (
-      <Modal>
-        <Modal.Header>Modalka</Modal.Header>
-        <Modal.Body>
-          <Button onClick={this.showNotification}>Show notification</Button>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={() => this.setState({ modal: false })}>Close Modal</Button>
-        </Modal.Footer>
-      </Modal>
-    );
-  }
-}
+  return (
+    <div>
+      <Toast ref={toastRef} onClose={action('close')} onPush={action('push')} />
+      <button data-tid="show-toast" onClick={showNotification}>
+        Show Toast
+      </button>
+    </div>
+  );
+};
 
 export default {
   title: 'Toast',

--- a/packages/react-ui/components/Toast/__stories__/ToastView.stories.tsx
+++ b/packages/react-ui/components/Toast/__stories__/ToastView.stories.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 
 import { ToastView as Toast } from '../ToastView';
 
-export default { title: 'ToastView', parameters: { creevey: { captureElement: "[data-tid='ToastView__root']" } } };
+export default { title: 'ToastView', parameters: { creevey: { skip: [true] } } };
 
 export const SimpleToast = () => <Toast>Changes saved</Toast>;
 SimpleToast.story = { name: 'simple toast' };

--- a/packages/react-ui/components/TopBar/TopBarDropdown.tsx
+++ b/packages/react-ui/components/TopBar/TopBarDropdown.tsx
@@ -5,7 +5,7 @@ import { Nullable } from '../../typings/utility-types';
 import { IconProps } from '../../internal/icons/20px';
 import { DropdownMenu, DropdownMenuProps } from '../DropdownMenu';
 import { PopupMenuCaptionProps } from '../../internal/PopupMenu';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { TopBarButtonItem } from './TopBarButtonItem';
 
@@ -34,14 +34,16 @@ export class TopBarDropdown extends React.Component<TopBarDropdownProps> {
   private dropdownMenu: Nullable<DropdownMenu> = null;
 
   public render() {
-    return (
-      <CommonWrapper {...this.props}>
-        <DropdownMenu {...this.props} ref={this.refDropdownMenu} caption={this.renderButton}>
-          {this.props.children}
-        </DropdownMenu>
-      </CommonWrapper>
-    );
+    return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
   }
+
+  private renderMain = (props: CommonWrapperRestProps<TopBarDropdownProps>) => {
+    return (
+      <DropdownMenu {...props} ref={this.refDropdownMenu} caption={this.renderButton}>
+        {this.props.children}
+      </DropdownMenu>
+    );
+  };
 
   public open = (): void => {
     if (this.dropdownMenu) {

--- a/packages/react-ui/components/TopBar/TopBarItem.tsx
+++ b/packages/react-ui/components/TopBar/TopBarItem.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 import { Icon, IconProps } from '../../internal/icons/20px';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { jsStyles } from './TopBar.styles';
 
@@ -38,7 +38,11 @@ export class TopBarItem extends React.Component<TopBarItemProps> {
   };
 
   public render() {
-    const { active, children, _onClick, _onKeyDown, iconOnly, icon, minWidth, use, ...rest } = this.props;
+    return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
+  }
+
+  private renderMain = (props: CommonWrapperRestProps<TopBarItemProps>) => {
+    const { active, _onClick, _onKeyDown, iconOnly, icon, minWidth, use, ...rest } = props;
 
     const classes = cn({
       [jsStyles.item()]: true,
@@ -54,12 +58,10 @@ export class TopBarItem extends React.Component<TopBarItemProps> {
     const iconNode = typeof icon === 'string' ? <Icon name={icon} /> : icon;
 
     return (
-      <CommonWrapper {...this.props}>
-        <div {...rest} className={classes} onClick={_onClick} onKeyDown={_onKeyDown} style={{ minWidth }}>
-          {icon && <span className={iconClasses}>{iconNode}</span>}
-          {icon && iconOnly ? null : children}
-        </div>
-      </CommonWrapper>
+      <div {...rest} className={classes} onClick={_onClick} onKeyDown={_onKeyDown} style={{ minWidth }}>
+        {icon && <span className={iconClasses}>{iconNode}</span>}
+        {icon && iconOnly ? null : this.props.children}
+      </div>
     );
-  }
+  };
 }

--- a/packages/react-ui/components/TopBar/TopBarLogout.tsx
+++ b/packages/react-ui/components/TopBar/TopBarLogout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { locale } from '../../lib/locale/decorators';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { TopBarButtonItem, TopBarButtonItemProps } from './TopBarButtonItem';
 import { TopBarLocale, TopBarLocaleHelper } from './locale';
@@ -20,10 +20,10 @@ export class TopBarLogout extends React.Component<TopBarLogoutProps> {
   private readonly locale!: TopBarLocale;
 
   public render() {
-    return (
-      <CommonWrapper {...this.props}>
-        <TopBarButtonItem {...this.props}>{this.props.children || this.locale.logout}</TopBarButtonItem>
-      </CommonWrapper>
-    );
+    return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
   }
+
+  private renderMain = (props: CommonWrapperRestProps<TopBarLogoutProps>) => {
+    return <TopBarButtonItem {...props}>{this.props.children || this.locale.logout}</TopBarButtonItem>;
+  };
 }

--- a/packages/react-ui/components/TopBar/TopBarOrganizations.tsx
+++ b/packages/react-ui/components/TopBar/TopBarOrganizations.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Nullable } from '../../typings/utility-types';
 import { ArrowChevronDownIcon } from '../../internal/icons/16px';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { TopBarDropdown } from './TopBarDropdown';
 import { jsStyles } from './TopBar.styles';
@@ -44,7 +44,11 @@ export class TopBarOrganizations extends React.Component<TopBarOrganizationsProp
   }
 
   public render() {
-    const { caption, comment } = this.props;
+    return <CommonWrapper {...this.props}>{this.renderMain}</CommonWrapper>;
+  }
+
+  private renderMain = (props: CommonWrapperRestProps<TopBarOrganizationsProps>) => {
+    const { caption, comment, ...rest } = props;
 
     const title = (
       <div>
@@ -72,13 +76,11 @@ export class TopBarOrganizations extends React.Component<TopBarOrganizationsProp
     );
 
     return (
-      <CommonWrapper {...this.props}>
-        <TopBarDropdown {...this.props} label={title} minWidth={this.state.minWidth}>
-          {this.props.children}
-        </TopBarDropdown>
-      </CommonWrapper>
+      <TopBarDropdown {...rest} label={title} minWidth={this.state.minWidth}>
+        {this.props.children}
+      </TopBarDropdown>
     );
-  }
+  };
 
   private _getCaptionRef = (element: HTMLSpanElement) => {
     this._caption = element;

--- a/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
+++ b/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
@@ -938,3 +938,40 @@ export const ModalSidePageStack = () => {
   );
 };
 ModalSidePageStack.story = { name: 'Modal and SidePage Stack', parameters: { creevey: { skip: [true] } } };
+
+export const ModalAndToast: CSFStory<JSX.Element> = () => {
+  const toast = React.useRef<Toast>(null);
+  const showNotification = () => {
+    if (toast.current) {
+      toast.current.push('Toast');
+    }
+  };
+
+  return (
+    <div>
+      <Toast ref={toast} />
+      <Modal>
+        <Modal.Header>Modal</Modal.Header>
+        <Modal.Body>
+          <Button onClick={showNotification}>Show Toast</Button>
+        </Modal.Body>
+      </Modal>
+    </div>
+  );
+};
+ModalAndToast.story = {
+  parameters: {
+    creevey: {
+      tests: {
+        async toastShown() {
+          await this.browser
+            .actions({ bridge: true })
+            .click(this.browser.findElement({ css: '[data-comp-name~="Button"] button' }))
+            .perform();
+
+          await this.expect(await this.browser.takeScreenshot()).to.matchImage();
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Были найдены некоторые проблемы после #2257: 
- Toast 
- Center 
- TopBarDropdown
- TopBarItem 
- TopBarLogout 
- TopBarOrganizations

А именно, в Toast и Center были допущены банальные ошибки, которые позволяли классам, переданным из вне, перезаписывать внутренние. 

А в остальных компонентах при передачи классов из вне, они могли дублироваться на обертке из-за неправильного использования `CommonWrapper` и `CommonWrapperRestProps`. Повод задуматься об удачности получившегося решения. Возможно его стоит упростить и сделать более прозрачным.

В случае Toast мы допустили регресс из-за не совсем полноценного теста, когда скриншотилась только внутрянка, а не Toast целиком. Доработал этот момент. Остальное же пока не очень понятно как можно тестировать. 

fix #2312