### PR TITLE
fix(Checkbox): revert to old focus behavior

### DIFF
--- a/packages/react-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/react-ui/components/Checkbox/Checkbox.tsx
@@ -183,11 +183,11 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
     const box = (
       <span
         className={cx(styles.box(this.theme), globalClasses.box, {
-          [styles.boxChecked(this.theme)]: Boolean(props.checked) || isIndeterminate,
-          [styles.boxWarning(this.theme)]: Boolean(props.warning),
-          [styles.boxError(this.theme)]: Boolean(props.error),
+          [styles.boxChecked(this.theme)]: props.checked || isIndeterminate,
           [styles.boxFocus(this.theme)]: this.state.focusedByTab,
-          [styles.boxDisabled(this.theme)]: Boolean(props.disabled),
+          [styles.boxError(this.theme)]: props.error,
+          [styles.boxWarning(this.theme)]: props.warning,
+          [styles.boxDisabled(this.theme)]: props.disabled,
         })}
       >
         {(isIndeterminate && <SquareIcon className={iconClass} />) || <OkIcon className={iconClass} />}


### PR DESCRIPTION
Fix #2550

Лишь "вернул" старое поведение фокусировки при валидации. Требуемое поведение, описанное в последнем комментарии, выходит за рамки исправления этого бага, т.к. затргивает несколько контролов. Поэтому создал [отдельную задачу](https://yt.skbkontur.ru/issue/IF-183) для этого.


| было | стало |
| --- | --- |
| ![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/2708211/136200337-a0795f3c-29aa-4b85-9371-d234d9dd46a0.gif) | ![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/2708211/136200390-f0c54ab3-d180-43bf-a02d-09d4c500955c.gif) |
