### PR TITLE
[WIP] Пропадающая валидация поля с маской

### DIFF
--- a/packages/react-ui-validations/stories/Input.stories.tsx
+++ b/packages/react-ui-validations/stories/Input.stories.tsx
@@ -399,6 +399,49 @@ class Example7 extends React.Component<{}, Example7State> {
   private refContainer = (el: ValidationContainer | null) => (this.container = el);
 }
 
+interface Example9State {
+  value: string;
+}
+
+class Example9 extends React.Component<{}, Example9State> {
+  public state: Example9State = {
+    value: '',
+  };
+
+  private container: ValidationContainer | null = null;
+  private refContainer = (el: ValidationContainer | null) => (this.container = el);
+
+  public validateValue(): Nullable<ValidationInfo> {
+    const { value } = this.state;
+    if (value === '') {
+      return { message: 'Должно быть не пусто', type: 'submit' };
+    }
+    if (!/^\+7\s\d{3}\s\d{3}-\d{2}-\d{2}$/.test(value)) {
+      return { message: 'Неверный телефон', type: 'lostfocus' };
+    }
+    return null;
+  }
+
+  public render() {
+    return (
+      <ValidationContainer ref={this.refContainer}>
+        <div style={{ padding: 10 }}>
+          <ValidationWrapper validationInfo={this.validateValue()} renderMessage={text('bottom')}>
+            <Input
+              mask={'+7 999 999-99-99'}
+              value={this.state.value}
+              onValueChange={value => this.setState({ value })}
+            />
+          </ValidationWrapper>
+          <div style={{ padding: '30px 0' }}>
+            <Button onClick={() => this.container && this.container.validate()}>Check</Button>
+          </div>
+        </div>
+      </ValidationContainer>
+    );
+  }
+}
+
 storiesOf('Input', module)
   .add('#1', () => {
     return <Example1 />;
@@ -423,4 +466,7 @@ storiesOf('Input', module)
   })
   .add('#8 Промотка с фиксированной плашкой снизу', () => {
     return <Example8 />;
+  })
+  .add('#9 Валидация с маской', () => {
+    return <Example9 />;
   });


### PR DESCRIPTION
fixes #1739 

### Проблема:

- `ReactInputMask` сетит `value` на фокус, вызывая `handleChange`
- Это `value` не пустое, если в маске есть какое-то значение помимо маркеров маски. Т.е. если маска '999-999', то `value` будет `''`, а если '+7 999-999', то `+7 `
- Либа валидации считает, что значение инпута поменялось (а оно и вправду поменялось), поэтому убирает статус ошибки (обводку)

**Никакие из вариантов, что я пробовал не помогали решить проблему и без падения тестов**

- то слетает на фокусе правильное положение каретки
- то 'value' сэтится не тогда, когда ожидается
- то 'value' не сетится вообще, хотя вроде должно

**Просто no way таск**

**Возможное решение проблемы**:

- Может кто-нибудь придумает хак как сделать это с `ReactInputMask`, но я что только не пробовал, все упирается в безотказное установление  `value` на `focus`, попытки управлять через  `beforeMaskedValueChange` к успеху тоже не приводят, потому что там надо вернуть `InputState`, что потом вызывает... да, `handleChange`
- Обновление версии `ReactInputMask`, может быть с новой функциональностью эту проблему решить получится, не успел посмотреть что добавляли и правили в версиях выше
- Отказ от `ReactInputMask` и написание велосипеда с нуля
- Отказ от `ReactInputMask` и написание велосипеда, подсмотрев как маска реализована в других компонентах (а она походу везде по разному сделана)

_**Или может я слишком зарылся в этот таск и есть какое-то решение на поверхности?..**_
