### PR TITLE
feat(react-ui-codemod): add codemod for addons 3.0

### DIFF
--- a/packages/react-ui-codemod/README.md
+++ b/packages/react-ui-codemod/README.md
@@ -27,6 +27,13 @@ yarn react-ui-codemod CODEMOD [JSCODESHIFT_OPTIONS] [CODEMOD_OPTIONS]
 
 ## Список кодмодов
 
+### addons-3/renameThemeVars
+
+Переименовывает переменные темы в соответствии с изменениями в [!122](https://git.skbkontur.ru/ui/ui-parking/-/merge_requests/122).
+
+```
+npx react-ui-codemod addons-3/renameThemeVars.ts FILES_PATH
+```
 ### react-ui-2.0/transformImportsAndExports.ts
 
 Правит импорты и реэкспорты из библиотеки в соответствии с изменениями #1828 #1932.

--- a/packages/react-ui-codemod/addons-3/__tests__/transformThemeVars.test.ts
+++ b/packages/react-ui-codemod/addons-3/__tests__/transformThemeVars.test.ts
@@ -1,0 +1,49 @@
+const { defineInlineTest } = require('jscodeshift/dist/testUtils');
+
+const transform = require('../renameThemeVars');
+
+jest.autoMockOff();
+
+defineInlineTest(
+  transform,
+  {},
+  `
+    const THEME = ThemeFactory.create({
+      blue: '#0000ff',
+      tbHeight: '100px',
+      logoColor() {},
+    }, DEFAULT_THEME);
+`,
+  `
+    const THEME = ThemeFactory.create({
+      blue: '#0000ff',
+      addonsTopBarHeight: '100px',
+      addonsLogoColor() {},
+    }, DEFAULT_THEME);
+  `,
+  `transforms object`,
+);
+
+defineInlineTest(
+  transform,
+  {},
+  `
+    const node = (
+      <ThemeContext.Provider value={ThemeFactory.create({
+        blue: '#0000ff',
+        tbHeight: '100px',
+        logoColor() {},
+      }, DEFAULT_THEME)} />
+    );
+`,
+  `
+    const node = (
+      <ThemeContext.Provider value={ThemeFactory.create({
+        blue: '#0000ff',
+        addonsTopBarHeight: '100px',
+        addonsLogoColor() {},
+      }, DEFAULT_THEME)} />
+    );
+  `,
+  `transforms jsx`,
+);

--- a/packages/react-ui-codemod/addons-3/renameThemeVars.ts
+++ b/packages/react-ui-codemod/addons-3/renameThemeVars.ts
@@ -1,0 +1,76 @@
+/* eslint-disable import/no-default-export */
+import { API, FileInfo } from 'jscodeshift';
+
+const RENAMED_VARS: Record<string, string> = {
+  tbBg: 'addonsTopBarBg',
+  tbShadow: 'addonsTopBarShadow',
+  tdDividerBg: 'addonsTopBarDividerBg',
+  tbDividerHeight: 'addonsTopBarDividerHeight',
+  tbDividerMarginX: 'addonsTopBarDividerMarginX',
+  tbHeight: 'addonsTopBarHeight',
+  tbItemHeight: 'addonsTopBarItemHeight',
+  tbItemLineHeight: 'addonsTopBarItemLineHeight',
+  tbItemPaddingY: 'addonsTopBarItemPaddingY',
+  tbItemPaddingX: 'addonsTopBarItemPaddingX',
+  tbItemMarginY: 'addonsTopBarItemMarginY',
+  tbItemMarginX: 'addonsTopBarItemMarginX',
+  tbAvatarItemOutline: 'addonsTopBarAvatarItemOutline',
+  tbAvatarItemGap: 'addonsTopBarAvatarItemGap',
+  tbAvatarItemHeight: 'addonsTopBarAvatarItemHeight',
+  tbAvatarItemPaddingY: 'addonsTopBarAvatarItemPaddingY',
+  tbAvatarItemPaddingX: 'addonsTopBarAvatarItemPaddingX',
+  tbAvatarItemMarginY: 'addonsTopBarAvatarItemMarginY',
+  tbAvatarItemMarginX: 'addonsTopBarAvatarItemMarginX',
+  tbPaddingX: 'addonsTopBarPaddingX',
+  tbPaddingY: 'addonsTopBarPaddingY',
+  tbMarginBottom: 'addonsTopBarMarginBottom',
+  tbItemIconGap: 'addonsTopBarItemIconGap',
+  tbIconColor: 'addonsTopBarIconColor',
+  tbItemBorderRadius: 'addonsTopBarItemBorderRadius',
+  tbItemActionBackground: 'addonsTopBarItemActionBackground',
+  tbMenuSeparatorMarginX: 'addonsTopBarMenuSeparatorMarginX',
+  tbMenuSeparatorMarginY: 'addonsTopBarMenuSeparatorMarginY',
+  tbMenuSeparatorColor: 'addonsTopBarMenuSeparatorColor',
+  tbMenuItemHoverBg: 'addonsTopBarMenuItemHoverBg',
+  tbMenuItemHoverColor: 'addonsTopBarMenuItemHoverColor',
+  tbMenuItemPaddingX: 'addonsTopBarMenuItemPaddingX',
+
+  logoColor: 'addonsLogoColor',
+  logoHoverColor: 'addonsLogoHoverColor',
+  logoDividerHeight: 'addonsLogoDividerHeight',
+  logoDividerWidth: 'addonsLogoDividerWidth',
+  logoDividerMarginX: 'addonsLogoDividerMarginX',
+  logoDividerBg: 'addonsLogoDividerBg',
+
+  logoWidgetPaddingX: 'addonsLogoWidgetPaddingX',
+  logoButtonHeight: 'addonsLogoButtonHeight',
+  logoButtonWidth: 'addonsLogoButtonWidth',
+  logoButtonMarginLeft: 'addonsLogoButtonMarginLeft',
+  logoButtonActionBorderRadius: 'addonsLogoButtonActionBorderRadius',
+  logoButtonActionBackground: 'addonsLogoButtonActionBackground',
+
+  userAvatarSize:  'addonsUserAvatarSize',
+  userAvatarBorderRadius:  'addonsUserAvatarBorderRadius',
+  userAvatarBackground:  'addonsUserAvatarBackground',
+  userAvatarHoverBackground:  'addonsUserAvatarHoverBackground',
+  userAvatarActiveBackground:  'addonsUserAvatarActiveBackground',
+  userAvatarColor:  'addonsUserAvatarColor',
+  userAvatarHoverColor:  'addonsUserAvatarHoverColor',
+  userAvatarActiveColor:  'addonsUserAvatarActiveColor',
+};
+
+export default function transform(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+  let modified = false;
+  const result = j(file.source)
+    .find(j.ObjectExpression)
+    .find(j.Identifier, node => RENAMED_VARS[node.name])
+    .replaceWith(path => {
+      path.node.name = RENAMED_VARS[path.node.name];
+      modified = true;
+      return path.node;
+    });
+  if (modified) {
+    return result.toSource();
+  }
+}


### PR DESCRIPTION
Добавил кодмод и тесты для Аддонов 3.0. Конкретно, для переименованных переменных из [122](https://git.skbkontur.ru/ui/ui-parking/-/merge_requests/122).

Выпустил тестовую версию `react-ui-codemod@1.1.0-beta.4`.

Можно проверить так:
```
npx react-ui-codemod@1.1.0-beta.4 addons-3/renameThemeVars.ts FILES
```