### PR TITLE
[Checkbox] пропадают стили фокуса при наведении мышью

### DIFF
--- a/packages/react-ui/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react-ui/components/Checkbox/Checkbox.styles.ts
@@ -117,7 +117,7 @@ export const styles = memoizeStyle({
   boxFocus(t: Theme) {
     return css`
       box-shadow: inset 0 0 0 1px ${t.checkboxOutlineColorFocus},
-        0 0 0 ${t.checkboxOutlineWidth} ${t.checkboxBorderColorFocus};
+        0 0 0 ${t.checkboxOutlineWidth} ${t.checkboxBorderColorFocus} !important; // override hover and active
     `;
   },
 


### PR DESCRIPTION
fix #2517 
Стили наведения перебивали стили фокуса, исправила с помощью !important по аналогии с другими стилями чекбокса