### PR TITLE
fix(Modal, SidePage, HBVS): performance

### DIFF
--- a/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
+++ b/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 
 import { getScrollWidth } from '../../lib/dom/getScrollWidth';
 import { isFirefox } from '../../lib/client';
+import { css } from '../../lib/theming/Emotion';
 
 export class HideBodyVerticalScroll extends React.Component {
   public static __KONTUR_REACT_UI__ = 'HideBodyVerticalScroll';
 
-  public static hash = Math.random()
-    .toString(16)
-    .slice(2, 6);
   private disposeDocumentStyle: (() => void) | null = null;
   private initialScroll = 0;
   private master = false;
@@ -59,17 +57,15 @@ export class HideBodyVerticalScroll extends React.Component {
     const documentComputedStyle = getComputedStyle(document);
     const scrollWidth = getScrollWidth();
     const documentMargin = parseFloat(documentComputedStyle.marginRight || '');
-    const documentStyle = generateDocumentStyle(documentMargin + scrollWidth);
+    const className = generateDocumentStyle(documentMargin + scrollWidth);
 
-    this.disposeDocumentStyle = this.attachStyle(document, documentStyle);
+    this.disposeDocumentStyle = this.attachStyle(document, className);
   };
 
-  private attachStyle = (element: HTMLElement, style: { css: string; className: string }) => {
-    element.classList.add(style.className);
-    const removeStyleNode = attachStylesheet(style.css);
+  private attachStyle = (element: HTMLElement, className: string) => {
+    element.classList.add(className);
     return () => {
-      removeStyleNode();
-      element.classList.remove(style.className);
+      element.classList.remove(className);
     };
   };
 
@@ -78,12 +74,18 @@ export class HideBodyVerticalScroll extends React.Component {
       this.disposeDocumentStyle();
       this.disposeDocumentStyle = null;
 
+      const { documentElement } = document;
+
       if (isFirefox) {
         // Forcing reflow for Firefix
-        attachStylesheet('html, body { height: auto; }')();
+        this.attachStyle(
+          documentElement,
+          css`
+            height: auto;
+          `,
+        )();
       }
 
-      const { documentElement } = document;
       if (documentElement) {
         documentElement.scrollTop = this.initialScroll;
       }
@@ -107,39 +109,10 @@ class VerticalScrollCounter {
   };
 }
 
-function generateClassName(className: string) {
-  const { name, hash } = HideBodyVerticalScroll;
-  return `${name}-${className}-${hash}`;
-}
-
 function generateDocumentStyle(documentMargin: number) {
-  const className = generateClassName('document');
-  const css = `\
-.${className} {
-  overflow: hidden !important;
-  margin-right: ${documentMargin}px !important;
-  height: 100%;
-}
-`;
-  return { className, css };
-}
-
-function attachStylesheet(sheet: string) {
-  const style = document.createElement('style');
-  style.setAttribute('type', 'text/css');
-  // @ts-ignore IE specific api
-  if (style.styleSheet) {
-    // @ts-ignore IE specific api
-    style.styleSheet.cssText = sheet;
-  } else {
-    const textnode = document.createTextNode(sheet);
-    style.appendChild(textnode);
-  }
-  const head = document.getElementsByTagName('head')[0];
-  head.appendChild(style);
-  return () => {
-    if (head.contains(style)) {
-      head.removeChild(style);
-    }
-  };
+  return css`
+    overflow: hidden !important;
+    margin-right: ${documentMargin}px !important;
+    height: 100%;
+  `;
 }

--- a/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
+++ b/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { getScrollWidth } from '../../lib/dom/getScrollWidth';
-import { isFirefox } from '../../lib/client';
 import { css } from '../../lib/theming/Emotion';
 
 export class HideBodyVerticalScroll extends React.Component {
@@ -75,16 +74,6 @@ export class HideBodyVerticalScroll extends React.Component {
       this.disposeDocumentStyle = null;
 
       const { documentElement } = document;
-
-      if (isFirefox) {
-        // Forcing reflow for Firefix
-        this.attachStyle(
-          documentElement,
-          css`
-            height: auto;
-          `,
-        )();
-      }
 
       if (documentElement) {
         documentElement.scrollTop = this.initialScroll;


### PR DESCRIPTION
Улучшение производительности в Modal и SidePage.

#### Суть проблемы

Есть компонент `HideBodyVerticalScroll`. Он служит для скрытия скроллбара всей страницы на время открытия Modal или SidePage. Для этого он раньше при каждом рендере проверял, есть ли у первоначальной страницы (т.е. у страницы в состоянии до открытия модалки) скролл. Если есть, то он добавлял стили для его скрытия. Таким же образом, он сразу реагировал на пропажу скролла у первоначальной страницы,  удаляя свои добавленные стили. Однако, чтобы определить наличие скролла у первоначальной страницы, необходимо сперва удалить все добавленные стили, влияющие на него, а затем снова добавить, если требуется. Это приводило к постоянному добавлению/удалению стилей на `<html />`, что и сказывалось на производительности. Но зато, так обеспечивалось отсутствие дерганья контента при открытии/закрытии модалок в результате появления/пропажи скролла у всей страницы.

#### Решение

Решить проблему удается, если ограничить манипуляции со стилями только двумя событиями: 
1. добавление стилей в момент первого скрытия скролла 
2. удаление добавленных стилей в конце при закрытии


Но, в этом случае придется немного пожертвовать тем самым отсутствием дергания при закрытии. А именно, если до открытия модалки на странице был скролл, а во время, пока модалка была открыта - он пропал, то после закрытия модалки контент расширится на ширину скроллбара. Раньше он расширился бы сразу, в момент пропажи скрола. 

Думаю, это не очень большая цена. Ведь главное все-таки это скрыть скроллбар.

Для тестов использовал такой пример на витрине. Увидеть тормоза легко, если в IE встать в инипут и зажать любую клавишу (букву любую, например).
```jsx
import { Button, Toggle, Input } from '@skbkontur/react-ui';

const [opened, setOpened] = React.useState(false);
const [text, setText] = React.useState('');
const [content, setContent] = React.useState([]);

function renderModal() {
  return (
    <Modal onClose={close}>
      <Modal.Header>Title</Modal.Header>
      <Modal.Body>
        <p>Use rxjs operators with react hooks</p>
        <Input value={text} onValueChange={setText} />
        <Button onClick={() => setContent([...content, ...content, 'hey'])}>Add Content</Button>
        <Button onClick={() => setContent([...content.slice(0, content.length / 2)])}>Remove Content</Button>
      </Modal.Body>
      <Modal.Footer panel={panel}>
        <Button onClick={close}>Close</Button>
      </Modal.Footer>
    </Modal>
  );
}

function open() {
  setOpened(true);
}

function close() {
  setOpened(false);
}

<div>
  {opened && renderModal()}
  <Button onClick={open}>Open</Button>
  {content.map(text => (
    <p>{text}</p>
  ))}
</div>;
```



fix #1870
fix #2274

Плюс, перевел механизм вставки стилей на страницу на Emotion.


---

Выкатил `@skbkontur/react-ui@0.0.0-599274d651` на основе 2.17.1 (lts) с этой правкой и отдал на тест в продукт.
`@skbkontur/react-ui@0.0.0-34314258fc` на основе 3.2.0.