### PR TITLE
docs(Button): enhance documentation

### DIFF
--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -6,7 +6,7 @@ import { Button } from '@skbkontur/react-ui';
 <Button>Создать отчёт</Button>;
 ```
 
-У кнопки есть различные темы.
+У кнопки есть различные стили.
 
 ```jsx harmony
 import { Gapped } from '@skbkontur/react-ui';

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -30,24 +30,6 @@ import { Button } from '@skbkontur/react-ui';
 <Button icon={<PrintIcon />}>Напечатать</Button>;
 ```
 
-Пример кнопки-чекбокса.
-
-```jsx harmony
-import BookmarkIcon from '@skbkontur/react-icons/Bookmark';
-import BookmarkLiteIcon from '@skbkontur/react-icons/BookmarkLite';
-import { Button } from '@skbkontur/react-ui';
-
-const [isChecked, setIsChecked] = React.useState(false);
-
-<Button
-  checked={isChecked}
-  icon={isChecked ? <BookmarkLiteIcon /> : <BookmarkIcon />}
-  onClick={() => setIsChecked(!isChecked)}
-  >
-  {isChecked ? "Удалить из закладок" : "Сохранить в закладках"}
-</Button>;
-```
-
 Пример кнопки, которая получит фокус после загрузки страницы.
 
 ```jsx harmony

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -30,14 +30,6 @@ import { Button } from '@skbkontur/react-ui';
 <Button icon={<PrintIcon />}>Напечатать</Button>;
 ```
 
-Пример кнопки, которая получит фокус после загрузки страницы.
-
-```jsx harmony
-import { Button } from '@skbkontur/react-ui';
-
-<Button autoFocus>Создать отчёт</Button>;
-```
-
 У кнопки есть 3 стандартных размера.
 
 ```jsx harmony

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -1,13 +1,12 @@
-Button example
+Базовый пример кнопки.
 
 ```jsx harmony
-import OkIcon from '@skbkontur/react-icons/Ok';
 import { Button } from '@skbkontur/react-ui';
 
-<Button icon={<OkIcon />}>Ok</Button>;
+<Button>Создать отчёт</Button>;
 ```
 
-Button has different use styles
+У кнопки есть различные темы.
 
 ```jsx harmony
 import { Gapped } from '@skbkontur/react-ui';
@@ -22,19 +21,58 @@ import { Gapped } from '@skbkontur/react-ui';
 </Gapped>;
 ```
 
-Button can have different sizes
+Пример кнопки с иконкой.
 
 ```jsx harmony
-import { Gapped } from '@skbkontur/react-ui';
+import PrintIcon from '@skbkontur/react-icons/Print';
+import { Button } from '@skbkontur/react-ui';
 
-<Gapped>
-  <Button size="small">Small</Button>
-  <Button size="medium">Medium</Button>
-  <Button size="large">Large</Button>
-</Gapped>;
+<Button icon={<PrintIcon />}>Напечатать</Button>;
 ```
 
-Кнопки-стрелки
+Пример кнопки-чекбокса.
+
+```jsx harmony
+import BookmarkIcon from '@skbkontur/react-icons/Bookmark';
+import BookmarkLiteIcon from '@skbkontur/react-icons/BookmarkLite';
+import { Button } from '@skbkontur/react-ui';
+
+const [isChecked, setIsChecked] = React.useState(false);
+
+<Button
+  checked={isChecked}
+  icon={isChecked ? <BookmarkLiteIcon /> : <BookmarkIcon />}
+  onClick={() => setIsChecked(!isChecked)}
+  >
+  {isChecked ? "Удалить из закладок" : "Сохранить в закладках"}
+</Button>;
+```
+
+Пример кнопки, которая получит фокус после загрузки страницы.
+
+```jsx harmony
+import { Button } from '@skbkontur/react-ui';
+
+<Button autoFocus>Создать отчёт</Button>;
+```
+
+У кнопки есть 3 стандартных размера.
+
+```jsx harmony
+<div
+  style={{
+    display: "flex",
+    alignItems: "end",
+    justifyContent: "space-between",
+    width: "330px"
+  }}>
+  <Button size="small">Маленькая</Button>
+  <Button size="medium">Средняя</Button>
+  <Button size="large">Большая</Button>
+</div>
+```
+
+Кнопки в виде стрелок.
 
 ```jsx harmony
 import { Gapped, Button } from '@skbkontur/react-ui';
@@ -48,25 +86,23 @@ import { Gapped, Button } from '@skbkontur/react-ui';
       Далее
     </Button>
   </Gapped>
-  <Gapped gap={5}>
-    <Button arrow="left" size="large">
-      Назад
-    </Button>
-    <Button arrow size="large">
-      Далее
-    </Button>
-  </Gapped>
 </Gapped>;
 ```
 
