### PR TITLE
chore(forwardRefAndName): decorator for forwarding name and ref to component

### DIFF
--- a/packages/react-ui/lib/forwardRefAndName.ts
+++ b/packages/react-ui/lib/forwardRefAndName.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface CompoundedComponent<T> extends React.ForwardRefExoticComponent<T> {
+  __KONTUR_REACT_UI__: string;
+}
+
+export function forwardRefAndName<ElementType, Props>(
+  name: string,
+  render: React.ForwardRefRenderFunction<ElementType, Props>,
+) {
+  const renderWithRef = React.forwardRef(render) as CompoundedComponent<Props>;
+
+  renderWithRef.displayName = name;
+  renderWithRef.__KONTUR_REACT_UI__ = name;
+  return renderWithRef;
+}

--- a/packages/react-ui/lib/forwardRefAndName.ts
+++ b/packages/react-ui/lib/forwardRefAndName.ts
@@ -1,16 +1,18 @@
-import React from 'react';
+import { forwardRef } from 'react';
 
-export interface CompoundedComponent<T> extends React.ForwardRefExoticComponent<T> {
+export interface ReactUIComponentWithRef<T, P>
+  extends React.NamedExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> {
   __KONTUR_REACT_UI__: string;
+  propTypes?: React.WeakValidationMap<P>;
 }
 
 export function forwardRefAndName<ElementType, Props>(
   name: string,
   render: React.ForwardRefRenderFunction<ElementType, Props>,
-) {
-  const renderWithRef = React.forwardRef(render) as CompoundedComponent<Props>;
-
+): ReactUIComponentWithRef<ElementType, Props> {
+  const renderWithRef = forwardRef(render) as ReactUIComponentWithRef<ElementType, Props>;
   renderWithRef.displayName = name;
   renderWithRef.__KONTUR_REACT_UI__ = name;
+
   return renderWithRef;
 }

--- a/packages/react-ui/lib/forwardRefAndName.ts
+++ b/packages/react-ui/lib/forwardRefAndName.ts
@@ -1,18 +1,23 @@
 import { forwardRef } from 'react';
 
 export interface ReactUIComponentWithRef<T, P>
-  extends React.NamedExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> {
+  extends React.NamedExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>,
+    Pick<React.ForwardRefExoticComponent<P>, 'propTypes'> {
   __KONTUR_REACT_UI__: string;
-  propTypes?: React.WeakValidationMap<P>;
+}
+
+function forwardName<ElementType, Props>(
+  name: string,
+  render: ReactUIComponentWithRef<ElementType, Props>,
+): ReactUIComponentWithRef<ElementType, Props> {
+  render.displayName = name;
+  render.__KONTUR_REACT_UI__ = name;
+  return render;
 }
 
 export function forwardRefAndName<ElementType, Props>(
   name: string,
   render: React.ForwardRefRenderFunction<ElementType, Props>,
 ): ReactUIComponentWithRef<ElementType, Props> {
-  const renderWithRef = forwardRef(render) as ReactUIComponentWithRef<ElementType, Props>;
-  renderWithRef.displayName = name;
-  renderWithRef.__KONTUR_REACT_UI__ = name;
-
-  return renderWithRef;
+  return forwardName<ElementType, Props>(name, forwardRef(render) as ReactUIComponentWithRef<ElementType, Props>);
 }


### PR DESCRIPTION
Декоратор для проброски `displayName`, `__KONTUR_REACT_UI__` и `ref` в компонент.