### PR TITLE
refactor(Radio): use prop `checked` instead of `input:checked` style

### DIFF
--- a/packages/react-ui/components/Radio/Radio.styles.ts
+++ b/packages/react-ui/components/Radio/Radio.styles.ts
@@ -36,12 +36,17 @@ export const styles = memoizeStyle({
         background: ${t.radioHoverBg};
         box-shadow: ${t.radioHoverShadow};
       }
-      &:hover input:checked + .${globalClasses.radio} {
-        background: ${t.radioCheckedHoverBgColor};
-      }
       &:active .${globalClasses.radio} {
         background: ${t.radioActiveBg};
         box-shadow: ${t.radioActiveShadow};
+      }
+    `;
+  },
+
+  rootChecked(t: Theme) {
+    return css`
+      &:hover .${globalClasses.radio} {
+        background: ${t.radioCheckedHoverBgColor};
       }
     `;
   },

--- a/packages/react-ui/components/Radio/Radio.tsx
+++ b/packages/react-ui/components/Radio/Radio.tsx
@@ -126,7 +126,7 @@ export class Radio<T> extends React.Component<RadioProps<T>> {
     };
 
     const labelProps = {
-      className: styles.root(this.theme),
+      className: cx(styles.root(this.theme), this.props.checked && styles.rootChecked(this.theme)),
       onMouseOver: this.handleMouseOver,
       onMouseEnter: this.handleMouseEnter,
       onMouseLeave: this.handleMouseLeave,


### PR DESCRIPTION
### В чём цимес?
Нативная радиокнопка при первом клике сеттит `checked` в `true`, если `checked` не определён.
У нас в компоненте нативный инпут полностью controlled. Мы игнорируем это нативное поведение, но всё должно норм работать. Но мы также оборачиваем нативный инпут в `<label/>`, который всё-таки сеттит ему `checked` в `true`. 

Т.е. если кликнуть по такому `<Radio value="radio" />` контролу, то нативная радиокнопка станет `checked=true`, а наш контрол только рамку фокуса покажет.


### Как проявляется?
Новые стили подвязались на нативный инпут - `&:hover input:checked`. В плоской теме появился артефакт, когда стили думают, что `checked=true`, но на самом деле он не тру =)

<details><summary>💎 Артефакт</summary>

https://user-images.githubusercontent.com/2708211/128408202-f89960ba-579d-4d26-a158-1bc4d9e9854e.mp4

</details>


### А раньше как работало?
Раньше в цепочке селектора стилей был конкретный класс, который добавлялся, когда проп `checked` был `true`.
Но с отказом от [овервложенность](https://github.com/skbkontur/retail-ui/pull/2488#pullrequestreview-714785649) классов, и рефакторингом стилей в `Radio` это вскрылось.

### Как исправил?
По факту я просто вернул старое поведение, когда стили зависели от пропа `checked`. Считаю, что сейчас этого будет достаточно, т.к. повторение поведения нативной радиокнопки - это ломающее изменение. К тому же, вскрылось даже несколько проблем.

### Что за проблемы?
1. Поведение нашего контрола отличается от нативной радиокнопки. 🔂 
2. Мы используем `<label/>` внутри контрола, что не очень. Так, например, пользователям приходится стилизовать именно наш контрол, чтобы изменить кликабельную область. А `<label/>` внутри `<label/>` не валидненько.
3. Клики в `RadioGroup` работают только благодаря этому абьюзу.

### Итого
У нас есть большая задача про нативность всех контролов, использовании FormData, uncontrolled, и всякое такое.
Думаю, исправить упомянутые проблемы можно будет в рамках этой challenging задачи.

