### PR TITLE
docs(Radio): enhance documentation

### DIFF
--- a/packages/react-ui/components/Radio/Radio.md
+++ b/packages/react-ui/components/Radio/Radio.md
@@ -1,14 +1,38 @@
-```jsx harmony
-import { Gapped, Radio } from '@skbkontur/react-ui';
+Различные виды радио-кнопок.
 
-<Gapped gap={20}>
-  <Radio value="value" />
-  <Radio value="value" disabled />
-  <Radio value="value" disabled checked />
-  <Radio value="value" checked />
-  <Radio value="value" focused />
-  <Radio value="value" focused checked />
-  <Radio value="value" error />
-  <Radio value="value" warning />
-</Gapped>;
+```jsx harmony
+import { Gapped, Radio, RadioGroup } from '@skbkontur/react-ui';
+
+const [chosen, setChosen] = React.useState(null);
+
+<RadioGroup onValueChange={(value) => setChosen(value)}>
+  <Gapped gap={3} vertical>
+    <Radio value={1}>
+      Обычная радио-кнопка
+    </Radio>
+    <Radio value={2} disabled>
+      Отключенная радио-кнопка
+    </Radio>
+    <Radio value={3} checked={!chosen}>
+      Радио-кнопка отмеченная по умолчанию
+    </Radio>
+    <Radio value={4} focused>
+      Радио-кнопка в состоянии <b>focused</b> (меняется только обводка)
+    </Radio>
+    <Radio value={5} error>
+      Радио-кнопка в состоянии <b>error</b>
+    </Radio>
+    <Radio value={6} warning>
+      Радио-кнопка в состоянии <b>warning</b>
+    </Radio>
+  </Gapped>
+</RadioGroup>
+```
+
+Радио-кнопки могут иметь сразу несколько состояний.
+
+```jsx harmony
+<Radio disabled checked warning>
+  Отключенная, отмеченная радио-кнопка в состоянии <b>warning</b>
+</Radio>
 ```

--- a/packages/react-ui/components/Radio/Radio.tsx
+++ b/packages/react-ui/components/Radio/Radio.tsx
@@ -16,15 +16,15 @@ export interface RadioProps<T>
       React.InputHTMLAttributes<HTMLInputElement>,
       {
         /**
-         *  Добавляет **красную** обводку.
+         *  Cостояние валидации при ошибке.
          */
         error?: boolean;
         /**
-         * Добавляет **оранжевую** обводку.
+         * Cостояние валидации при предупреждении.
          */
         warning?: boolean;
         /**
-         * Добавляет **синюю** обводку.
+         * Состояние фокуса.
          */
         focused?: boolean;
         /**

--- a/packages/react-ui/components/Radio/Radio.tsx
+++ b/packages/react-ui/components/Radio/Radio.tsx
@@ -28,18 +28,6 @@ export interface RadioProps<T>
          */
         focused?: boolean;
         /**
-         * Состояние нажатия.
-         */
-        pressed?: boolean;
-        /**
-         * Состояние hover.
-         */
-        hovered?: boolean;
-        /**
-         * Состояние active.
-         */
-        active?: boolean;
-        /**
          * Функция, вызываемая при изменении `value`.
          */
         onValueChange?: (value: T) => void;
@@ -120,13 +108,10 @@ export class Radio<T> extends React.Component<RadioProps<T>, RadioState> {
 
   public renderMain = (props: CommonWrapperRestProps<RadioProps<T>>) => {
     const {
-      active,
       disabled = this.context.disabled,
       warning = this.context.warning,
       error = this.context.error,
       focused,
-      pressed,
-      hovered,
       onMouseOver,
       onMouseEnter,
       onMouseLeave,

--- a/packages/react-ui/components/Radio/Radio.tsx
+++ b/packages/react-ui/components/Radio/Radio.tsx
@@ -15,24 +15,49 @@ export interface RadioProps<T>
     Override<
       React.InputHTMLAttributes<HTMLInputElement>,
       {
-        /** Состояние ошибки */
+        /**
+         *  Добавляет **красную** обводку.
+         */
         error?: boolean;
-        /** Состояние Предупреждения */
+        /**
+         * Добавляет **оранжевую** обводку.
+         */
         warning?: boolean;
-        /** Состояние фокуса */
+        /**
+         * Добавляет **синюю** обводку.
+         */
         focused?: boolean;
-        /** Состояние нажатия */
+        /**
+         * Состояние нажатия.
+         */
         pressed?: boolean;
-        /** Состояние hover */
+        /**
+         * Состояние hover.
+         */
         hovered?: boolean;
-        /** Состояние active */
+        /**
+         * Состояние active.
+         */
         active?: boolean;
-        /** Вызывается при изменении `value` */
+        /**
+         * Функция, вызываемая при изменении `value`.
+         */
         onValueChange?: (value: T) => void;
+        /**
+         * HTML-событие `onmouseenter`
+         */
         onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
+        /**
+         * HTML-событие `mouseleave`
+         */
         onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
+        /**
+         * HTML-событие `onmouseover`
+         */
         onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
-        /** Значение */
+        /**
+         * HTML-атрибут `value`.
+         */
         value: T;
       }
     > {}
@@ -41,6 +66,9 @@ export interface RadioState {
   focusedByKeyboard: boolean;
 }
 
+/**
+ * Радио-кнопки используются, когда может быть выбран только один вариант из нескольких.
+ */
 export class Radio<T> extends React.Component<RadioProps<T>, RadioState> {
   public static __KONTUR_REACT_UI__ = 'Radio';
 


### PR DESCRIPTION
Улучшил документацию контрола `Radio`: добавил пример и изменил существующий, изменил и дополнил описание пропов и добавил описание самого контрола.

Пропы `pressed`, `hovered` и `active` существуют в этом контроле только номинально. Нужно либо понять зачем они изначально были добавлены и восстановить заложенное поведение, либо удалить их из `API` контрола. Не вижу особого смысла в этих пропах. 