### PR TITLE
refactor(react-selenium-testing): using webdriver interface

### DIFF
--- a/packages/react-ui-testing/SeleniumTesting/Browser.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Browser.cs
@@ -6,7 +6,6 @@ using Kontur.Selone.Extensions;
 using Microsoft.Win32;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
-using OpenQA.Selenium.Remote;
 using SKBKontur.SeleniumTesting.Internals.Commons;
 
 namespace SKBKontur.SeleniumTesting
@@ -61,7 +60,7 @@ namespace SKBKontur.SeleniumTesting
             return PageBase.InitializePage<T>(WebDriver);
         }
 
-        private RemoteWebDriver WebDriver
+        private IWebDriver WebDriver
         {
             get
             {
@@ -127,7 +126,7 @@ namespace SKBKontur.SeleniumTesting
         }
 
         private const string RegistryKey = @"Software\Google\Update\Clients\{8A69D345-D564-463c-AFF1-A69D9E530F96}";
-        private RemoteWebDriver webDriver;
+        private IWebDriver webDriver;
         private readonly string defaultPort;
         private readonly string defaultDomain;
     }

--- a/packages/react-ui-testing/SeleniumTesting/PageBase.cs
+++ b/packages/react-ui-testing/SeleniumTesting/PageBase.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
-
 using SKBKontur.SeleniumTesting.Internals;
 
 namespace SKBKontur.SeleniumTesting
 {
     public class PageBase : ISearchContainer, IRetailUiVersionProvider
     {
-        public PageBase(RemoteWebDriver webDriver)
+        public PageBase(IWebDriver webDriver)
         {
             this.webDriver = webDriver;
             ExecuteInitAction();
@@ -39,8 +38,9 @@ namespace SKBKontur.SeleniumTesting
                 throw new ArgumentException("script");
             try
             {
-                webDriver.ExecuteScript("window.callArgs = arguments", arguments);
-                return webDriver.ExecuteScript(script, arguments);
+                var javaScriptExecutor = (IJavaScriptExecutor) webDriver;
+                javaScriptExecutor.ExecuteScript("window.callArgs = arguments", arguments);
+                return javaScriptExecutor.ExecuteScript(script, arguments);
             }
             catch(StaleElementReferenceException)
             {
@@ -79,7 +79,7 @@ namespace SKBKontur.SeleniumTesting
             return new Actions(webDriver);
         }
 
-        public RemoteWebDriver DangerousGetWebDriverInstance()
+        public IWebDriver DangerousGetWebDriverInstance()
         {
             return webDriver;
         }
@@ -89,7 +89,7 @@ namespace SKBKontur.SeleniumTesting
             return InitializePage<TPage>(webDriver);
         }
 
-        public static TPage InitializePage<TPage>(RemoteWebDriver webDriver) where TPage : PageBase
+        public static TPage InitializePage<TPage>(IWebDriver webDriver) where TPage : PageBase
         {
             TPage page = (TPage)Activator.CreateInstance(typeof(TPage), webDriver);
             page.WaitLoaded();
@@ -101,6 +101,6 @@ namespace SKBKontur.SeleniumTesting
             return ExecuteScript("return window.__RETAIL_UI_VERSION__ || ''") as string;
         }
 
-        protected internal RemoteWebDriver webDriver;
+        protected internal IWebDriver webDriver;
     }
 }

