### PR TITLE
fix(ComboBox): fix blur in Chrome

### DIFF
--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -172,6 +172,7 @@ describe('ComboBox', () => {
     await promise;
 
     clickOutside();
+    await delay(0);
 
     expect(onUnexpectedInput).toBeCalledWith('one');
     expect(onUnexpectedInput).toHaveBeenCalledTimes(1);
@@ -194,6 +195,7 @@ describe('ComboBox', () => {
       await delay(0);
       wrapper.find('input').simulate('change', { target: { value: values.pop() } });
       clickOutside();
+      await delay(0);
     }
 
     expect(onValueChange).toHaveBeenCalledWith(null);
@@ -230,11 +232,12 @@ describe('ComboBox', () => {
         opened: true,
       });
       clickOutside();
+      await delay(0);
 
       expect(onBlur).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onBlur on input blur when menu is closed', () => {
+    it('calls onBlur on input blur when menu is closed', async () => {
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
 
@@ -242,6 +245,7 @@ describe('ComboBox', () => {
         opened: false,
       });
       wrapper.find('input').simulate('blur');
+      await delay(0);
 
       expect(onBlur).toHaveBeenCalledTimes(1);
     });
@@ -336,6 +340,7 @@ describe('ComboBox', () => {
     wrapper.find('input').simulate('change', { target: { value: 'foo' } });
 
     clickOutside();
+    await delay(0);
     wrapper.update();
 
     expect(wrapper.find('CustomComboBox').state('textValue')).toBe('');
@@ -353,9 +358,10 @@ describe('ComboBox', () => {
     expect(wrapper.find(ComboBoxView).prop('opened')).toEqual(true);
 
     clickOutside();
+    await delay(0);
     wrapper.update();
 
-    expect(wrapper.find(ComboBoxView).prop('loading')).toEqual(true);
+    expect(wrapper.find(ComboBoxView).prop('loading')).toEqual(false);
     expect(wrapper.find(ComboBoxView).prop('opened')).toEqual(false);
 
     await delay(1000);
@@ -405,18 +411,20 @@ describe('ComboBox', () => {
       { value: 1, label: 'one' },
       { value: 2, label: 'two' },
     ];
-    const check = (wrapper: ReactWrapper<ComboBoxProps<any>, {}, ComboBox<any>>) => {
+    const check = async (wrapper: ReactWrapper<ComboBoxProps<any>, {}, ComboBox<any>>) => {
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
       expect(wrapper.find('input').prop('value')).toBe(VALUES[0].label);
 
       wrapper.instance().blur();
+      await delay(0);
       wrapper.setProps({ value: VALUES[1] });
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
       expect(wrapper.find('input').prop('value')).toBe(VALUES[1].label);
 
       wrapper.instance().blur();
+      await delay(0);
       wrapper.setProps({ value: null });
       wrapper.find(ComboBoxView).prop('onFocus')?.();
       wrapper.update();
@@ -531,6 +539,7 @@ describe('ComboBox', () => {
     await delay(300);
 
     clickOutside();
+    await delay(0);
     wrapper.update();
 
     expect(changeHandler).toHaveBeenCalledWith(EXPECTED_ITEM);

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -8,7 +8,6 @@ import { MenuItemState } from '../../components/MenuItem';
 import { CancelationError, taskWithDelay } from '../../lib/utils';
 import { fixClickFocusIE } from '../../lib/events/fixClickFocusIE';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
-import { isFirefox, isIE11 } from '../../lib/client';
 
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { CustomComboBoxAction, CustomComboBoxEffect, reducer } from './CustomComboBoxReducer';
@@ -367,15 +366,12 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       return;
     }
     this.focused = false;
-    if (isFirefox || isIE11) {
-      // workaround for the Firefox focusout bug
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1363964
-      setTimeout(() => {
-        this.dispatch({ type: 'Blur' });
-      });
-    } else {
+    // workaround for the similar bug with focusout
+    // in Firefox, Chrome and IE
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1363964
+    setTimeout(() => {
       this.dispatch({ type: 'Blur' });
-    }
+    });
   };
 
   private handleInputBlur = () => {


### PR DESCRIPTION
Из обращения в личке:

> в сочетании с комбобоксом при наличии данных в тултипе - не срабатывает на блюр при смене значения в комбобоксе. В Хроме.

![image](https://user-images.githubusercontent.com/4607770/142347614-2827100e-b682-4a98-a074-94cf3a496dfc.png)
![image](https://user-images.githubusercontent.com/4607770/142347627-34ed558c-fb75-4ee5-ba40-4c7c19a8580e.png)

Как воспроизвести:
1. В [первом примере](https://tech.skbkontur.ru/react-ui/#!/Components/ComboBox/ComboBox/1) в доке установить триггер Тултипу в `focus` 
2. Зафокуситься в Комбобокс, выбрать любое значение
3. Сбросить фокус из Комбобокса
4. Тултип не закрывается

Похоже, дело в той же проблеме с событием focusout, что была ранее в firefox (#2485). Распространил прошлый фикс на все браузеры и подправил тесты.