### PR TITLE
fix(seleniumtesting): fix selector for select menu items

### DIFF
--- a/packages/react-ui-testing/SeleniumTesting/Controls/Paging.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Paging.cs
@@ -13,7 +13,7 @@ namespace SKBKontur.SeleniumTesting.Controls
     public class Paging : ControlList<Label>
     {
         public Paging(ISearchContainer container, ISelector selector)
-            : base(container, selector, new BySelector(By.CssSelector("[data-comp-name='component']")))
+            : base(container, selector, new BySelector(By.CssSelector("[data-comp-name~='component']")))
         {
         }
 

--- a/packages/react-ui-testing/SeleniumTesting/Controls/RadioGroup.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/RadioGroup.cs
@@ -35,7 +35,7 @@ namespace SKBKontur.SeleniumTesting.Controls
                 {
                     var items = GetReactProp<JsonArray>("items");
                     var index = items.ToList().FindIndex(x => ElementMatchToValue(id, x));
-                    element.FindElements(By.CssSelector($"[data-comp-name='{"Radio"}']")).ElementAt(index).Click();
+                    element.FindElements(By.CssSelector($"[data-comp-name~='{"Radio"}']")).ElementAt(index).Click();
                 }, $"SelectItemById({id})");
         }
 

--- a/packages/react-ui-testing/SeleniumTesting/Controls/Select.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Select.cs
@@ -116,9 +116,9 @@ namespace SKBKontur.SeleniumTesting.Controls
                 {
                     x.Click();
                     var renderContainer = GetRenderContainer();
-                    renderContainer.FindElements(By.CssSelector($"[data-comp-name='{"MenuItem"}']"))
+                    renderContainer.FindElements(By.CssSelector("[data-comp-name~='MenuItem']"))
                                    .Skip(index)
-                                   .FirstOrDefault()
+                                   .First()
                                    .Click();
                 },
                           $"SelectItemByIndex({index})");


### PR DESCRIPTION
Версии:
- @skbkontur/react-props2attrs: 0.1.2
- @skbkontur/react-ui: 2.15.0
- react: 16.8.6

`react-props2attrs` закидывает в `data-comp-name`  в Item у Select `"MenuItem CommonWrapper"`, а обвязка ожидает только `'MenuItem"`

+ Заменил `FirstOrDefault` на `First`. Раньше, если хотя бы один item не нашли, то возвращался `null` и по этому `null` делался `.Click()` - получалась ошибка `NullReferenceException`, которая в стектрейсе ничего понятного не содержала. `First` развалится сразу, как только не найдет хотя бы один item - думаю получше будет