### PR TITLE
fix(Button): remove error and warning states

### DIFF
--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -64,37 +64,12 @@ export const styles = memoizeStyle({
     `;
   },
 
-  outlineWarning(t: Theme) {
-    return css`
-      box-shadow: 0 0 0 ${t.btnOutlineWidth} ${t.btnBorderColorWarning},
-        inset 0 0 0 ${t.btnInsetWidth} ${t.btnInsetColor};
-    `;
-  },
-
-  outlineError(t: Theme) {
-    return css`
-      box-shadow: 0 0 0 ${t.btnOutlineWidth} ${t.btnBorderColorError}, inset 0 0 0 ${t.btnInsetWidth} ${t.btnInsetColor};
-    `;
-  },
-
   outlineLink() {
     return css`
       box-shadow: none;
       left: -2px;
       right: -2px;
       bottom: -2px;
-    `;
-  },
-
-  outlineLinkWarning(t: Theme) {
-    return css`
-      background-color: ${t.btnWarningSecondary};
-    `;
-  },
-
-  outlineLinkError(t: Theme) {
-    return css`
-      background-color: ${t.btnErrorSecondary};
     `;
   },
 
@@ -250,22 +225,6 @@ export const styles = memoizeStyle({
       .${globalClasses.arrowHelper} {
         box-shadow: ${t.btnBorderWidth} 0 0 0 ${t.btnDisabledBorderColor};
       }
-    `;
-  },
-
-  arrowWarning(t: Theme) {
-    return css`
-      box-shadow: inset 0 0 0 ${t.btnInsetWidth} ${t.btnInsetColor};
-
-      ${arrowOutlineMixin(t.btnInsetWidth, t.btnBorderColorWarning, t.btnOutlineWidth, t.btnInsetColor)}
-    `;
-  },
-
-  arrowError(t: Theme) {
-    return css`
-      box-shadow: inset 0 0 0 ${t.btnInsetWidth} ${t.btnInsetColor};
-
-      ${arrowOutlineMixin(t.btnInsetWidth, t.btnBorderColorError, t.btnOutlineWidth, t.btnInsetColor)}
     `;
   },
 

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -53,8 +53,6 @@ export interface ButtonProps extends CommonProps {
   /** @ignore */
   disableFocus?: boolean;
 
-  error?: boolean;
-
   focused?: boolean;
 
   /**
@@ -97,8 +95,6 @@ export interface ButtonProps extends CommonProps {
 
   /** @ignore */
   visuallyFocused?: boolean;
-
-  warning?: boolean;
 
   width?: number | string;
 }
@@ -167,8 +163,6 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
       disabled,
       borderless,
       checked,
-      error,
-      warning,
       loading,
       arrow,
       narrow,
@@ -245,11 +239,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
       outlineNode = (
         <div
           className={cx(styles.outline(), {
-            [styles.outlineWarning(this.theme)]: warning,
-            [styles.outlineError(this.theme)]: error,
             [styles.outlineLink()]: isLink,
-            [styles.outlineLinkWarning(this.theme)]: isLink && warning,
-            [styles.outlineLinkError(this.theme)]: isLink && error,
           })}
         />
       );
@@ -280,8 +270,6 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
         <div
           className={cx({
             [styles.arrow()]: true,
-            [styles.arrowWarning(this.theme)]: !checked && warning,
-            [styles.arrowError(this.theme)]: !checked && error,
             [styles.arrowFocus(this.theme)]: !checked && isFocused,
             [styles.arrowLeft()]: arrow === 'left',
           })}


### PR DESCRIPTION
fixes #2599

Удалил состояния `error` и `warning`. В том числе для кнопки в виде ссылки, т.к. [эти состояния](https://guides.kontur.ru/components/hyperlink/#35) не реализованы в контроле `Link`.