### PR TITLE
fix(HBVS): fix styles restoration

### DIFF
--- a/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
+++ b/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { getScrollWidth } from '../../lib/dom/getScrollWidth';
 import { css } from '../../lib/theming/Emotion';
 
+let disposeDocumentStyle: (() => void) | null = null;
+
 export class HideBodyVerticalScroll extends React.Component {
   public static __KONTUR_REACT_UI__ = 'HideBodyVerticalScroll';
 
-  private disposeDocumentStyle: (() => void) | null = null;
   private initialScroll = 0;
   private master = false;
 
@@ -45,7 +46,7 @@ export class HideBodyVerticalScroll extends React.Component {
     }
 
     const { clientHeight, scrollHeight } = documentElement;
-    const shouldHide = !this.disposeDocumentStyle && clientHeight < scrollHeight;
+    const shouldHide = !disposeDocumentStyle && clientHeight < scrollHeight;
 
     if (shouldHide) {
       this.hideScroll(documentElement);
@@ -58,7 +59,7 @@ export class HideBodyVerticalScroll extends React.Component {
     const documentMargin = parseFloat(documentComputedStyle.marginRight || '');
     const className = generateDocumentStyle(documentMargin + scrollWidth);
 
-    this.disposeDocumentStyle = this.attachStyle(document, className);
+    disposeDocumentStyle = this.attachStyle(document, className);
   };
 
   private attachStyle = (element: HTMLElement, className: string) => {
@@ -69,9 +70,9 @@ export class HideBodyVerticalScroll extends React.Component {
   };
 
   private restoreStyles = () => {
-    if (this.disposeDocumentStyle) {
-      this.disposeDocumentStyle();
-      this.disposeDocumentStyle = null;
+    if (disposeDocumentStyle) {
+      disposeDocumentStyle();
+      disposeDocumentStyle = null;
 
       const { documentElement } = document;
 


### PR DESCRIPTION
Фикс регресса после #2450 и падающих скриншотов на история ZIndex. 

В нестабильно падающих скриншотах обнаружился кейс, когда на странице появлялось одновременно несколько HBVS. Но размонтировались они не всегда в порядке, обратном монтированию. Это приводило к тому, что после закрытия Modal/SidePage на странице могли остаться стили для скрытия скролла. Починил.