### PR TITLE
fix(Tab): fix low height artefact

### DIFF
--- a/packages/react-ui/internal/ResizeDetector/ResizeDetector.styles.ts
+++ b/packages/react-ui/internal/ResizeDetector/ResizeDetector.styles.ts
@@ -18,6 +18,7 @@ export const styles = memoizeStyle({
       margin: 0;
       border: 0;
       background: transparent;
+      opacity: 0;
     `;
   },
 


### PR DESCRIPTION
Добавил прозрачности iframe'у в ResizeDetector'е, чтобы скрыть скролбары в IE, которые появлялись при маленькой высоте контейнера.

fix #2500