### PR TITLE
test(screenshots): disable anti-aliasing detection

### DIFF
--- a/packages/react-ui/.creevey/config.js
+++ b/packages/react-ui/.creevey/config.js
@@ -1,5 +1,19 @@
 const path = require('path');
 
+/**
+ * Debuggin instructions: https://wiki.skbkontur.ru/pages/viewpage.action?pageId=418699157
+ * Instructions for Windows nodes: https://git.skbkontur.ru/ke/keweb.front/-/blob/f25788b0c0fce83b762e1b51553683e4d30484bd/.creevey/readme.md#debug
+ */
+
+const debug = process.env.DEBUG_SCREENSHOTS;
+
+const capabilities = debug
+  ? {
+      enableVNC: true,
+      enableVideo: true,
+    }
+  : {};
+
 const config = {
   storybookDir: path.join(__dirname, '../.storybook'),
   reportDir: path.join(__dirname, 'report'),
@@ -20,6 +34,8 @@ const config = {
       _storybookGlobals: {
         theme: 'DEFAULT_THEME_OLD',
       },
+      name: 'infrafront/chrome',
+      ...capabilities,
     },
     chrome8px: {
       browserName: 'chrome',
@@ -28,6 +44,8 @@ const config = {
       _storybookGlobals: {
         theme: 'DEFAULT_THEME',
       },
+      name: 'infrafront/chrome8px',
+      ...capabilities,
     },
     chromeFlat: {
       browserName: 'chrome',
@@ -36,6 +54,8 @@ const config = {
       _storybookGlobals: {
         theme: 'FLAT_THEME_OLD',
       },
+      name: 'infrafront/chromeFlat',
+      ...capabilities,
     },
     chromeFlat8px: {
       browserName: 'chrome',
@@ -44,6 +64,8 @@ const config = {
       _storybookGlobals: {
         theme: 'FLAT_THEME',
       },
+      name: 'infrafront/chromeFlat8px',
+      ...capabilities,
     },
     firefox: {
       browserName: 'firefox',
@@ -51,6 +73,8 @@ const config = {
       _storybookGlobals: {
         theme: 'DEFAULT_THEME_OLD',
       },
+      name: 'infrafront/firefox',
+      ...capabilities,
     },
     firefox8px: {
       browserName: 'firefox',
@@ -58,6 +82,8 @@ const config = {
       _storybookGlobals: {
         theme: 'DEFAULT_THEME',
       },
+      name: 'infrafront/firefox8px',
+      ...capabilities,
     },
     firefoxFlat: {
       browserName: 'firefox',
@@ -65,6 +91,8 @@ const config = {
       _storybookGlobals: {
         theme: 'FLAT_THEME_OLD',
       },
+      name: 'infrafront/firefoxFlat',
+      ...capabilities,
     },
     firefoxFlat8px: {
       browserName: 'firefox',
@@ -72,6 +100,8 @@ const config = {
       _storybookGlobals: {
         theme: 'FLAT_THEME',
       },
+      name: 'infrafront/firefoxFlat8px',
+      ...capabilities,
     },
     ie11: {
       browserName: 'internet explorer',
@@ -79,6 +109,8 @@ const config = {
       _storybookGlobals: {
         theme: 'DEFAULT_THEME_OLD',
       },
+      name: 'infrafront/ie11',
+      ...capabilities,
 
       // NOTE Enable after switch new separate pool for IE to allow test hover
       // 'se:ieOptions': {
@@ -96,6 +128,8 @@ const config = {
       _storybookGlobals: {
         theme: 'DEFAULT_THEME',
       },
+      name: 'infrafront/ie118px',
+      ...capabilities,
     },
     ie11Flat: {
       browserName: 'internet explorer',
@@ -103,6 +137,8 @@ const config = {
       _storybookGlobals: {
         theme: 'FLAT_THEME_OLD',
       },
+      name: 'infrafront/ie11Flat',
+      ...capabilities,
     },
     ie11Flat8px: {
       browserName: 'internet explorer',
@@ -110,6 +146,8 @@ const config = {
       _storybookGlobals: {
         theme: 'FLAT_THEME',
       },
+      name: 'infrafront/ie11Flat8px',
+      ...capabilities,
     },
   },
 };

--- a/packages/react-ui/.creevey/config.js
+++ b/packages/react-ui/.creevey/config.js
@@ -26,6 +26,7 @@ const config = {
     ...options,
     extends: path.join(__dirname, '../.babelrc.js'),
   }),
+  diffOptions: { includeAA: false },
   browsers: {
     chrome: {
       browserName: 'chrome',


### PR DESCRIPTION
Подправил часть скриншотов. [IF-163](https://yt.skbkontur.ru/issue/IF-163)

#### 1. Выключил реагирование скриншотов на изменение антиалиасинга. 

Чинит мигающие скриншоты в ИЕ (с красными точками):

![image](https://user-images.githubusercontent.com/4607770/133959022-f5c76f1f-d37e-4c06-89ae-7f2a804e81dd.png)


#### 2. Добавил инструкции для дебага скриншотов. 
> На [вики](https://wiki.skbkontur.ru/pages/viewpage.action?pageId=418699157) в основном про линуксовые ноды (у нас пока на нем работает хром).
> И [отдельно](https://git.skbkontur.ru/ke/keweb.front/-/blob/f25788b0c0fce83b762e1b51553683e4d30484bd/.creevey/readme.md#debug) про ноды на Windows (для наших firefox и IE11).

Появилась переменная для активации дебага `process.env.DEBUG_SCREENSHOTS`. Ее можно включать при ручном запуске скриншотов на ТС, и смотреть как гоняются скриншоты.

![image](https://user-images.githubusercontent.com/4607770/133974731-17cefa8f-b42c-4a79-8ebf-ab1e4e8ed21e.png)
![image](https://user-images.githubusercontent.com/4607770/133959214-41b813b1-d4dc-4bf6-aa71-fd51638ae43e.png)

Дальше по инструкциям.