### PR TITLE
feat(Popup): adjust position to fit viewport automatically

### DIFF
--- a/packages/react-ui/components/TokenInput/TokenInputMenu.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInputMenu.tsx
@@ -67,7 +67,7 @@ export class TokenInputMenu<T = string> extends React.Component<TokenInputMenuPr
     return (
       <Popup
         opened={opened!}
-        positions={['bottom left']}
+        positions={['bottom left', 'top left']}
         anchorElement={anchorElement}
         popupOffset={menuAlign === 'left' ? 0 : 5}
         margin={menuAlign === 'left' ? 1 : undefined}

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -327,6 +327,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
           ignoreHover={this.props.trigger === 'hoverAnchor'}
           onOpen={this.props.onOpen}
           onClose={this.props.onClose}
+          tryPreserveFirstRenderedPosition
           {...popupProps}
         >
           {content}

--- a/packages/react-ui/internal/Popup/PopupHelper.tsx
+++ b/packages/react-ui/internal/Popup/PopupHelper.tsx
@@ -44,6 +44,7 @@ function isAbsoluteRectFullyVisible(coordinates: Offset, popupRect: Rect): boole
   return _rectContainsRect(windowAbsoluteRect, absoluteRect);
 }
 
+// Can become fully visible by scrolling into viewport
 function canBecomeFullyVisible(positionName: PopupPosition, coordinates: Offset) {
   const position = getPositionObject(positionName);
 


### PR DESCRIPTION
Фикс [проблемы из чата](https://kontur.slack.com/archives/C013HTCE18Q/p1636375441135000). 

До этого момента, Popup не менял позицию автоматически, если он не помещался во вьюпорт, но мог быть в него проскролен. Это специфичное поведение создавалось для Tooltip (#1195). Остальные выпадашки скорее должны менять позицию сразу при выходе за вьюпорт и обратно, по аналогии со старым движком выпадашек DropdownMenu. 

Поменял эту ситуацию, вынеся специфику в отдельный проп и заиспользовав его в Tooltip.

Остальные компоненты, построенные на Popup (TokenInput/Kebab/DropdownMenu/TooltipMenu) теперь будут всегда перестаивать свою позицию, при наличии вариантов в пропе `positions`.