### PR TITLE
fix(Checkbox): fix indeterminate state in IE11/Edge

### DIFF
--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/chrome/clicked.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/chrome/clicked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c7d995f34d5ededf732ce9f572da0be29c18339ce211ebffc1203e6421461da
+size 1007

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/chromeFlat/clicked.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/chromeFlat/clicked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:192ab2ae19887ceef7e64e8656e7142afd0698f1e3a0941c9888cb6eb1bda6ab
+size 986

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/firefox/clicked.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/firefox/clicked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a67192693352dac8e86c8190da49161f8f8ef488a9323111d8d6bdbc99001a1
+size 624

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/firefoxFlat/clicked.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/firefoxFlat/clicked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccb3336b9fe6f4dcd48c7d4f2689d3bbd7a9e5f655d8a0e5416da5309e2238cd
+size 586

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/ie11/clicked.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/ie11/clicked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd0624e59c43f9fa803b57dfb5e356a6ab818e694b46d70e42cf2d63a0f79ecd
+size 657

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/ie11Flat/clicked.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/clicked/ie11Flat/clicked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d7c025deb1b1e3480b7b2a9cf0b1d3cfbdface14f89ebff2bf0f89ffcb7c6fb
+size 604

--- a/packages/react-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/react-ui/components/Checkbox/Checkbox.tsx
@@ -165,6 +165,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
       onChange: this.handleChange,
       onFocus: this.handleFocus,
       onBlur: this.handleBlur,
+      onClick: this.handleClick,
       ref: this.inputRef,
     };
 
@@ -225,5 +226,27 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
     this.resetIndeterminate();
 
     this.props.onChange?.(event);
+  };
+
+  private handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    // support IE11's and old Edge's special behavior
+    // https://github.com/jquery/jquery/issues/1698
+    if (this.state.indeterminate && (isIE11 || isEdge)) {
+      this.resetIndeterminate();
+      // simulate correct behavior only if onValueChange is used
+      // because we cant simulate real native onChange event
+      if (this.props.onValueChange && this.input) {
+        const checked = !this.input.checked;
+
+        if (this.props.checked === undefined) {
+          // in case of uncontrolled mode
+          this.input.checked = checked;
+        }
+
+        this.props.onValueChange(checked);
+      }
+    }
+
+    this.props.onClick?.(e);
   };
 }

--- a/packages/react-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/react-ui/components/Checkbox/Checkbox.tsx
@@ -229,6 +229,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
   };
 
   private handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    this.props.onClick?.(e);
     // support IE11's and old Edge's special behavior
     // https://github.com/jquery/jquery/issues/1698
     if (this.state.indeterminate && (isIE11 || isEdge)) {
@@ -246,7 +247,5 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
         this.props.onValueChange(checked);
       }
     }
-
-    this.props.onClick?.(e);
   };
 }

--- a/packages/react-ui/components/Checkbox/__stories__/Checkbox.stories.tsx
+++ b/packages/react-ui/components/Checkbox/__stories__/Checkbox.stories.tsx
@@ -274,6 +274,16 @@ Indeterminate.story = {
             .perform();
           await this.expect(await element.takeScreenshot()).to.matchImage('tabPress');
         },
+        async clicked() {
+          const element = await this.browser.findElement({ css: '#screenshot-capture' });
+          await this.browser
+            .actions({
+              bridge: true,
+            })
+            .click(this.browser.findElement({ css: 'label' }))
+            .perform();
+          await this.expect(await element.takeScreenshot()).to.matchImage('clicked');
+        },
       },
     },
   },


### PR DESCRIPTION
В IE11 и старом Egde есть особенность поведения при выходе из состояния indeterminate, при котором текущее состояние checked не меняется, в отличии от остальных браузеров. 
jquery/jquery#1698

Это приводило в тому, что иконка при первом клике по indeterminate не менялась, т.к. при этом не происходит события onChange.

Починить иконку не проблема, но остается разное поведение в разных браузерах. Это ломает тесты пользователей. Но эмулировать onChange как решение кажется не очень, ведь у нас нет полноценного объекта события (а его могут использовать). Поэтому предлагаю ограничить фикс в рамках нашего кастомного события `onValueChange`.

#2316