### PR TITLE
fix(react-ui): add compatibility with addons@2.x

### DIFF
--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -1,4 +1,4 @@
-import { exposeGetters, markAs8pxTheme } from '../../lib/theming/ThemeHelpers';
+import { exposeGetters } from '../../lib/theming/ThemeHelpers';
 
 import { DefaultThemeInternal } from './DefaultTheme';
 
@@ -603,4 +603,4 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
   //#endregion
 }
 
-export const Theme8pxInternal = exposeGetters(markAs8pxTheme(Theme8px));
+export const Theme8pxInternal = exposeGetters(Theme8px);

--- a/packages/react-ui/lib/theming/ThemeFactory.ts
+++ b/packages/react-ui/lib/theming/ThemeFactory.ts
@@ -1,7 +1,7 @@
 import { DefaultThemeInternal } from '../../internal/themes/DefaultTheme';
 
 import { Theme, ThemeIn } from './Theme';
-import { isFullTheme, is8pxTheme, markAs8pxTheme } from './ThemeHelpers';
+import { isFullTheme } from './ThemeHelpers';
 
 export class ThemeFactory {
   public static create<T extends {}>(theme: ThemeIn & T, baseTheme: Theme = DefaultThemeInternal): Readonly<Theme & T> {
@@ -38,12 +38,6 @@ export class ThemeFactory {
       const descriptor = Object.getOwnPropertyDescriptor(theme, propName)!;
       Object.defineProperty(newTheme, propName, descriptor);
     });
-
-    if (is8pxTheme(theme)) {
-      // 8px key isn't enumerable
-      // so replicate it manually
-      markAs8pxTheme(newTheme);
-    }
 
     return Object.freeze(newTheme);
   }

--- a/packages/react-ui/lib/theming/ThemeHelpers.ts
+++ b/packages/react-ui/lib/theming/ThemeHelpers.ts
@@ -16,19 +16,22 @@ export const REACT_UI_FULL_THEME_KEY = '__IS_REACT_UI_THEME__';
 
 export const REACT_UI_8PX_THEME_KEY = '__IS_REACT_UI_8PX_THEME__';
 
+export const REACT_UI_FLAT_THEME_KEY = '__IS_REACT_UI_FLAT_THEME__';
+
 export const isFullTheme = (theme: Theme | ThemeIn): boolean => {
   //@ts-ignore
   return theme[REACT_UI_FULL_THEME_KEY] === true;
 };
 
 export const markAsFullTheme = <T extends object>(theme: T): T => {
-  Object.defineProperty(theme, REACT_UI_FULL_THEME_KEY, {
-    value: true,
-    writable: false,
-    enumerable: false,
-    configurable: false,
+  return Object.create(theme, {
+    [REACT_UI_FULL_THEME_KEY]: {
+      value: true,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    },
   });
-  return theme;
 };
 
 export const is8pxTheme = (theme: Theme | ThemeIn): boolean => {
@@ -37,11 +40,28 @@ export const is8pxTheme = (theme: Theme | ThemeIn): boolean => {
 };
 
 export const markAs8pxTheme = <T extends object>(theme: T): T => {
-  Object.defineProperty(theme, REACT_UI_8PX_THEME_KEY, {
-    value: true,
-    writable: false,
-    enumerable: false,
-    configurable: false,
+  return Object.create(theme, {
+    [REACT_UI_8PX_THEME_KEY]: {
+      value: true,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    },
   });
-  return theme;
+};
+
+export const isFlatTheme = (theme: Theme | ThemeIn): boolean => {
+  //@ts-ignore
+  return theme[REACT_UI_FLAT_THEME_KEY] === true;
+};
+
+export const markAsFlatTheme = <T extends object>(theme: T): T => {
+  return Object.create(theme, {
+    [REACT_UI_FLAT_THEME_KEY]: {
+      value: true,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    },
+  });
 };

--- a/packages/react-ui/lib/theming/themes/DefaultTheme8px.ts
+++ b/packages/react-ui/lib/theming/themes/DefaultTheme8px.ts
@@ -1,4 +1,6 @@
+import { DefaultThemeInternal } from '../../../internal/themes/DefaultTheme';
 import { Theme8pxInternal } from '../../../internal/themes/Theme8px';
 import { ThemeFactory } from '../ThemeFactory';
+import { markAs8pxTheme } from '../ThemeHelpers';
 
-export const DEFAULT_THEME_8PX = ThemeFactory.create(Theme8pxInternal);
+export const DEFAULT_THEME_8PX = ThemeFactory.create(Theme8pxInternal, markAs8pxTheme(DefaultThemeInternal));

--- a/packages/react-ui/lib/theming/themes/FlatTheme.ts
+++ b/packages/react-ui/lib/theming/themes/FlatTheme.ts
@@ -1,4 +1,6 @@
+import { DefaultThemeInternal } from '../../../internal/themes/DefaultTheme';
 import { FlatThemeInternal } from '../../../internal/themes/FlatTheme';
 import { ThemeFactory } from '../ThemeFactory';
+import { markAsFlatTheme } from '../ThemeHelpers';
 
-export const FLAT_THEME = ThemeFactory.create(FlatThemeInternal);
+export const FLAT_THEME = ThemeFactory.create(FlatThemeInternal, markAsFlatTheme(DefaultThemeInternal));

--- a/packages/react-ui/lib/theming/themes/FlatTheme8px.ts
+++ b/packages/react-ui/lib/theming/themes/FlatTheme8px.ts
@@ -1,5 +1,6 @@
 import { Theme8pxInternal } from '../../../internal/themes/Theme8px';
 import { FlatThemeInternal } from '../../../internal/themes/FlatTheme';
 import { ThemeFactory } from '../ThemeFactory';
+import { markAs8pxTheme, markAsFlatTheme } from '../ThemeHelpers';
 
-export const FLAT_THEME_8PX = ThemeFactory.create(Theme8pxInternal, FlatThemeInternal);
+export const FLAT_THEME_8PX = ThemeFactory.create(Theme8pxInternal, markAs8pxTheme(markAsFlatTheme(FlatThemeInternal)));


### PR DESCRIPTION
Продублировал небходимые правки из #2339 чтобы наладить совместимость `react-ui@2.x` и последних `react-ui-addons` (2.x).

Выпустил `@skbkontur/react-ui@0.0.0-acc8bd836b` на основе `2.17.2`.