### PR TITLE
test(creevey): set threshold back to 0

### DIFF
--- a/packages/react-ui/.creevey/config.js
+++ b/packages/react-ui/.creevey/config.js
@@ -26,7 +26,7 @@ const config = {
     ...options,
     extends: path.join(__dirname, '../.babelrc.js'),
   }),
-  diffOptions: { includeAA: false },
+  diffOptions: { threshold: 0, includeAA: false },
   browsers: {
     chrome: {
       browserName: 'chrome',


### PR DESCRIPTION
Оказалось, что вместе с отключением антиалиазинга https://github.com/skbkontur/retail-ui/commit/f5bbceae384145ee42495c65d0b96fa055c1ec2d понизилась чувствительность скриншотов. 

В  криви по умолчанию `threshold: 0`, до тех пор, пока ты не трогаешь руками `diffOptions`. В ином случае берется дефолтный. `0.1` из [pixelmatch](https://github.com/mapbox/pixelmatch#api). 