### PR TITLE
fix(Link): prohibit actions on link with disabled and loading states

### DIFF
--- a/packages/react-ui/components/Link/Link.mixins.ts
+++ b/packages/react-ui/components/Link/Link.mixins.ts
@@ -14,6 +14,7 @@ export const linkDisabledMixin = () => {
   return `
     box-shadow: none;
     cursor: default;
+    pointer-events: none;
     text-decoration: none;
 
     &:hover {

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -121,11 +121,8 @@ export class Link extends React.Component<LinkProps, LinkState> {
       onClick: this._handleClick,
       onFocus: this._handleFocus,
       onBlur: this._handleBlur,
-      tabIndex: this.props.tabIndex,
+      tabIndex: disabled ? -1 : this.props.tabIndex,
     };
-    if (disabled) {
-      props.tabIndex = -1;
-    }
 
     return (
       <a {...rest} {...linkProps}>

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -121,7 +121,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
       onClick: this._handleClick,
       onFocus: this._handleFocus,
       onBlur: this._handleBlur,
-      tabIndex: disabled ? -1 : this.props.tabIndex,
+      tabIndex: disabled || loading ? -1 : this.props.tabIndex,
     };
 
     return (
@@ -150,11 +150,11 @@ export class Link extends React.Component<LinkProps, LinkState> {
   };
 
   private _handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    const { href, onClick, disabled } = this.props;
+    const { href, onClick, disabled, loading } = this.props;
     if (!href) {
       event.preventDefault();
     }
-    if (onClick && !disabled) {
+    if (onClick && !disabled && !loading) {
       onClick(event);
     }
   };


### PR DESCRIPTION
Вынес все запреты на действия у ссылки с состояниями `loading` и `disabled` в этот PR, чтобы избежать конфликтов при мёрже и не множить PR'ы.