### PR TITLE
fix(Modal): up in ZIndex, now upper than ModalHeader

### DIFF
--- a/packages/retail-ui/components/ZIndex/ZIndexStorage.ts
+++ b/packages/retail-ui/components/ZIndex/ZIndexStorage.ts
@@ -10,7 +10,7 @@ const componentPriorities = {
   Loader: 1,
   ModalHeader: 1,
   ModalFooter: 1,
-  ModalCross: 1,
+  ModalCross: 2,
   ModalBody: 0,
 };
 const priorityStep = 1000;


### PR DESCRIPTION
Cherry-picked from de8d81cc343d31a4a6c49b6cc065086f817a216b
Fix #2034