### PR TITLE
fix(Paging): use default cursor style for disabled paging link

### DIFF
--- a/packages/react-ui/components/Paging/Paging.styles.ts
+++ b/packages/react-ui/components/Paging/Paging.styles.ts
@@ -54,6 +54,7 @@ export const styles = memoizeStyle({
   disabled(t: Theme) {
     return css`
       color: ${t.pagingForwardLinkDisabledColor};
+      cursor: default;
     `;
   },
 


### PR DESCRIPTION
fixes #2566

Использовал дефолтный форму курсора, возможно есть смысл использовать форму not-allowed