### PR TITLE
[CurrencyInput] Прокручивать поле для денежных сумм, когда сумма не помещается по ширине

### DIFF
--- a/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/chrome/Input moves left with cursor.png
+++ b/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/chrome/Input moves left with cursor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ec65f87f24bd06b4b379819ba7858f724fe3395523cdf473b5836d5925e4a3a
+size 1073

--- a/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/chrome8px/Input moves left with cursor.png
+++ b/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/chrome8px/Input moves left with cursor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46ec69ac8be1fcfe2a8e4d2ffbd3f4080e653a65323ded7a36d7cf28521d8ee8
+size 1115

--- a/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/firefox/Input moves left with cursor.png
+++ b/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/firefox/Input moves left with cursor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddfad4832473237bc395b0cff01bb28591696454f40f6f47766e39513157f885
+size 418

--- a/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/firefox8px/Input moves left with cursor.png
+++ b/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/firefox8px/Input moves left with cursor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b6d07ecb79ea65a14e404fc0479274b6cb0ed786d6a2fe5fba70f6300354af5
+size 436

--- a/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/ie11/Input moves left with cursor.png
+++ b/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/ie11/Input moves left with cursor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e76a9e505a0781159a3c597cfaba1c904d3620b49a70933aef46f3d824049b28
+size 502

--- a/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/ie118px/Input moves left with cursor.png
+++ b/packages/react-ui/.creevey/images/CurrencyInput/Input moves with cursor/MoveLeft/ie118px/Input moves left with cursor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dda8b9a670dd45bc9f2116e5a1d938748f5cd8b9ca6a3b8f74e89c5f90fa6a26
+size 532

--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -185,6 +185,10 @@ export class CurrencyInput extends React.Component<CurrencyInputProps, CurrencyI
     this.setState({ selection: normilized });
   };
 
+  private isCursorMoves = (action: unknown) => {
+    return action === CURRENCY_INPUT_ACTIONS.MoveCursorLeft || action === CURRENCY_INPUT_ACTIONS.MoveCursorRight;
+  };
+
   private handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const selection = this.getSelection(event.target);
     this.tempSelectionForOnChange = selection;
@@ -202,7 +206,7 @@ export class CurrencyInput extends React.Component<CurrencyInputProps, CurrencyI
       return;
     }
 
-    if (action !== CURRENCY_INPUT_ACTIONS.Unknown) {
+    if (action !== CURRENCY_INPUT_ACTIONS.Unknown && !this.isCursorMoves(action)) {
       event.preventDefault();
     }
 

--- a/packages/react-ui/components/CurrencyInput/__stories__/CurrencyInput.stories.tsx
+++ b/packages/react-ui/components/CurrencyInput/__stories__/CurrencyInput.stories.tsx
@@ -258,3 +258,61 @@ export const ManualMount = () => {
   return <ManualMounting />;
 };
 ManualMount.story = { name: 'Manual mount', parameters: { creevey: { skip: [true] } } };
+
+export const InputMovesWithCursor: CSFStory<JSX.Element> = () => <Sample width={60} />;
+InputMovesWithCursor.story = {
+  name: 'Input moves with cursor',
+  parameters: {
+    creevey: {
+      tests: {
+        async MoveLeft() {
+          await this.browser
+            .actions({
+              bridge: true,
+            })
+            .click(this.browser.findElement({ css: '[data-comp-name*="CurrencyInput"] input' }))
+            .perform();
+          await this.browser
+            .actions({
+              bridge: true,
+            })
+            .sendKeys('1')
+            .pause(500)
+            .sendKeys('2')
+            .pause(500)
+            .sendKeys('3')
+            .pause(500)
+            .sendKeys('4')
+            .pause(500)
+            .sendKeys('5')
+            .pause(500)
+            .sendKeys('6')
+            .pause(500)
+            .sendKeys('7')
+            .pause(500)
+            .sendKeys('8')
+            .pause(500)
+            .sendKeys('9')
+            .pause(500)
+            .sendKeys('0')
+            .perform();
+          await this.browser
+            .actions({
+              bridge: true,
+            })
+            .sendKeys(this.keys.ARROW_LEFT)
+            .pause(500)
+            .sendKeys(this.keys.ARROW_LEFT)
+            .pause(500)
+            .sendKeys(this.keys.ARROW_LEFT)
+            .pause(500)
+            .sendKeys(this.keys.ARROW_LEFT)
+            .pause(500)
+            .sendKeys(this.keys.ARROW_LEFT)
+            .perform();
+          await this.expect(await this.takeScreenshot()).to.matchImage('Input moves left with cursor');
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Fix для https://github.com/skbkontur/retail-ui/issues/2188

**Проблема**

При использовании стрелок `selectionRange` в инпуте сетится, но область видимости (те числа, что мы видим) не перемещается

**Попытки решения**

- Проверка нажатий стрелок во избежание `event.preventDefault()`

В таком случае область видимости перемещается за курсором при нажатии стрелок, но иногда позиция не совсем правильная. 

_Кнопки `End`, `Home` через такое решение все равно не работают._ Каретка перемещается, а область видимости нет