--- a/packages/react-ui-testing/Tests/AutocompleteTests/AutocompleteTestPage.cs
+++ b/packages/react-ui-testing/Tests/AutocompleteTests/AutocompleteTestPage.cs
@@ -1,5 +1,4 @@
-using OpenQA.Selenium.Remote;
-
+using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.AutocompleteTests
     [AutoFillControls]
     public class AutocompleteTestPage : PageBase
     {
-        public AutocompleteTestPage(RemoteWebDriver webDriver)
+        public AutocompleteTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ButtonTests/ButtonTestPage.cs
+++ b/packages/react-ui-testing/Tests/ButtonTests/ButtonTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ButtonTests
     [AutoFillControls]
     public class ButtonTestPage : PageBase
     {
-        public ButtonTestPage(RemoteWebDriver webDriver)
+        public ButtonTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/CheckBoxTests/CheckBoxTestPage.cs
+++ b/packages/react-ui-testing/Tests/CheckBoxTests/CheckBoxTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.CheckBoxTests
     [AutoFillControls]
     public class CheckBoxTestPage : PageBase
     {
-        public CheckBoxTestPage(RemoteWebDriver webDriver)
+        public CheckBoxTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ComboBoxTests/ComboBoxesTestPage.cs
+++ b/packages/react-ui-testing/Tests/ComboBoxTests/ComboBoxesTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ComboBoxTests
     [AutoFillControls]
     public class ComboBoxesTestPage : PageBase
     {
-        public ComboBoxesTestPage(RemoteWebDriver webDriver)
+        public ComboBoxesTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/DatePickerTests/DatePickerTestPage.cs
+++ b/packages/react-ui-testing/Tests/DatePickerTests/DatePickerTestPage.cs
@@ -1,4 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
+﻿using OpenQA.Selenium;
 
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
@@ -8,7 +8,7 @@ namespace SKBKontur.SeleniumTesting.Tests.DatePickerTests
     [AutoFillControls]
     public class DatePickerTestPage : PageBase
     {
-        public DatePickerTestPage(RemoteWebDriver webDriver)
+        public DatePickerTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ExposeTidToDomTests/ExposeTidToDomTestPage.cs
+++ b/packages/react-ui-testing/Tests/ExposeTidToDomTests/ExposeTidToDomTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ExposeTidToDomTests
     [AutoFillControls]
     public class ExposeTidToDomTestPage : PageBase
     {
-        public ExposeTidToDomTestPage(RemoteWebDriver webDriver)
+        public ExposeTidToDomTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/InputTests/InputTestPage.cs
+++ b/packages/react-ui-testing/Tests/InputTests/InputTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.InputTests
     [AutoFillControls]
     public class InputTestPage : PageBase
     {
-        public InputTestPage(RemoteWebDriver webDriver)
+        public InputTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/KebabTests/KebabTestPage.cs
+++ b/packages/react-ui-testing/Tests/KebabTests/KebabTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.KebabTests
     [AutoFillControls]
     public class KebabTestPage : PageBase
     {
-        public KebabTestPage(RemoteWebDriver webDriver)
+        public KebabTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/LinkTests/LinkTestPage.cs
+++ b/packages/react-ui-testing/Tests/LinkTests/LinkTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.LinkTests
     [AutoFillControls]
     public class LinkTestPage : PageBase
     {
-        public LinkTestPage(RemoteWebDriver webDriver)
+        public LinkTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ListTests/ListsTestPage.cs
+++ b/packages/react-ui-testing/Tests/ListTests/ListsTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ListTests
     [AutoFillControls]
     public class ListsTestPage : PageBase
     {
-        public ListsTestPage(RemoteWebDriver webDriver)
+        public ListsTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ModalTests/ModalsTestPage.cs
+++ b/packages/react-ui-testing/Tests/ModalTests/ModalsTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
 namespace SKBKontur.SeleniumTesting.Tests.ModalTests
@@ -7,7 +6,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ModalTests
     [AutoFillControls]
     public class ModalsTestPage : PageBase
     {
-        public ModalsTestPage(RemoteWebDriver webDriver)
+        public ModalsTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/PageActionAttributesTests/PageActionAttributes/Base1PageBase.cs
+++ b/packages/react-ui-testing/Tests/PageActionAttributesTests/PageActionAttributes/Base1PageBase.cs
@@ -1,11 +1,11 @@
-using OpenQA.Selenium.Remote;
+using OpenQA.Selenium;
 
 namespace SKBKontur.SeleniumTesting.Tests.PageActionAttributesTests.PageActionAttributes
 {
     [TestPageAction("Base1PageBase")]
     public class Base1PageBase : Base2PageBase, IPageInterface1
     {
-        public Base1PageBase(RemoteWebDriver webDriver)
+        public Base1PageBase(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/PageActionAttributesTests/PageActionAttributes/Base2PageBase.cs
+++ b/packages/react-ui-testing/Tests/PageActionAttributesTests/PageActionAttributes/Base2PageBase.cs
@@ -1,11 +1,11 @@
-using OpenQA.Selenium.Remote;
+using OpenQA.Selenium;
 
 namespace SKBKontur.SeleniumTesting.Tests.PageActionAttributesTests.PageActionAttributes
 {
     [TestPageAction("Base2PageBase")]
     public class Base2PageBase : PageBase, IPageInterface2
     {
-        public Base2PageBase(RemoteWebDriver webDriver)
+        public Base2PageBase(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/PageActionAttributesTests/PageActionAttributes/PageActionAttributeTestPage.cs
+++ b/packages/react-ui-testing/Tests/PageActionAttributesTests/PageActionAttributes/PageActionAttributeTestPage.cs
@@ -1,11 +1,11 @@
-﻿using OpenQA.Selenium.Remote;
+﻿using OpenQA.Selenium;
 
 namespace SKBKontur.SeleniumTesting.Tests.PageActionAttributesTests.PageActionAttributes
 {
     [TestPageAction("Root")]
     public class PageActionAttributeTestPage : Base1PageBase, IPageInterface
     {
-        public PageActionAttributeTestPage(RemoteWebDriver webDriver)
+        public PageActionAttributeTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/PagingTests/PagingTestPage.cs
+++ b/packages/react-ui-testing/Tests/PagingTests/PagingTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.PagingTests
     [AutoFillControls]
     public class PagingTestPage : PageBase
     {
-        public PagingTestPage(RemoteWebDriver webDriver)
+        public PagingTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/RadioGroupTests/RadioGroupTestPage.cs
+++ b/packages/react-ui-testing/Tests/RadioGroupTests/RadioGroupTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.RadioGroupTests
     [AutoFillControls]
     public class RadioGroupTestPage : PageBase
     {
-        public RadioGroupTestPage(RemoteWebDriver webDriver)
+        public RadioGroupTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/RadioTests/RadioTestPage.cs
+++ b/packages/react-ui-testing/Tests/RadioTests/RadioTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.RadioTests
     [AutoFillControls]
     public class RadioTestPage : PageBase
     {
-        public RadioTestPage(RemoteWebDriver webDriver)
+        public RadioTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/SelectTests/SelectTest.cs
+++ b/packages/react-ui-testing/Tests/SelectTests/SelectTest.cs
@@ -1,7 +1,5 @@
 ﻿using NUnit.Framework;
-
-using OpenQA.Selenium.Remote;
-
+using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 using SKBKontur.SeleniumTesting.Tests.TestEnvironment;
@@ -55,7 +53,7 @@ namespace SKBKontur.SeleniumTesting.Tests.SelectTests
     [AutoFillControls]
     public class SelectTestPage : PageBase
     {
-        public SelectTestPage(RemoteWebDriver webDriver)
+        public SelectTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/SidePages/SidePageTestPage.cs
+++ b/packages/react-ui-testing/Tests/SidePages/SidePageTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.SidePages
     [AutoFillControls]
     public class SidePageTestPage: PageBase
     {
-        public SidePageTestPage(RemoteWebDriver webDriver)
+        public SidePageTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Drawing;
-using System.Linq;
-using System.IO;
 using Kontur.Selone.Extensions;
 using NUnit.Framework;
 using OpenQA.Selenium;
@@ -62,7 +60,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
             return WebDriver.Screenshoter().GetScreenshot();
         }
 
-        private RemoteWebDriver WebDriver
+        private IWebDriver WebDriver
         {
             get
             {
@@ -91,7 +89,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
             return $"http://{defaultDomain}:{defaultPort}/{relativeUrl}/";
         }
 
-        private RemoteWebDriver webDriver;
+        private IWebDriver webDriver;
         private readonly string defaultDomain;
         private readonly string defaultPort;
         private readonly string tunnelIdentifier;

--- a/packages/react-ui-testing/Tests/TestEnvironment/BrowserSetUp.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/BrowserSetUp.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Net;
 
 namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment

--- a/packages/react-ui-testing/Tests/TestEnvironmentFixture.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironmentFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Threading;

--- a/packages/react-ui-testing/Tests/TextAreaTests/TextAreaTestPage.cs
+++ b/packages/react-ui-testing/Tests/TextAreaTests/TextAreaTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TextAreaTests
     [AutoFillControls]
     public class TextAreaTestPage : PageBase
     {
-        public TextAreaTestPage(RemoteWebDriver webDriver)
+        public TextAreaTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ToastTests/ToastTestPage.cs
+++ b/packages/react-ui-testing/Tests/ToastTests/ToastTestPage.cs
@@ -1,4 +1,4 @@
-using OpenQA.Selenium.Remote;
+using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -7,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ToastTests
     [AutoFillControls]
     public class ToastTestPage : PageBase
     {
-        public ToastTestPage(RemoteWebDriver webDriver)
+        public ToastTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/ToggleTests/ToggleTestPage.cs
+++ b/packages/react-ui-testing/Tests/ToggleTests/ToggleTestPage.cs
@@ -1,4 +1,4 @@
-using OpenQA.Selenium.Remote;
+using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -7,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ToggleTests
     [AutoFillControls]
     public class ToggleTestPage : PageBase
     {
-        public ToggleTestPage(RemoteWebDriver webDriver)
+        public ToggleTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }

--- a/packages/react-ui-testing/Tests/TooltipTests/TooltipTestPage.cs
+++ b/packages/react-ui-testing/Tests/TooltipTests/TooltipTestPage.cs
@@ -1,5 +1,4 @@
-﻿using OpenQA.Selenium.Remote;
-
+﻿using OpenQA.Selenium;
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -8,7 +7,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TooltipTests
     [AutoFillControls]
     public class TooltipTestPage : PageBase
     {
-        public TooltipTestPage(RemoteWebDriver webDriver)
+        public TooltipTestPage(IWebDriver webDriver)
             : base(webDriver)
         {
         }


### PR DESCRIPTION
Привет!

Текущая реализация PageBase в конструкторе принимает RemoteWebDriver вместо IWebDriver. Это приводит к нескольким проблемам:

1. Если тестирующая система не использует SeleniumGrid, то в ней не нужно использовать RemoteWebDriver. Но сейчас PageBase привязан к конкретной реализации IWebDriver и требует именно его. Поэтому приходится писать примерно такой код для инициализации драйвера:

```C#
RemoteWebDriver webDriver = new ChromeDriver();
```
Или если в тестирующей системе с драйвером работают как с IWebDriver, но для страницы требуется передать RemoteWebDriver, то делают каст:

```C#
TestPage((RemoteWebDriver) webDriver) : base(webDriver)
{}
```

Сами разработчики Selenium в своих гайдах пишут, что в коде нужно использовать IWebDriver, вместо какой-то конкретной реализации.

2. В Selenium 4.0 (начиная с v4.0.0b4) разработчики отрефакторили иерархию наследования ([changelog](https://github.com/SeleniumHQ/selenium/blob/trunk/dotnet/CHANGELOG), пункт *Refactored .NET bindings class inheritance hierarchy*). Long story short: ChromeDriver, FirefoxDriver и т.п. не наследуются от RemoteWebDriver, а следовательно код выше не будет работать. Если те кто не используют "настоящий" RemoteWebDriver обновятся до этой версии, то у них все развалится.

Я проверил новую реализацию у нас в проекте (Контур.ОФД) для Selenium 3.13.1 и 4.0.0b4 - все завелось