### PR TITLE
Добавить data-tid для календаря

### DIFF
--- a/packages/react-ui/internal/Calendar/Calendar.tsx
+++ b/packages/react-ui/internal/Calendar/Calendar.tsx
@@ -212,7 +212,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     const positions = this.getMonthPositions();
     const wrapperStyle = { height: themeConfig(this.theme).WRAPPER_HEIGHT };
     return (
-      <div ref={this.refRoot} className={styles.root(this.theme)} data-tid="calendar-content">
+      <div ref={this.refRoot} className={styles.root(this.theme)} data-tid="Calendar">
         <div style={wrapperStyle} className={styles.wrapper()}>
           {this.state.months
             .map<[number, MonthViewModel]>((x, i) => [positions[i], x])

--- a/packages/react-ui/internal/Calendar/Calendar.tsx
+++ b/packages/react-ui/internal/Calendar/Calendar.tsx
@@ -212,7 +212,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     const positions = this.getMonthPositions();
     const wrapperStyle = { height: themeConfig(this.theme).WRAPPER_HEIGHT };
     return (
-      <div ref={this.refRoot} className={styles.root(this.theme)}>
+      <div ref={this.refRoot} className={styles.root(this.theme)} data-tid="calendar-content">
         <div style={wrapperStyle} className={styles.wrapper()}>
           {this.state.months
             .map<[number, MonthViewModel]>((x, i) => [positions[i], x])


### PR DESCRIPTION
Сложно в e2e тесте найти выпадашку с календарем. есть только `Monthview__month`, но их много. Хочется один атрибут для всей выпадашки.

влейте пожалуйста в LTS