### PR TITLE
Замена старого шрифта на Lab Grotesque

### DIFF
--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -3,6 +3,7 @@
     font-family: 'Lab Grotesque';
     font-weight: 400;
     src: local('Lab Grotesque'), local('LabGrotesque'),
+      url('https://s.kontur.ru/common/fonts/LabGrotesque/LabGrotesque-Regular.woff2') format('woff2'),
       url('https://s.kontur.ru/common/fonts/LabGrotesque/LabGrotesque-Regular.woff') format('woff');
   }
 

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -1,9 +1,9 @@
 <style>
   @font-face {
-    font-family: 'Segoe UI';
+    font-family: 'Lab Grotesque';
     font-weight: 400;
-    src: local('Segoe UI'), local('SegoeUI'),
-    url('//c.s-microsoft.com/static/fonts/segoe-ui/cyrillic/normal/latest.woff') format('woff');
+    src: local('Lab Grotesque'), local('LabGrotesque'),
+      url('https://s.kontur.ru/common/fonts/LabGrotesque/LabGrotesque-Regular.woff') format('woff');
   }
 
   html,
@@ -12,7 +12,7 @@
   }
 
   body {
-    font-family: 'Segoe UI', 'Helvetica Neue', Roboto, Arial, sans-serif;
+    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
     font-size: 14px;
     margin: 0;
     background: white;

--- a/packages/react-ui/.styleguide/config/base.config.js
+++ b/packages/react-ui/.styleguide/config/base.config.js
@@ -12,15 +12,14 @@ const { publishVersion } = require('../helpers');
 const styles = {
   StyleGuide: {
     '@global body': {
-      fontFamily: '"Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+      fontFamily: '"Lab Grotesque", Roboto, "Helvetica Neue", Arial, sans-serif',
       fontSize: 14,
     },
     '@font-face': {
-      fontFamily: 'Segoe UI',
+      fontFamily: 'Lab Grotesque',
       fontWeight: 400,
-      src: `local('Segoe UI'), local('SegoeUI'),
-            url('//c.s-microsoft.com/static/fonts/segoe-ui/cyrillic/normal/latest.woff')
-              format('woff')`,
+      src: `local('Lab Grotesque'), local('LabGrotesque'),
+      url('https://s.kontur.ru/common/fonts/LabGrotesque/LabGrotesque-Regular.woff') format('woff');`,
     },
     content: {
       padding: '30px 40px',

--- a/packages/react-ui/components/Button/Button.mixins.ts
+++ b/packages/react-ui/components/Button/Button.mixins.ts
@@ -1,30 +1,4 @@
 import { css } from '../../lib/theming/Emotion';
-import { shift } from '../../lib/styles/DimensionFunctions';
-
-const getBtnPadding = (
-  fontSize: string,
-  paddingY: string,
-  paddingX: string,
-  fontFamilyCompensation: string,
-  additionalOffset = 0,
-): string => {
-  let paddingTop = paddingY;
-  let paddingBottom = paddingY;
-  const offset = parseInt(fontFamilyCompensation) || 0;
-
-  const shiftUp = (top: string, bottom: string, offset: number) => {
-    return [shift(top, `${-offset}`), shift(bottom, `${offset}`)];
-  };
-
-  if (fontSize === '16px' && offset) {
-    [paddingTop, paddingBottom] = shiftUp(paddingTop, paddingBottom, offset);
-  }
-  if (additionalOffset) {
-    [paddingTop, paddingBottom] = shiftUp(paddingTop, paddingBottom, additionalOffset);
-  }
-
-  return `${paddingTop} ${paddingX} ${paddingBottom}`;
-};
 
 export const buttonUseMixin = (
   btnBackground: string,
@@ -112,9 +86,7 @@ export const buttonSizeMixin = (
   lineHeight: string,
   paddingX: string,
   paddingY: string,
-  fontFamilyCompensation: string,
   selectorLink: string,
-  selectorFallback: string,
 ) => {
   return css`
     font-size: ${fontSize} !important;
@@ -122,12 +94,8 @@ export const buttonSizeMixin = (
     &:not(${selectorLink}) {
       box-sizing: border-box;
       height: ${height};
-      padding: ${getBtnPadding(fontSize, paddingY, paddingX, fontFamilyCompensation)};
+      padding: ${paddingY} ${paddingX};
       line-height: ${lineHeight};
-
-      &${selectorFallback} {
-        padding: ${getBtnPadding(fontSize, paddingY, paddingX, fontFamilyCompensation, 1)};
-      }
     }
   `;
 };

--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -592,7 +592,7 @@ const styles = {
       white-space: nowrap;
       display: inline-block;
       width: 100%;
-      vertical-align: top;
+      vertical-align: middle;
     `;
   },
 

--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -82,9 +82,7 @@ const styles = {
         t.btnLineHeightSmall,
         t.btnPaddingXSmall,
         t.btnPaddingYSmall,
-        t.fontFamilyCompensationBaseline,
         cssName(styles.link(t)),
-        cssName(styles.fallback(t)),
       )};
     `;
   },
@@ -99,9 +97,7 @@ const styles = {
         t.btnLineHeightMedium,
         t.btnPaddingXMedium,
         t.btnPaddingYMedium,
-        t.fontFamilyCompensationBaseline,
         cssName(styles.link(t)),
-        cssName(styles.fallback(t)),
       )};
     `;
   },
@@ -116,9 +112,7 @@ const styles = {
         t.btnLineHeightLarge,
         t.btnPaddingXLarge,
         t.btnPaddingYLarge,
-        t.fontFamilyCompensationBaseline,
         cssName(styles.link(t)),
-        cssName(styles.fallback(t)),
       )};
     `;
   },
@@ -211,17 +205,6 @@ const styles = {
         ${cssName(styles.caption())} {
           transform: none !important;
         }
-      }
-    `;
-  },
-
-  fallback(t: Theme) {
-    return css`
-      &${cssName(styles.disabled(t))} {
-        outline-color: transparent;
-      }
-      &:not(${cssName(styles.link(t))}) {
-        line-height: normal !important;
       }
     `;
   },

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import cn from 'classnames';
 
-import { isIE11, isEdge } from '../../lib/client';
 import { tabListener } from '../../lib/events/tabListener';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -183,7 +182,6 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
         [jsStyles.focus(this.theme)]: isFocused,
         [jsStyles.checked(this.theme)]: !!this.props.checked,
         [jsStyles.disabled(this.theme)]: !!this.props.disabled || !!this.props.loading,
-        [jsStyles.fallback(this.theme)]: isIE11 || isEdge,
       }),
       style: {
         borderTopLeftRadius: corners & Corners.TOP_LEFT ? 0 : undefined,

--- a/packages/react-ui/components/Hint/Hint.styles.ts
+++ b/packages/react-ui/components/Hint/Hint.styles.ts
@@ -7,7 +7,7 @@ const styles = {
       box-sizing: border-box;
       color: ${t.hintColor};
       font-size: ${t.hintFontSize};
-      line-height: ${t.hintLineHeight}
+      line-height: ${t.hintLineHeight};
       max-width: ${t.hintMaxWidth};
       overflow-wrap: break-word;
       padding: ${t.hintPaddingY} ${t.hintPaddingX};

--- a/packages/react-ui/components/Toast/ToastView.styles.ts
+++ b/packages/react-ui/components/Toast/ToastView.styles.ts
@@ -1,16 +1,8 @@
 import { css, memoizeStyle } from '../../lib/theming/Emotion';
 import { Theme } from '../../lib/theming/Theme';
 
-const getVerticalPaddingsWithCompensation = (theme: Theme) => {
-  const { toastPaddingY, fontFamilyCompensationBaseline } = theme;
-  const paddingY = parseInt(toastPaddingY);
-  const compensation = parseInt(fontFamilyCompensationBaseline);
-  return [`${paddingY - compensation}px`, `${paddingY + compensation}px`];
-};
-
 const styles = {
   root(t: Theme) {
-    const [paddingTop, paddingBottom] = getVerticalPaddingsWithCompensation(t);
     return css`
       background: ${t.toastBg};
       border-radius: ${t.toastBorderRadius};
@@ -20,7 +12,7 @@ const styles = {
       font-size: ${t.toastFontSize};
       line-height: ${t.toastLineHeight};
       opacity: 1;
-      padding: ${paddingTop} ${t.toastPaddingX} ${paddingBottom};
+      padding: ${t.toastPaddingY} ${t.toastPaddingX};
       position: relative;
       top: ${t.toastTop};
     `;
@@ -38,15 +30,13 @@ const styles = {
   },
 
   closeWrapper(t: Theme) {
-    const [paddingTop, paddingBottom] = getVerticalPaddingsWithCompensation(t);
     return css`
       display: flex;
-      margin: -${paddingTop} -${t.toastPaddingX} -${paddingBottom} -${t.toastClosePadding};
+      margin: -${t.toastPaddingY} -${t.toastPaddingX} -${t.toastPaddingY} -${t.toastClosePadding};
     `;
   },
 
   link(t: Theme) {
-    const [paddingTop, paddingBottom] = getVerticalPaddingsWithCompensation(t);
     const marginRight = `${Math.round(parseInt(t.toastPaddingX) * 1.5)}px`;
     return css`
       color: ${t.toastLinkColor};
@@ -54,9 +44,9 @@ const styles = {
       display: inline-block;
       font-weight: 600;
 
-      margin: -${paddingTop} ${marginRight} -${paddingBottom} ${t.toastPaddingX};
+      margin: -${t.toastPaddingY} ${marginRight} -${t.toastPaddingY} ${t.toastPaddingX};
 
-      padding: ${paddingTop} 0 ${paddingBottom};
+      padding: ${t.toastPaddingY} 0 ${t.toastPaddingY};
 
       &:hover {
         text-decoration: underline;

--- a/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
+++ b/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
@@ -394,7 +394,7 @@ class TooltipAndSelect extends React.Component<{}> {
         style={{
           width: 250,
           fontSize: 14,
-          fontFamily: 'Segoe UI',
+          fontFamily: 'Lab Grotesque',
         }}
       >
         Задача организации, в особенности же рамки и место обучения кадров влечет за собой процесс внедрения и

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -3,7 +3,6 @@ import { exposeGetters, markAsFullTheme } from '../../lib/theming/ThemeHelpers';
 
 export class DefaultTheme {
   //#region Common variables
-  public static fontFamilyCompensationBaseline = '1';
   public static brandXLight = '#cae5f5';
   public static brandLight = '#3094d0';
   public static brand = '#1e79be';


### PR DESCRIPTION
### Примеры скриншотов после добавления шрифта и удаления компенсации в кнопках
| Компонент  | Было / Стало |
| ------------- | ------------- |
| Autocomplete  | <img width="125" alt="Снимок экрана 2021-04-29 в 12 24 29" src="https://user-images.githubusercontent.com/31249664/116519681-35e65300-a8eb-11eb-8638-e43ea6774759.png"> |
| Autocomplete | <img width="170" alt="Снимок экрана 2021-04-29 в 12 37 25" src="https://user-images.githubusercontent.com/31249664/116519728-44346f00-a8eb-11eb-9de4-a3fdf30d8d7c.png"> |
| Button (Chrome 8px) | <img width="114" alt="Снимок экрана 2021-04-29 в 13 10 12" src="https://user-images.githubusercontent.com/31249664/116520592-5c58be00-a8ec-11eb-959c-2857c71f2d7c.png"> |
| Button (Firefox 8px) | <img width="99" alt="Снимок экрана 2021-04-29 в 13 11 42" src="https://user-images.githubusercontent.com/31249664/116520676-772b3280-a8ec-11eb-9512-e188d9221c7d.png"> |
| Button (IE11 8px) | <img width="101" alt="Снимок экрана 2021-04-29 в 13 15 14" src="https://user-images.githubusercontent.com/31249664/116521099-fae51f00-a8ec-11eb-9f4f-c72ba39e2993.png"> |
| Button use link (Chrome 8px) | <img width="88" alt="Снимок экрана 2021-04-29 в 13 21 13" src="https://user-images.githubusercontent.com/31249664/116521788-da699480-a8ed-11eb-955a-5869475bb46c.png"> |
| Button use link (IE11 8px) | <img width="82" alt="Снимок экрана 2021-04-29 в 13 22 55" src="https://user-images.githubusercontent.com/31249664/116521971-10a71400-a8ee-11eb-972b-29a50e70b015.png"> |
| Button use link with icon (IE11, Chrome, Firefox 8px) | <img width="109" alt="Снимок экрана 2021-04-29 в 13 25 23" src="https://user-images.githubusercontent.com/31249664/116522318-80b59a00-a8ee-11eb-87df-b4767d96e43a.png"> |
| Checkbox (all) | <img width="151" alt="Снимок экрана 2021-04-29 в 13 32 45" src="https://user-images.githubusercontent.com/31249664/116523411-a2635100-a8ef-11eb-9dad-6a2c98ccca81.png"> |
| Checkbox (clicked) | <img width="445" alt="Снимок экрана 2021-04-29 в 13 33 55" src="https://user-images.githubusercontent.com/31249664/116523476-b60eb780-a8ef-11eb-9d4c-7b94d6145fdc.png"> |
### Резюме

- В кнопках после добавления `vertical-align: middle` текст стал располагаться как надо и без компенсации
- Но при этом гротеск приподнимает текст во всех компонентах на `1px` и приводит к тому, что не везде это выглядит хорошо
- Необходимо понять почему: это кривой шрифт или же позиционирование в компонентах  ( ̶ ̶̶̶я̶̶̶ ̶̶̶д̶у̶м̶а̶ю̶,̶̶̶ ̶̶̶ч̶̶̶т̶̶̶о̶̶̶ ̶̶̶п̶̶̶е̶̶̶р̶̶̶в̶̶̶ы̶̶̶й̶̶̶ ̶̶̶в̶̶̶а̶̶̶р̶̶̶и̶̶̶а̶̶̶н̶̶̶т̶̶̶)