-Кнопка в состоянии загрузки
+Кнопка в состоянии загрузки.
+
+**Поведение:**
+
+Кнопка на время нахождения в состоянии загрузки отключается.
+
+Если в кнопке есть иконка, на время загрузки иконка заменяется на спиннер, если иконки нет - весь контент кнопки заменяется на спиннер.
 
 ```jsx harmony
+import { Button, Gapped } from '@skbkontur/react-ui';
 import OkIcon from '@skbkontur/react-icons/Ok';
-import { Button } from '@skbkontur/react-ui';
+import BookmarkIcon from '@skbkontur/react-icons/Bookmark';
 
 const [loading, setLoading] = React.useState(false);
-const [success, setSuccess] = React.useState(false);
 
 const delay = time => args => new Promise(resolve => setTimeout(resolve, time, args));
 
@@ -74,19 +110,21 @@ const handleLoadingStart = () => {
   delay(2000)()
     .then(() => {
       setLoading(false);
-      setSuccess(true);
     })
-    .then(delay(1000))
-    .then(() => setSuccess(false));
 };
 
 const handleClick = () => {
   setLoading(true);
-  setSuccess(false);
   handleLoadingStart();
 };
 
-<Button width={150} onClick={handleClick} loading={loading}>
-  {success ? <OkIcon /> : 'Сохранить'}
-</Button>;
+<Gapped>
+  <Button width={150} onClick={handleClick} loading={loading}>
+    Сохранить
+  </Button>
+  <Button icon={<BookmarkIcon />} width={150} onClick={handleClick} loading={loading}>
+    Сохранить
+  </Button>
+</Gapped>
+
 ```

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -138,7 +138,7 @@ export interface ButtonProps extends CommonProps {
   title?: string;
 
   /**
-   * Тема кнопки.
+   * Стиль кнопки.
    *
    * **Допустимые значения**: `"default"`, `"primary"`, `"success"`, `"danger"`, `"pay"`, `"link"`.
    */

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -48,7 +48,7 @@ export interface ButtonProps extends CommonProps {
   borderless?: boolean;
 
   /**
-   * Позволяет использовать кнопку как чекбокс.
+   * @ignore
    */
   checked?: boolean;
 

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -23,24 +23,33 @@ export interface ButtonProps extends CommonProps {
   _noRightPadding?: boolean;
 
   /**
-   * Визуально нажатое состояние.
+   * Применяет к кнопке стили псевдокласса `:active`.
    */
   active?: boolean;
 
-  /** `type TextAlignProperty = "inherit" | "initial" | "unset" | "center" | "end" | "justify" | "left" | "match-parent" | "right" | "start"` */
+  /**
+   * CSS-свойство `text-align`.
+   */
   align?: React.CSSProperties['textAlign'];
 
   /**
-   * Кнопка со стрелкой.
-   *
-   * `type ButtonArrow = boolean | "left"`
+   * Превращает обычную кнопку в кнопку со стрелкой.
    */
   arrow?: boolean | 'left';
 
+  /**
+   * Даёт кнопке фокус после окончания загрузки страницы.
+   */
   autoFocus?: boolean;
 
+  /**
+   * Убирает обводку у кнопки.
+   */
   borderless?: boolean;
 
+  /**
+   * Позволяет использовать кнопку как чекбокс.
+   */
   checked?: boolean;
 
   children?: React.ReactNode;
@@ -48,11 +57,17 @@ export interface ButtonProps extends CommonProps {
   /** @ignore */
   corners?: number;
 
+  /**
+   * Отключенное состояние кнопки.
+   */
   disabled?: boolean;
 
   /** @ignore */
   disableFocus?: boolean;
 
+  /**
+   * Цветовая схема обводки кнопки для ошибки.
+   */
   error?: boolean;
 
   focused?: boolean;
@@ -62,44 +77,86 @@ export interface ButtonProps extends CommonProps {
    */
   icon?: React.ReactElement<any>;
 
+  /**
+   * Переводит кнопку в состояние загрузки.
+   */
   loading?: boolean;
 
+  /**
+   * Сужает кнопку.
+   */
   narrow?: boolean;
 
+  /**
+   * HTML-событие `onblur`.
+   */
   onBlur?: React.FocusEventHandler<HTMLButtonElement>;
 
+  /**
+   * HTML-событие `onclick`.
+   */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 
+  /**
+   * HTML-событие `onfocus`.
+   */
   onFocus?: React.FocusEventHandler<HTMLButtonElement>;
 
+  /**
+   * HTML-событие `keydown`.
+   */
   onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
 
+  /**
+   * HTML-событие `onmouseenter`.
+   */
   onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
 
+  /**
+   * HTML-событие `mouseleave`.
+   */
   onMouseLeave?: React.MouseEventHandler<HTMLButtonElement>;
 
+  /**
+   * HTML-событие `onmouseover`.
+   */
   onMouseOver?: React.MouseEventHandler<HTMLButtonElement>;
 
-  /** `type ButtonSize = "small" | "medium" | "large"` */
+  /**
+   * Задаёт размер кнопки.
+   *
+   * **Допустимые значения**: `"small"`, `"medium"`, `"large"`.
+   */
   size?: ButtonSize;
 
-  /** `type ButtonType = "button" | "submit" | "reset"` */
+  /**
+   * HTML-атрибут `type`.
+   */
   type?: ButtonType;
 
+  /**
+   * HTML-атрибут `title`.
+   */
   title?: string;
 
   /**
-   * Вариант использования. Влияет на цвет кнопки.
+   * Тема кнопки.
    *
-   * `type ButtonUse = "default" | "primary" | "success" | "danger" | "pay" | "link"`
+   * **Допустимые значения**: `"default"`, `"primary"`, `"success"`, `"danger"`, `"pay"`, `"link"`.
    */
   use?: ButtonUse;
 
   /** @ignore */
   visuallyFocused?: boolean;
 
+  /**
+   * Цветовая схема обводки кнопки для предупреждения.
+   */
   warning?: boolean;
 
+  /**
+   * CSS-свойство `width`.
+   */
   width?: number | string;
 }
 

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -70,8 +70,6 @@ export interface ButtonProps extends CommonProps {
    */
   error?: boolean;
 
-  focused?: boolean;
-
   /**
    * Иконка слева от текста кнопки.
    */

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -66,7 +66,7 @@ export interface ButtonProps extends CommonProps {
   disableFocus?: boolean;
 
   /**
-   * Цветовая схема обводки кнопки для ошибки.
+   * Cостояние валидации при ошибке.
    */
   error?: boolean;
 
@@ -148,7 +148,7 @@ export interface ButtonProps extends CommonProps {
   visuallyFocused?: boolean;
 
   /**
-   * Цветовая схема обводки кнопки для предупреждения.
+   * Cостояние валидации при предупреждении.
    */
   warning?: boolean;
 


### PR DESCRIPTION
Улучшил документацию контрола `Button`: добавил новые примеры, дополнил описание старых, добавил описание для пропов.

Проп `focused` передаётся в этот контрол только номинально. Нужно понять нужен ли он и затем восстановить поведение, либо удалить его.

У пропа `arrow` неконсистентное `API`. Сейчас у пропа `arrow` такой тип: `arrow?: boolean | "left"`. Правильно было бы временно изменить тип пропа на `arrow?: boolean | "left" | "right"` и в  одном из мажорных релизов избавиться от `boolean` поменяв тип на `arrow?: "left" | "right"`.

С пропами  `focused`, `warning` и `error` та же проблема, что и в [#2606](https://github.com/skbkontur/retail-ui/pull/2606#discussion_r740847532).