### PR TITLE
fix(Autocomplete): use prop `active` from `RenderLayer` [master]

### DIFF
--- a/packages/react-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.tsx
@@ -64,6 +64,7 @@ export interface AutocompleteProps
 export interface AutocompleteState {
   items: Nullable<string[]>;
   selected: number;
+  focused: boolean;
 }
 
 /**
@@ -110,6 +111,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
   public state: AutocompleteState = {
     items: null,
     selected: -1,
+    focused: false,
   };
 
   private theme!: Theme;
@@ -118,7 +120,6 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
   private menu: Nullable<Menu>;
   private rootSpan: Nullable<HTMLSpanElement>;
 
-  private focused = false;
   private requestId = 0;
 
   private getProps = createPropsGetter(Autocomplete.defaultProps);
@@ -156,6 +157,8 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
     );
   }
   public renderMain = (props: CommonWrapperRestProps<AutocompleteProps>) => {
+    const { focused } = this.state;
+
     const {
       onValueChange,
       onKeyDown,
@@ -182,7 +185,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
     };
 
     return (
-      <RenderLayer onFocusOutside={this.handleBlur} onClickOutside={this.handleClickOutside}>
+      <RenderLayer onFocusOutside={this.handleBlur} onClickOutside={this.handleClickOutside} active={focused}>
         <span style={{ display: 'inline-block', width }} ref={this.refRootSpan}>
           <Input {...inputProps} />
           {this.renderMenu()}
@@ -239,24 +242,24 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
   };
 
   private handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (this.focused) {
+    if (this.state.focused) {
       return;
     }
 
-    this.focused = true;
+    this.setState({ focused: true });
+
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
   };
 
   private handleBlur = () => {
-    if (!this.focused) {
+    if (!this.state.focused) {
       return;
     }
 
-    this.focused = false;
     this.opened = false;
-    this.setState({ items: null });
+    this.setState({ items: null, focused: false });
 
     if (this.input) {
       this.input.blur();

--- a/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
+++ b/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
@@ -5,6 +5,12 @@ import OkIcon from '@skbkontur/react-icons/Ok';
 import { Autocomplete, AutocompleteProps } from '../Autocomplete';
 import { delay } from '../../../lib/utils';
 
+function clickOutside() {
+  const event = document.createEvent('HTMLEvents');
+  event.initEvent('mousedown', true, true);
+
+  document.body.dispatchEvent(event);
+}
 describe('<Autocomplete />', () => {
   it('renders with given value', () => {
     const onValueChange = jest.fn();
@@ -153,6 +159,18 @@ describe('<Autocomplete />', () => {
     });
     await delay(500);
     expect(wrapper.state('items')).toEqual(['1']);
+  });
+
+  it(`don't call handleBlur() method when where is no focus`, () => {
+    const handleBlur = jest.fn();
+    const props = { value: '', source: [], onValueChange: () => '' };
+    const wrapper = mount<Autocomplete>(<Autocomplete {...props} />);
+    // @ts-ignore
+    wrapper.instance().handleBlur = handleBlur;
+
+    clickOutside();
+
+    expect(handleBlur).not.toBeCalled();
   });
 });
 


### PR DESCRIPTION
Cherry-picked from #2268

Fix #2267