### PR TITLE
fix(ComboBox): render placeholder instead of empty string value

### DIFF
--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -305,8 +305,9 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
   private renderPlaceholder = (): JSX.Element | null => {
     const { children, placeholder, disabled } = this.props;
     const { focused } = this.state;
+    const hasValue = isNonNullable(children) && children !== '';
 
-    if (!isNonNullable(children) && placeholder) {
+    if (!hasValue && placeholder) {
       return (
         <span
           className={cx(jsInputStyles.placeholder(this.theme), {

--- a/packages/react-ui/internal/InputLikeText/__tests__/InputLikeText-test.tsx
+++ b/packages/react-ui/internal/InputLikeText/__tests__/InputLikeText-test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { InputLikeText } from '../InputLikeText';
+
+describe('placeholder', () => {
+  it.each([[null], [undefined], ['']])('renders placeholder if value equals "%s"', (value) => {
+    const placeholder = 'placeholder';
+    const wrapper = mount(<InputLikeText placeholder={placeholder}>{value}</InputLikeText>);
+    expect(wrapper.text()).toBe(placeholder);
+  });
+
+  it.each([[0], ['value']])('renders value if value equals "%s"', (value) => {
+    const wrapper = mount(<InputLikeText placeholder="placeholder">{value}</InputLikeText>);
+    expect(wrapper.text()).toBe(value.toString());
+  });
+});


### PR DESCRIPTION
Правка замечания [из чата](https://kontur.slack.com/archives/C013HTCE18Q/p1635754761115000). Когда `value` рендерится в пустую строку, комбобокс перестал отрисовывать плейсхолдер. Это поведение отличается от предыдущего и не соответствует поведению нативного инпута. Поправил.

Причем, при фокусе плейсхолдер появляется.

[Демо](https://codesandbox.io/s/affectionate-dubinsky-ddj69).