### PR TITLE
fix(react-ui-testing): remove weird hardcode from Toast control

### DIFF
--- a/packages/react-ui-testing/SeleniumTesting/Controls/Toast.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Toast.cs
@@ -1,5 +1,7 @@
 using Kontur.Selone.Properties;
+
 using OpenQA.Selenium;
+
 using SKBKontur.SeleniumTesting.Internals.Selectors;
 
 namespace SKBKontur.SeleniumTesting.Controls
@@ -19,11 +21,6 @@ namespace SKBKontur.SeleniumTesting.Controls
         public new IProp<bool> IsPresent => toastView.IsPresent;
 
         public override IProp<string> Text => notification.Text;
-
-        public static Toast Static(ISearchContainer container)
-        {
-            return new Toast(container.GetRootContainer(), new UniversalSelector("##StaticToast"));
-        }
 
         private readonly Label toastView;
 

--- a/packages/react-ui-testing/Tests/ToastTests/ToastTest.cs
+++ b/packages/react-ui-testing/Tests/ToastTests/ToastTest.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using SKBKontur.SeleniumTesting.Controls;
+
 using SKBKontur.SeleniumTesting.Tests.Helpers;
 using SKBKontur.SeleniumTesting.Tests.TestEnvironment;
 
@@ -41,14 +41,13 @@ namespace SKBKontur.SeleniumTesting.Tests.ToastTests
         [Test]
         public void TestWithStaticToast()
         {
-            var toast = Toast.Static(page);
-            toast.IsPresent.Wait().False();
+            page.StaticToast.IsPresent.Wait().False();
             page.StaticToastButton.Click();
-            toast.IsPresent.Wait().True();
-            toast.Text.Wait().EqualTo("Static");
-            toast.Action.Text.Wait().EqualTo("close");
-            toast.Action.Click();
-            toast.IsPresent.Wait().False();
+            page.StaticToast.IsPresent.Wait().True();
+            page.StaticToast.Text.Wait().EqualTo("Static");
+            page.StaticToast.Action.Text.Wait().EqualTo("close");
+            page.StaticToast.Action.Click();
+            page.StaticToast.IsPresent.Wait().False();
         }
 
         private ToastTestPage page;

--- a/packages/react-ui-testing/Tests/ToastTests/ToastTestPage.cs
+++ b/packages/react-ui-testing/Tests/ToastTests/ToastTestPage.cs
@@ -1,4 +1,5 @@
 using OpenQA.Selenium;
+
 using SKBKontur.SeleniumTesting.Controls;
 using SKBKontur.SeleniumTesting.Tests.AutoFill;
 
@@ -21,5 +22,7 @@ namespace SKBKontur.SeleniumTesting.Tests.ToastTests
         public Toast ToastWithAction { get; set; }
 
         public Button StaticToastButton { get; set; }
+
+        public Toast StaticToast { get; set; }
     }
 }


### PR DESCRIPTION
Нашел странную захардкоженную штуку в контроле Toast. Избавился от нее, переписал тест.