### PR TITLE
chore(babel): generate prop types based on typescript types

### DIFF
--- a/packages/react-ui/.babelrc.js
+++ b/packages/react-ui/.babelrc.js
@@ -1,6 +1,15 @@
 const env = {
   cjs: {
-    presets: [['@babel/preset-env', { loose: true, modules: 'commonjs', targets: { ie: '11' } }]],
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          loose: true,
+          modules: 'commonjs',
+          targets: { ie: '11' },
+        },
+      ],
+    ],
     plugins: [['@babel/plugin-transform-runtime', { version: '7.8.3' }]],
   },
 };
@@ -11,13 +20,7 @@ const plugins = [
   ['@babel/plugin-transform-runtime', { useESModules: true, version: '7.8.3' }],
   ['@babel/plugin-proposal-decorators', { legacy: true }],
   ['@babel/plugin-proposal-class-properties', { loose: true }],
+  ['babel-plugin-typescript-to-proptypes', { comments: true, mapUnknownReferenceTypesToAny: true, maxSize: 0 }],
 ];
-
-if (process.env.NODE_ENV === 'development') {
-  plugins.push([
-    'babel-plugin-typescript-to-proptypes',
-    { comments: true, mapUnknownReferenceTypesToAny: true, maxSize: 0 },
-  ]);
-}
 
 module.exports = { env, presets, plugins };

--- a/packages/react-ui/.babelrc.js
+++ b/packages/react-ui/.babelrc.js
@@ -1,14 +1,23 @@
-module.exports = {
-  env: {
-    cjs: {
-      presets: [['@babel/preset-env', { loose: true, modules: 'commonjs', targets: { ie: '11' } }]],
-      plugins: [['@babel/plugin-transform-runtime', { version: '7.8.3' }]],
-    },
+const env = {
+  cjs: {
+    presets: [['@babel/preset-env', { loose: true, modules: 'commonjs', targets: { ie: '11' } }]],
+    plugins: [['@babel/plugin-transform-runtime', { version: '7.8.3' }]],
   },
-  presets: [['@babel/preset-env', { loose: true, modules: false }], '@babel/typescript', '@babel/preset-react'],
-  plugins: [
-    ['@babel/plugin-transform-runtime', { useESModules: true, version: '7.8.3' }],
-    ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-  ],
 };
+
+const presets = [['@babel/preset-env', { loose: true, modules: false }], '@babel/typescript', '@babel/preset-react'];
+
+const plugins = [
+  ['@babel/plugin-transform-runtime', { useESModules: true, version: '7.8.3' }],
+  ['@babel/plugin-proposal-decorators', { legacy: true }],
+  ['@babel/plugin-proposal-class-properties', { loose: true }],
+];
+
+if (process.env.NODE_ENV === 'development') {
+  plugins.push([
+    'babel-plugin-typescript-to-proptypes',
+    { comments: true, mapUnknownReferenceTypesToAny: true, maxSize: 0 },
+  ]);
+}
+
+module.exports = { env, presets, plugins };

--- a/packages/react-ui/components/Center/Center.tsx
+++ b/packages/react-ui/components/Center/Center.tsx
@@ -1,26 +1,25 @@
 import React from 'react';
 
-import { Override } from '../../typings/utility-types';
-import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
+import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { styles } from './Center.styles';
 
 export type HorizontalAlign = 'left' | 'center' | 'right';
 
+interface CenterInterface {
+  /**
+   * Определяет, как контент будет выровнен по горизонтали.
+   *
+   * **Допустимые значения**: `"left"`, `"center"`, `"right"`.
+   */
+  align?: HorizontalAlign;
+}
+
 export interface CenterProps
   extends CommonProps,
-    Override<
-      React.HTMLAttributes<HTMLDivElement>,
-      {
-        /**
-         * Определяет, как контент будет выровнен по горизонтали.
-         *
-         * **Допустимые значения**: `"left"`, `"center"`, `"right"`.
-         */
-        align?: HorizontalAlign;
-      }
-    > {}
+    Omit<React.HTMLAttributes<HTMLDivElement>, keyof CenterInterface>,
+    CenterInterface {}
 
 /**
  * Контейнер, который центрирует элементы внутри себя.

--- a/packages/react-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/react-ui/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Nullable, Override } from '../../typings/utility-types';
+import { Nullable } from '../../typings/utility-types';
 import { keyListener } from '../../lib/events/keyListener';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -12,49 +11,49 @@ import { cx } from '../../lib/theming/Emotion';
 
 import { styles, globalClasses } from './Checkbox.styles';
 
+interface CheckboxInterface {
+  /**
+   * Контент `label`
+   */
+  children?: React.ReactNode;
+  /**
+   * Cостояние валидации при ошибке.
+   */
+  error?: boolean;
+  /**
+   * Cостояние валидации при предупреждении.
+   */
+  warning?: boolean;
+  /**
+   * HTML-событие `mouseenter`.
+   */
+  onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-событие `mouseleave`.
+   */
+  onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-событие `mouseover`.
+   */
+  onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * Функция, вызываемая при изменении `value`.
+   */
+  onValueChange?: (value: boolean) => void;
+  /**
+   * HTML-событие `onblur`.
+   */
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  /**
+   * [Неопределённое состояние](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-indeterminate) чекбокса из HTML.
+   */
+  initialIndeterminate?: boolean;
+}
+
 export interface CheckboxProps
   extends CommonProps,
-    Override<
-      React.InputHTMLAttributes<HTMLInputElement>,
-      {
-        /**
-         * Контент `label`
-         */
-        children?: React.ReactNode;
-        /**
-         * Cостояние валидации при ошибке.
-         */
-        error?: boolean;
-        /**
-         * Cостояние валидации при предупреждении.
-         */
-        warning?: boolean;
-        /**
-         * HTML-событие `mouseenter`.
-         */
-        onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
-        /**
-         * HTML-событие `mouseleave`.
-         */
-        onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
-        /**
-         * HTML-событие `mouseover`.
-         */
-        onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
-        /**
-         * Функция, вызываемая при изменении `value`.
-         */
-        onValueChange?: (value: boolean) => void;
-        /**
-         * HTML-событие `onblur`.
-         */
-        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
-        /**
-         * [Неопределённое состояние](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-indeterminate) чекбокса из HTML.
-         */
-        initialIndeterminate?: boolean;
-      }
-    > {}
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, keyof CheckboxInterface>,
+    CheckboxInterface {}
 
 export interface CheckboxState {
   focusedByTab: boolean;
@@ -63,18 +62,6 @@ export interface CheckboxState {
 
 export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
   public static __KONTUR_REACT_UI__ = 'Checkbox';
-
-  public static propTypes = {
-    checked: PropTypes.bool,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    warning: PropTypes.bool,
-    onValueChange: PropTypes.func,
-    onBlur: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
-  };
 
   public state = {
     focusedByTab: false,
@@ -108,7 +95,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
   }
 
   /**
-   * Программная установка фокуса чекбоксу.
+   * Статический метод для вызова фокуса у чекбокса.
    * @public
    */
   public focus() {
@@ -117,7 +104,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
   }
 
   /**
-   * Программное снятие фокуса с чекбокса.
+   * Статический метод для снятия фокуса с чекбокса
    * @public
    */
   public blur() {

--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import warning from 'warning';
 import debounce from 'lodash.debounce';
+import pt from 'prop-types';
 
 import { isIE11 } from '../../lib/client';
 import { Input, InputProps } from '../Input';
-import { Nullable, Override } from '../../typings/utility-types';
+import { Nullable } from '../../typings/utility-types';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
 import { MAX_SAFE_DIGITS } from './constants';
@@ -14,30 +14,42 @@ import { CurrencyHelper } from './CurrencyHelper';
 import { CurrencyInputHelper } from './CurrencyInputHelper';
 import { CURRENCY_INPUT_ACTIONS, extractAction } from './CurrencyInputKeyboardActions';
 
+interface CurrencyInputInterface {
+  /**
+   * Значение в поле инпута.
+   */
+  value: Nullable<number>;
+  /**
+   * Убрать лишние нули после запятой.
+   */
+  hideTrailingZeros: boolean;
+  /**
+   * Кол-во цифр после зяпятой.
+   */
+  fractionDigits?: Nullable<number>;
+  /**
+   * Отрицательные значения.
+   */
+  signed?: boolean;
+  /**
+   * Допустимое кол-во цифр целой части.
+   * Если передан **0**, или `fractionDigits=15`, то и в целой части допускается только **0**.
+   */
+  integerDigits?: Nullable<number>;
+  /**
+   * Функция вызываемая при изменении `value`.
+   */
+  onValueChange: (value: Nullable<number>) => void;
+  /**
+   * HTML-событие `onsubmit`.
+   */
+  onSubmit?: () => void;
+}
+
 export interface CurrencyInputProps
   extends CommonProps,
-    Override<
-      InputProps,
-      {
-        /** Значение */
-        value: Nullable<number>;
-        /** Убрать лишние нули после запятой */
-        hideTrailingZeros: boolean;
-        /** Кол-во цифр после зяпятой */
-        fractionDigits?: Nullable<number>;
-        /** Отрицательные значения */
-        signed?: boolean;
-        /**
-         * Допустимое кол-во цифр целой части.
-         * Если передан **0**, или `fractionDigits=15`, то и в целой части допускается только **0**.
-         */
-        integerDigits?: Nullable<number>;
-        /** Вызывается при изменении `value` */
-        onValueChange: (value: Nullable<number>) => void;
-        /** onSubmit */
-        onSubmit?: () => void;
-      }
-    > {}
+    Omit<InputProps, keyof CurrencyInputInterface>,
+    CurrencyInputInterface {}
 
 export interface CurrencyInputState {
   formatted: string;
@@ -57,27 +69,9 @@ export class CurrencyInput extends React.Component<CurrencyInputProps, CurrencyI
   public static __KONTUR_REACT_UI__ = 'CurrencyInput';
 
   public static propTypes = {
-    align: PropTypes.oneOf(['left', 'center', 'right']),
-    autoFocus: PropTypes.bool,
-    borderless: PropTypes.bool,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    fractionDigits: PropTypes.number,
-    hideTrailingZeros: PropTypes.bool,
-    leftIcon: PropTypes.element,
-    placeholder: PropTypes.string,
-    signed: PropTypes.bool,
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-    value: PropTypes.number,
-    warning: PropTypes.bool,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    onBlur: PropTypes.func,
-    onValueChange: PropTypes.func.isRequired,
-    onFocus: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
-    onSubmit: PropTypes.func,
+    value: pt.oneOf([pt.number, null, undefined]).isRequired,
+    fractionDigits: pt.oneOf([pt.number, null, undefined]),
+    integerDigits: pt.oneOf([pt.number, null, undefined]),
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/CurrencyLabel/CurrencyLabel.tsx
+++ b/packages/react-ui/components/CurrencyLabel/CurrencyLabel.tsx
@@ -10,7 +10,13 @@ export interface CurrencyLabelProps extends CommonProps {
    * @default 2
    */
   fractionDigits: number;
+  /**
+   * Текст ярлыка.
+   */
   value: number;
+  /**
+   * Знак валюты.
+   */
   currencySymbol?: React.ReactNode;
 }
 

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import pt from 'prop-types';
 import { findDOMNode } from 'react-dom';
 
 import { InternalDate } from '../../lib/date/InternalDate';
@@ -33,32 +33,62 @@ export const MIN_WIDTH = 120;
 export interface DatePickerProps<T> extends CommonProps {
   autoFocus?: boolean;
   disabled?: boolean;
+  /**
+   * Добавляет в календарь кнопку 'сегодня'.
+   */
   enableTodayLink?: boolean;
   /**
    * Cостояние валидации при ошибке.
    */
   error?: boolean;
+  /**
+   * Нижний порог даты.
+   */
   minDate: T;
+  /**
+   * Верхний порог даты.
+   */
   maxDate: T;
   menuAlign?: 'left' | 'right';
   size?: 'small' | 'medium' | 'large';
+  /**
+   * Строка формата `dd.mm.yyyy`.
+   */
   value?: T | null;
   /**
    * Cостояние валидации при предупреждении.
    */
   warning?: boolean;
   width?: number | string;
+  /**
+   * HTML-событие `onblur`.
+   */
   onBlur?: () => void;
   /**
-   * Вызывается при изменении `value`
+   * Функция, вызываемая при изменении `value`.
    *
    * @param value - строка в формате `dd.mm.yyyy`.
    */
   onValueChange: (value: T) => void;
+  /**
+   * HTML-событие `onfocus`.
+   */
   onFocus?: () => void;
+  /**
+   * HTML-событие `onkeydown`.
+   */
   onKeyDown?: (e: React.KeyboardEvent<any>) => void;
+  /**
+   * HTML-событие `onmouseenter`.
+   */
   onMouseEnter?: (e: React.MouseEvent<any>) => void;
+  /**
+   * HTML-событие `onmouseleave`.
+   */
   onMouseLeave?: (e: React.MouseEvent<any>) => void;
+  /**
+   * HTML-событие `onmouseover`.
+   */
   onMouseOver?: (e: React.MouseEvent<any>) => void;
   /**
    * Использовать на мобильных устройствах нативный календарь для выбора дат.
@@ -89,53 +119,9 @@ export class DatePicker extends React.Component<DatePickerProps<DatePickerValue>
   public static __KONTUR_REACT_UI__ = 'DatePicker';
 
   public static propTypes = {
-    autoFocus: PropTypes.bool,
-
-    disabled: PropTypes.bool,
-
-    /**
-     * Включает кнопку сегодня в календаре
-     */
-    enableTodayLink: PropTypes.bool,
-
-    error: PropTypes.bool,
-
-    /**
-     * Максимальная дата в календаре.
-     */
-    maxDate: PropTypes.string.isRequired,
-
-    menuAlign: PropTypes.oneOf(['left', 'right'] as Array<'left' | 'right'>),
-
-    /**
-     * Минимальная дата в календаре.
-     */
-    minDate: PropTypes.string.isRequired,
-
-    /**
-     * Строка формата `dd.mm.yyyy`
-     */
-    value: PropTypes.string,
-
-    warning: PropTypes.bool,
-
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-
-    onBlur: PropTypes.func,
-
-    onValueChange: PropTypes.func.isRequired,
-
-    onFocus: PropTypes.func,
-
-    onKeyDown: PropTypes.func,
-
-    onMouseEnter: PropTypes.func,
-
-    onMouseLeave: PropTypes.func,
-
-    onMouseOver: PropTypes.func,
-
-    isHoliday: PropTypes.func.isRequired,
+    minDate: pt.string.isRequired,
+    maxDate: pt.string.isRequired,
+    value: pt.string,
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/DatePicker/Picker.tsx
+++ b/packages/react-ui/components/DatePicker/Picker.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import shallowEqual from 'shallowequal';
+import pt from 'prop-types';
 
 import { InternalDate } from '../../lib/date/InternalDate';
 import { InternalDateGetter } from '../../lib/date/InternalDateGetter';
-import { Calendar, CalendarDateShape, isGreater, isLess } from '../../internal/Calendar';
+import { Calendar, CalendarDateShape, isGreater, isLess, ptDateShape } from '../../internal/Calendar';
 import { locale } from '../../lib/locale/decorators';
 import { Nullable } from '../../typings/utility-types';
 import { Theme } from '../../lib/theming/Theme';
@@ -12,7 +13,7 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { styles } from './Picker.styles';
 import { DatePickerLocale, DatePickerLocaleHelper } from './locale';
 
-interface Props {
+interface PickerProps {
   maxDate?: CalendarDateShape;
   minDate?: CalendarDateShape;
   value: Nullable<CalendarDateShape>;
@@ -37,14 +38,14 @@ const getTodayCalendarDate = () => {
 };
 
 @locale('DatePicker', DatePickerLocaleHelper)
-export class Picker extends React.Component<Props, State> {
+export class Picker extends React.Component<PickerProps, State> {
   public static __KONTUR_REACT_UI__ = 'Picker';
 
   private theme!: Theme;
   private calendar: Calendar | null = null;
   private readonly locale!: DatePickerLocale;
 
-  constructor(props: Props) {
+  constructor(props: PickerProps) {
     super(props);
     const today = getTodayCalendarDate();
     this.state = {
@@ -53,7 +54,13 @@ export class Picker extends React.Component<Props, State> {
     };
   }
 
-  public componentDidUpdate(prevProps: Props) {
+  public static propTypes = {
+    maxDate: pt.shape(ptDateShape),
+    minDate: pt.shape(ptDateShape),
+    value: pt.oneOf([pt.shape(ptDateShape), null, undefined]).isRequired,
+  };
+
+  public componentDidUpdate(prevProps: PickerProps) {
     const { value } = this.props;
     if (value && !shallowEqual(value, prevProps.value)) {
       this.scrollToMonth(value.month, value.year);

--- a/packages/react-ui/components/Dropdown/Dropdown.tsx
+++ b/packages/react-ui/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 
 import { filterProps } from '../../lib/filterProps';
 import { MenuHeader } from '../MenuHeader';
@@ -38,21 +38,20 @@ export interface DropdownProps extends CommonProps {
    * Иконка слева от текста кнопки
    */
   icon?: React.ReactElement<any>;
+  /**
+   * Ширина элемента.
+   */
   width?: React.CSSProperties['width'];
-
   /** @ignore */
   _renderButton?: (params: any) => JSX.Element;
-
   /**
    * Отключает использование портала
    */
   disablePortal?: boolean;
-
   /**
    * Визуально отключает Dropdown
    */
   disabled?: boolean;
-
   /**
    * Cостояние валидации при ошибке.
    */
@@ -65,12 +64,10 @@ export interface DropdownProps extends CommonProps {
   menuAlign?: 'left' | 'right';
   menuWidth?: number | string;
   size?: ButtonSize;
-
   /**
    * Смотри Button.
    */
   use?: ButtonUse;
-
   /**
    * Вызывается при закрытии меню.
    */
@@ -79,8 +76,17 @@ export interface DropdownProps extends CommonProps {
    * Вызывается при открытии меню.
    */
   onOpen?: () => void;
+  /**
+   * HTML-событие `onmouseenter`.
+   */
   onMouseEnter?: (event: React.MouseEvent<HTMLElement>) => void;
+  /**
+   * HTML-событие `onmouseleave`.
+   */
   onMouseLeave?: (event: React.MouseEvent<HTMLElement>) => void;
+  /**
+   * HTML-событие `onmouseover`.
+   */
   onMouseOver?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -98,66 +104,8 @@ export class Dropdown extends React.Component<DropdownProps> {
   public static Separator = MenuSeparator;
 
   public static propTypes = {
-    /**
-     * Подпись на кнопке.
-     */
-    caption: PropTypes.node.isRequired,
-
-    /**
-     * Отключает использование портала
-     */
-    disablePortal: PropTypes.bool,
-
-    /**
-     * Визуально отключает Dropdown
-     */
-    disabled: PropTypes.bool,
-
-    /**
-     * Визуально показать наличие ошибки.
-     */
-    error: PropTypes.bool,
-
-    /**
-     * Иконка слева от текста кнопки
-     */
-    icon: PropTypes.node,
-
-    maxMenuHeight: PropTypes.number,
-
-    menuAlign: PropTypes.oneOf(['left', 'right']),
-
-    menuWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-
-    /**
-     * Смотри Button.
-     */
-    use: PropTypes.any,
-
-    /**
-     * Визуально показать наличие предупреждения.
-     */
-    warning: PropTypes.bool,
-
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-
-    /**
-     * Вызывается при закрытии меню.
-     */
-    onClose: PropTypes.func,
-
-    onMouseEnter: PropTypes.func,
-
-    onMouseLeave: PropTypes.func,
-
-    onMouseOver: PropTypes.func,
-
-    /**
-     * Вызывается при открытии меню.
-     */
-    onOpen: PropTypes.func,
+    size: pt.oneOf(['small', 'medium', 'large']),
+    width: pt.oneOfType([pt.number, pt.string]),
   };
 
   private _select: Nullable<DropdownSelectType>;

--- a/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
@@ -9,21 +10,25 @@ import { PopupPosition } from '../../internal/Popup';
 import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
 
 export interface DropdownMenuProps extends CommonProps {
-  /** Максимальная высота меню */
+  /**
+   * Максимальная высота меню.
+   */
   menuMaxHeight?: React.CSSProperties['maxWidth'];
-  /** Ширина меню */
+  /**
+   * Ширина меню.
+   */
   menuWidth?: React.CSSProperties['width'];
-  /** Ширина caption */
+  /**
+   * Ширина caption.
+   */
   width?: React.CSSProperties['width'];
-
   /**
    * Элемент или функция возвращающая элемент,
    * если передана, используется вместо `caption`,
    * в таком случае управлять открытием и закрытием меню
-   * придется в этой функции
+   * придется в этой функции.
    */
   caption: PopupMenuProps['caption'];
-
   /**
    * Произвольный элемент, который будет отрендерен в шапке меню.
    *
@@ -45,12 +50,16 @@ export interface DropdownMenuProps extends CommonProps {
    * @default ['bottom left', 'bottom right', 'top left', 'top right']
    */
   positions?: PopupPosition[];
-
-  onOpen?: () => void;
-  onClose?: () => void;
-
   /**
-   * Не показывать анимацию
+   * Функция, вызывающаяся при открытии выпадашки.
+   */
+  onOpen?: () => void;
+  /**
+   * Функция, вызывающаяся при закрытии выпадашки.
+   */
+  onClose?: () => void;
+  /**
+   * Не показывать анимацию.
    */
   disableAnimations: boolean;
 }
@@ -64,6 +73,14 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
   public static defaultProps = {
     disableAnimations: isTestEnv,
     positions: ['bottom left', 'bottom right', 'top left', 'top right'],
+  };
+
+  // TODO: уточнить тип positions, когда #2623 будет смёржен.
+  public static propTypes = {
+    menuMaxHeight: pt.oneOf([pt.string, pt.number]),
+    menuWidth: pt.oneOf([pt.string, pt.number]),
+    width: pt.oneOf([pt.string, pt.number]),
+    caption: pt.oneOfType([pt.node, pt.func]).isRequired,
   };
 
   private popupMenu: Nullable<PopupMenu> = null;

--- a/packages/react-ui/components/FxInput/FxInput.tsx
+++ b/packages/react-ui/components/FxInput/FxInput.tsx
@@ -1,50 +1,60 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 
 import { Button } from '../Button';
 import { Group } from '../Group';
-import { Input, InputProps, InputType } from '../Input';
+import { Input, InputProps, inputType, InputType } from '../Input';
 import { CurrencyInput, CurrencyInputProps } from '../CurrencyInput';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { Override } from '../../typings/utility-types';
 import { FunctionIcon, UndoIcon } from '../../internal/icons/16px';
 import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 
-export interface FxInputProps
-  extends CommonProps,
-    Override<
-      CurrencyInputProps,
-      {
-        /** Авто-режим */
-        auto?: boolean;
-        /** Тип инпута */
-        type?: 'currency' | InputProps['type'];
-        /** onRestore */
-        onRestore?: () => void;
-        /** onValueChange */
-        onValueChange: CurrencyInputProps['onValueChange'] | InputProps['onValueChange'];
-        /** Значение */
-        value?: React.ReactText;
-        /** ref Input'а */
-        refInput?: (element: CurrencyInput | Input | null) => void;
-        /** Убрать лишние нули после запятой */
-        hideTrailingZeros?: boolean;
-      }
-    > {}
+interface FxInputInterface {
+  /**
+   * Авто-режим.
+   */
+  auto?: boolean;
+  /**
+   * Тип инпута.
+   */
+  type?: 'currency' | InputProps['type'];
+  /**
+   * onRestore.
+   */
+  onRestore?: () => void;
+  /**
+   * Функция вызываемая при изменении `value`.
+   */
+  onValueChange: CurrencyInputProps['onValueChange'] | InputProps['onValueChange'];
+  /**
+   * Значение в поле инпута.
+   */
+  value?: React.ReactText;
+  /**
+   * ref Input'а.
+   */
+  refInput?: (element: CurrencyInput | Input | null) => void;
+  /**
+   * Убрать лишние нули после запятой.
+   */
+  hideTrailingZeros?: boolean;
+}
+
+export interface FxInputProps extends CommonProps, Omit<CurrencyInputProps, keyof FxInputInterface>, FxInputInterface {}
 
 /** Принимает все свойства `Input`'a */
 export class FxInput extends React.Component<FxInputProps> {
   public static __KONTUR_REACT_UI__ = 'FxInput';
 
-  public static propTypes = {
-    auto: PropTypes.bool,
-    type: PropTypes.string,
-  };
-
   public static defaultProps = {
     width: 250,
     type: 'text',
     value: '',
+  };
+
+  public static propTypes = {
+    type: pt.oneOf(['currency', ...inputType]),
+    onValueChange: pt.func,
   };
 
   private input: Input | CurrencyInput | null = null;

--- a/packages/react-ui/components/Gapped/Gapped.tsx
+++ b/packages/react-ui/components/Gapped/Gapped.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
 import { is8pxTheme } from '../../lib/theming/ThemeHelpers';
@@ -8,22 +7,22 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 
 export interface GappedProps extends CommonProps {
   /**
-   * Расстояние между элементами в пикселях
+   * Расстояние между элементами в пикселях.
    * @default 8
    */
   gap?: number;
   /**
-   * Вертикальное выравнивание
+   * Вертикальное выравнивание.
    * @default "baseline"
    */
   verticalAlign: 'top' | 'middle' | 'baseline' | 'bottom';
   /**
-   * Расположение элементов по вертикали
+   * Расположение элементов по вертикали.
    * @default false
    */
   vertical: boolean;
   /**
-   * Перенос элементов на новую строку при горизонтальном расположении
+   * Перенос элементов на новую строку при горизонтальном расположении.
    * @default false
    */
   wrap: boolean;
@@ -35,23 +34,6 @@ export interface GappedProps extends CommonProps {
  */
 export class Gapped extends React.Component<GappedProps> {
   public static __KONTUR_REACT_UI__ = 'Gapped';
-
-  public static propTypes = {
-    /**
-     * Расстояние между элементами.
-     */
-    gap: PropTypes.number,
-
-    /**
-     * Располагать элементы вертикально.
-     */
-    vertical: PropTypes.bool,
-
-    /**
-     * Вертикальное выравнивание элементов.
-     */
-    verticalAlign: PropTypes.oneOf(['top', 'middle', 'baseline', 'bottom']),
-  };
 
   private theme!: Theme;
 

--- a/packages/react-ui/components/Group/Group.tsx
+++ b/packages/react-ui/components/Group/Group.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 
 import { isIE11, isEdge } from '../../lib/client';
 import { Corners } from '../Button/Corners';
@@ -23,7 +23,7 @@ export class Group extends React.Component<GroupProps> {
   public static __KONTUR_REACT_UI__ = 'Group';
 
   public static propTypes = {
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    width: pt.oneOfType([pt.number, pt.string]),
   };
 
   public render() {

--- a/packages/react-ui/components/Hint/Hint.tsx
+++ b/packages/react-ui/components/Hint/Hint.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
@@ -110,6 +111,11 @@ export class Hint extends React.Component<HintProps, HintState> {
     maxWidth: 200,
     disableAnimations: isTestEnv,
     useWrapper: false,
+  };
+
+  // TODO: поменять тип pos, когда #2623 будет смёржен.
+  public static propTypes = {
+    maxWidth: pt.oneOf([pt.string, pt.number]),
   };
 
   public state: HintState = {

--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -1,11 +1,12 @@
 import invariant from 'invariant';
 import React from 'react';
 import raf from 'raf';
+import pt from 'prop-types';
 
 import { isIE11, isEdge } from '../../lib/client';
 import { isKeyBackspace, isKeyDelete, someKeys } from '../../lib/events/keyboard/identifiers';
 import { polyfillPlaceholder } from '../../lib/polyfillPlaceholder';
-import { Nullable, Override } from '../../typings/utility-types';
+import { Nullable } from '../../typings/utility-types';
 import { MaskedInput } from '../../internal/MaskedInput';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -14,91 +15,118 @@ import { cx } from '../../lib/theming/Emotion';
 
 import { styles } from './Input.styles';
 
-export type InputSize = 'small' | 'medium' | 'large';
+export const inputSize = ['small', 'medium', 'large'] as const;
+export type InputSize = typeof inputSize[number];
 export type InputAlign = 'left' | 'center' | 'right';
-export type InputType = 'password' | 'text';
+export const inputType = ['password', 'text'] as const;
+export type InputType = typeof inputType[number];
 export type InputIconType = React.ReactNode | (() => React.ReactNode);
+
+interface InputInterface {
+  /**
+   * Иконка слева
+   * Если `ReactNode` применяются дефолтные стили для иконки
+   * Если `() => ReactNode` применяются только стили для позиционирование
+   */
+  leftIcon?: InputIconType;
+  /**
+   * Иконка справа
+   * Если `ReactNode` применяются дефолтные стили для иконки
+   * Если `() => ReactNode` применяются только стили для позиционирование
+   */
+  rightIcon?: InputIconType;
+  /**
+   * Cостояние валидации при ошибке.
+   */
+  error?: boolean;
+  /**
+   * Cостояние валидации при предупреждении.
+   */
+  warning?: boolean;
+  /**
+   * Режим прозрачной рамки.
+   */
+  borderless?: boolean;
+  /**
+   * Выравнивание текста.
+   */
+  align?: InputAlign;
+  /**
+   * Паттерн маски.
+   */
+  mask?: Nullable<string>;
+  /**
+   * Символ маски.
+   */
+  maskChar?: Nullable<string>;
+  /**
+   * Словарь символов-регулярок для задания маски
+   * @default { '9': '[0-9]', 'a': '[A-Za-z]', '*': '[A-Za-z0-9]' }
+   */
+  formatChars?: Record<string, string>;
+  /**
+   * Показывать символы маски.
+   */
+  alwaysShowMask?: boolean;
+  /**
+   * Размер инпута.
+   */
+  size?: InputSize;
+  /**
+   * Функция вызываемая при изменении значения.
+   */
+  onValueChange?: (value: string) => void;
+  /**
+   * HTML-событие `onmouseenter`.
+   */
+  onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-событие `onmouseleave`.
+   */
+  onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-событие `onmouseover`.
+   */
+  onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * Меняет тип инпута.
+   */
+  type?: InputType;
+  /**
+   * Значение в поле инпута.
+   */
+  value?: string;
+  capture?: boolean;
+  /**
+   * Префикс
+   * `ReactNode` перед значением, но после иконки.
+   */
+  prefix?: React.ReactNode;
+  /**
+   * Суффикс
+   * `ReactNode` после значения, но перед правой иконкой.
+   */
+  suffix?: React.ReactNode;
+  /**
+   * Выделять введенное значение при фокусе.
+   */
+  selectAllOnFocus?: boolean;
+  /**
+   * Обработчик неправильного ввода.
+   * По-умолчанию, инпут вспыхивает синим.
+   * Если передан - вызывается переданный обработчик,
+   * в таком случае вспыхивание можно вызвать
+   * публичным методом инстанса `blink()`.
+   *
+   * @param value значение инпута.
+   */
+  onUnexpectedInput?: (value: string) => void;
+}
 
 export interface InputProps
   extends CommonProps,
-    Override<
-      React.InputHTMLAttributes<HTMLInputElement>,
-      {
-        /**
-         * Иконка слева
-         * Если `ReactNode` применяются дефолтные стили для иконки
-         * Если `() => ReactNode` применяются только стили для позиционирование
-         */
-        leftIcon?: InputIconType;
-        /**
-         * Иконка справа
-         * Если `ReactNode` применяются дефолтные стили для иконки
-         * Если `() => ReactNode` применяются только стили для позиционирование
-         */
-        rightIcon?: InputIconType;
-        /**
-         * Cостояние валидации при ошибке.
-         */
-        error?: boolean;
-        /**
-         * Cостояние валидации при предупреждении.
-         */
-        warning?: boolean;
-        /** Режим прозрачной рамки */
-        borderless?: boolean;
-        /** Выравнивание текста */
-        align?: InputAlign;
-        /** Паттерн маски */
-        mask?: Nullable<string>;
-        /** Символ маски */
-        maskChar?: Nullable<string>;
-        /**
-         * Словарь символов-регулярок для задания маски
-         * @default { '9': '[0-9]', 'a': '[A-Za-z]', '*': '[A-Za-z0-9]' }
-         */
-        formatChars?: Record<string, string>;
-        /** Показывать символы маски */
-        alwaysShowMask?: boolean;
-        /** Размер */
-        size?: InputSize;
-        /** onValueChange */
-        onValueChange?: (value: string) => void;
-        /** Вызывается на label */
-        onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
-        /** Вызывается на label */
-        onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
-        /** Вызывается на label */
-        onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
-        /** Тип */
-        type?: InputType;
-        /** Значение */
-        value?: string;
-        capture?: boolean;
-
-        /**
-         * Префикс
-         * `ReactNode` перед значением, но после иконки
-         */
-        prefix?: React.ReactNode;
-        /**
-         * Суффикс
-         * `ReactNode` после значения, но перед правой иконкой
-         */
-        suffix?: React.ReactNode;
-        /** Выделять введенное значение при фокусе */
-        selectAllOnFocus?: boolean;
-        /**
-         * Обработчик неправильного ввода.
-         * По-умолчанию, инпут вспыхивает синим.
-         * Если передан - вызывается переданный обработчик,
-         * в таком случае вспыхивание можно вызвать
-         * публичным методом инстанса `blink()`.
-         *
-         * @param value значение инпута.
-         */
-        onUnexpectedInput?: (value: string) => void;
-      }
-    > {}
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, keyof InputInterface>,
+    InputInterface {}
 
 export interface InputState {
   blinking: boolean;
@@ -117,6 +145,12 @@ export class Input extends React.Component<InputProps, InputState> {
     size: InputSize;
   } = {
     size: 'small',
+  };
+
+  public static propTypes = {
+    mask: pt.oneOf([pt.string, null, undefined]),
+    maskChar: pt.oneOf([pt.string, null, undefined]),
+    type: pt.oneOf(inputType),
   };
 
   public state: InputState = {

--- a/packages/react-ui/components/Kebab/Kebab.tsx
+++ b/packages/react-ui/components/Kebab/Kebab.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { isKeyArrowVertical, isKeyEnter, isKeySpace, someKeys } from '../../lib/events/keyboard/identifiers';
 import * as LayoutEvents from '../../lib/LayoutEvents';
@@ -17,6 +16,7 @@ import { cx } from '../../lib/theming/Emotion';
 
 import { styles } from './Kebab.styles';
 
+// TODO: поправить тип positions после мержа #2623.
 export interface KebabProps extends CommonProps {
   disabled?: boolean;
   /**
@@ -29,6 +29,9 @@ export interface KebabProps extends CommonProps {
    * @default () => undefined
    */
   onOpen: () => void;
+  /**
+   * Размер кебаба.
+   */
   size: 'small' | 'medium' | 'large';
   /**
    * Список позиций доступных для расположения выпадашки.
@@ -58,8 +61,6 @@ export interface KebabState {
 
 export class Kebab extends React.Component<KebabProps, KebabState> {
   public static __KONTUR_REACT_UI__ = 'Kebab';
-
-  public static propTypes = {};
 
   public static defaultProps = {
     onOpen: () => undefined,
@@ -231,24 +232,3 @@ export class Kebab extends React.Component<KebabProps, KebabState> {
     );
   }
 }
-
-Kebab.propTypes = {
-  children: PropTypes.node,
-  disabled: PropTypes.bool,
-  menuMaxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-  /**
-   * Размер кебаба small 14px | large 20px
-   */
-  size: PropTypes.string,
-
-  /**
-   * Коллбек, вызывающийся перед закрытием кебаба
-   */
-  onClose: PropTypes.func,
-
-  /**
-   * Коллбек, вызывающийся перед открытием кебаба
-   */
-  onOpen: PropTypes.func,
-};

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Override } from '../../typings/utility-types';
 import { keyListener } from '../../lib/events/keyListener';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -12,49 +10,48 @@ import { cx } from '../../lib/theming/Emotion';
 
 import { styles } from './Link.styles';
 
-export interface LinkProps
-  extends CommonProps,
-    Override<
-      React.AnchorHTMLAttributes<HTMLAnchorElement>,
-      {
-        /**
-         * Отключенное состояние.
-         */
-        disabled?: boolean;
-        /**
-         * HTML-атрибут `href`.
-         */
-        href?: string;
-        /**
-         * Добавляет ссылке иконку.
-         */
-        icon?: React.ReactElement<any>;
-        /**
-         * Тема ссылки.
-         */
-        use?: 'default' | 'success' | 'danger' | 'grayed';
-        /**
-         * @ignore
-         */
-        _button?: boolean;
-        /**
-         * @ignore
-         */
-        _buttonOpened?: boolean;
-        /**
-         * HTML-атрибут `tabindex`.
-         */
-        tabIndex?: number;
-        /**
-         * Переводит ссылку в состояние загрузки.
-         */
-        loading?: boolean;
-        /**
-         * HTML-событие `onclick`.
-         */
-        onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
-      }
-    > {}
+interface LinkInterface {
+  /**
+   * Отключенное состояние.
+   */
+  disabled?: boolean;
+  /**
+   * HTML-атрибут `href`.
+   */
+  href?: string;
+  /**
+   * Добавляет ссылке иконку.
+   */
+  icon?: React.ReactElement<any>;
+  /**
+   * Тема ссылки.
+   */
+  use?: 'default' | 'success' | 'danger' | 'grayed';
+  /**
+   * @ignore
+   */
+  _button?: boolean;
+  /**
+   * @ignore
+   */
+  _buttonOpened?: boolean;
+  /**
+   * HTML-атрибут `tabindex`.
+   */
+  tabIndex?: number;
+  /**
+   * Переводит ссылку в состояние загрузки.
+   */
+  loading?: boolean;
+  /**
+   * HTML-событие `onclick`.
+   */
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+}
+
+export type LinkProps = CommonProps &
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkInterface> &
+  LinkInterface;
 
 export interface LinkState {
   focusedByTab: boolean;
@@ -65,16 +62,6 @@ export interface LinkState {
  */
 export class Link extends React.Component<LinkProps, LinkState> {
   public static __KONTUR_REACT_UI__ = 'Link';
-
-  public static propTypes = {
-    disabled: PropTypes.bool,
-
-    href: PropTypes.string,
-
-    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-
-    use: PropTypes.oneOf(['default', 'success', 'danger', 'grayed']),
-  };
 
   public static defaultProps = {
     href: '',

--- a/packages/react-ui/components/Loader/Loader.tsx
+++ b/packages/react-ui/components/Loader/Loader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 
 import * as LayoutEvents from '../../lib/LayoutEvents';
@@ -19,7 +18,7 @@ import { styles } from './Loader.styles';
 export interface LoaderProps extends CommonProps {
   children?: React.ReactNode;
   /**
-   * Флаг переключения состояния лоадера
+   * Флаг переключения состояния лоадера.
    * @default false
    */
   active: boolean;
@@ -36,7 +35,7 @@ export interface LoaderProps extends CommonProps {
    */
   delayBeforeSpinnerShow: number;
   /**
-   * Минимальное время в миллисекундах для показа спиннера
+   * Минимальное время в миллисекундах для показа спиннера.
    * @default 1000
    */
   minimalDelayBeforeSpinnerHide: number;
@@ -63,43 +62,7 @@ export class Loader extends React.Component<LoaderProps, LoaderState> {
   };
 
   public static propTypes = {
-    /**
-     * показываем лоадер или нет
-     */
-    active: PropTypes.bool,
-
-    /**
-     * Текст рядом с лоадером.
-     *
-     * @default  "Загрузка"
-     */
     caption: Spinner.propTypes.caption,
-
-    component: PropTypes.node,
-
-    /**
-     * Класс для обертки
-     */
-    className: PropTypes.string,
-
-    /**
-     * Тип спиннера: mini, normal, big
-     *
-     * @default  normal
-     *
-     * Spinner.types - все доступные типы
-     */
-    type: PropTypes.oneOf(Object.keys(Spinner.Types)),
-    /**
-     * Время в миллисекундах для показа вуали без спиннера.
-     * @default 300
-     */
-    delayBeforeSpinnerShow: PropTypes.number,
-    /**
-     * Минимальное время в миллисекундах для показа спиннера
-     * @default 1000
-     */
-    minimalDelayBeforeSpinnerHide: PropTypes.number,
   };
 
   private theme!: Theme;

--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 
 import { isFunction } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -84,21 +84,10 @@ export class MenuItem extends React.Component<MenuItemProps> {
   public static __MENU_ITEM__ = true;
 
   public static propTypes = {
-    comment: PropTypes.node,
-
-    disabled: PropTypes.bool,
-
-    href: PropTypes.string,
-
-    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-
-    loose: PropTypes.bool,
-
-    state: PropTypes.string,
-
-    target: PropTypes.string,
-
-    onClick: PropTypes.func,
+    target: pt.string,
+    title: pt.string,
+    href: pt.string,
+    state: pt.oneOf([null, 'hover', 'selected']),
   };
 
   private theme!: Theme;

--- a/packages/react-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-ui/components/PasswordInput/PasswordInput.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { isKeyCapsLock } from '../../lib/events/keyboard/identifiers';
 import { KeyboardEventCodes as Codes } from '../../lib/events/keyboard/KeyboardEventCodes';
@@ -28,13 +27,6 @@ export interface PasswordInputState {
  */
 export class PasswordInput extends React.Component<PasswordInputProps, PasswordInputState> {
   public static __KONTUR_REACT_UI__ = 'PasswordInput';
-
-  public static propTypes = {
-    /**
-     * Включает CapsLock детектор
-     */
-    detectCapsLock: PropTypes.bool,
-  };
 
   public static defaultProps = {
     size: 'small',

--- a/packages/react-ui/components/Radio/Radio.tsx
+++ b/packages/react-ui/components/Radio/Radio.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Override } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
@@ -10,45 +8,44 @@ import { keyListener } from '../../lib/events/keyListener';
 
 import { styles, globalClasses } from './Radio.styles';
 
-export interface RadioProps<T>
-  extends CommonProps,
-    Override<
-      React.InputHTMLAttributes<HTMLInputElement>,
-      {
-        /**
-         *  Cостояние валидации при ошибке.
-         */
-        error?: boolean;
-        /**
-         * Cостояние валидации при предупреждении.
-         */
-        warning?: boolean;
-        /**
-         * Состояние фокуса.
-         */
-        focused?: boolean;
-        /**
-         * Функция, вызываемая при изменении `value`.
-         */
-        onValueChange?: (value: T) => void;
-        /**
-         * HTML-событие `onmouseenter`
-         */
-        onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
-        /**
-         * HTML-событие `mouseleave`
-         */
-        onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
-        /**
-         * HTML-событие `onmouseover`
-         */
-        onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
-        /**
-         * HTML-атрибут `value`.
-         */
-        value: T;
-      }
-    > {}
+interface RadioInterface<T> {
+  /**
+   *  Cостояние валидации при ошибке.
+   */
+  error?: boolean;
+  /**
+   * Cостояние валидации при предупреждении.
+   */
+  warning?: boolean;
+  /**
+   * Состояние фокуса.
+   */
+  focused?: boolean;
+  /**
+   * Функция, вызываемая при изменении `value`.
+   */
+  onValueChange?: (value: T) => void;
+  /**
+   * HTML-событие `onmouseenter`
+   */
+  onMouseEnter?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-событие `mouseleave`
+   */
+  onMouseLeave?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-событие `onmouseover`
+   */
+  onMouseOver?: React.MouseEventHandler<HTMLLabelElement>;
+  /**
+   * HTML-атрибут `value`.
+   */
+  value: T;
+}
+
+export type RadioProps<T> = CommonProps &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, keyof RadioInterface<T>> &
+  RadioInterface<T>;
 
 export interface RadioState {
   focusedByKeyboard: boolean;
@@ -62,15 +59,6 @@ export class Radio<T> extends React.Component<RadioProps<T>, RadioState> {
 
   public state = {
     focusedByKeyboard: false,
-  };
-
-  public static contextTypes = {
-    activeItem: PropTypes.any,
-    onSelect: PropTypes.func,
-    name: PropTypes.string,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    warning: PropTypes.bool,
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react-ui/components/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 import invariant from 'invariant';
 
 import { getRandomID } from '../../lib/utils';
@@ -93,26 +93,16 @@ export class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGrou
   public static __KONTUR_REACT_UI__ = 'RadioGroup';
 
   public static childContextTypes = {
-    error: PropTypes.bool,
-    name: PropTypes.string,
-    warning: PropTypes.bool,
-    disabled: PropTypes.bool,
-    activeItem: PropTypes.any,
-    onSelect: PropTypes.func,
+    error: pt.bool,
+    name: pt.string,
+    warning: pt.bool,
+    disabled: pt.bool,
+    activeItem: pt.any,
+    onSelect: pt.func,
   };
 
   public static propTypes = {
-    children: PropTypes.node,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    inline: PropTypes.bool,
-    name: PropTypes.string,
-    warning: PropTypes.bool,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    onBlur: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
+    width: pt.oneOfType([pt.number, pt.string]),
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
@@ -47,12 +47,8 @@ export class ScrollContainer extends React.Component<ScrollContainerProps> {
   public static __KONTUR_REACT_UI__ = 'ScrollContainer';
 
   public static propTypes = {
-    invert: PropTypes.bool,
-    maxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    scrollBehaviour: PropTypes.oneOf(['auto', 'smooth']),
-    preventWindowScroll: PropTypes.bool,
-    onScrollStateChange: PropTypes.func,
+    maxWidth: pt.oneOf([pt.string, pt.number]),
+    maxHeight: pt.oneOf([pt.string, pt.number]),
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 import ReactDOM from 'react-dom';
 import invariant from 'invariant';
 
@@ -153,26 +153,8 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
   public static __KONTUR_REACT_UI__ = 'Select';
 
   public static propTypes = {
-    areValuesEqual: PropTypes.func,
-    defaultValue: PropTypes.any,
-    disablePortal: PropTypes.bool,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    filterItem: PropTypes.func,
-    items: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
-    maxMenuHeight: PropTypes.number,
-    maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    placeholder: PropTypes.node,
-    renderItem: PropTypes.func,
-    renderValue: PropTypes.func,
-    search: PropTypes.bool,
-    value: PropTypes.any,
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    onValueChange: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
-    onKeyDown: PropTypes.func,
+    items: pt.oneOfType([pt.array, pt.object]),
+    maxWidth: pt.oneOfType([pt.number, pt.string]),
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/Spinner/Spinner.tsx
+++ b/packages/react-ui/components/Spinner/Spinner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import pt from 'prop-types';
 
 import { locale } from '../../lib/locale/decorators';
 import { Theme } from '../../lib/theming/Theme';
@@ -37,28 +37,12 @@ export interface SpinnerProps extends CommonProps {
 export class Spinner extends React.Component<SpinnerProps> {
   public static __KONTUR_REACT_UI__ = 'Spinner';
 
-  public static propTypes = {
-    /**
-     * Текст рядом с мини-лоадером.
-     *
-     * 'Загрузка' - значение по-умолчанию
-     */
-    caption: PropTypes.node,
-
-    dimmed: PropTypes.bool,
-
-    /**
-     * Тип спиннера: mini, normal, big
-     *
-     * Значение по-умолчанию - normal
-     *
-     * Spinner.types - все доступные типы
-     */
-    type: PropTypes.oneOf(Object.keys(types)),
-  };
-
   public static defaultProps: SpinnerProps = {
     type: 'normal',
+  };
+
+  public static propTypes = {
+    caption: pt.node,
   };
 
   public static Types: typeof types = types;

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import shallowEqual from 'shallowequal';
 
 import * as LayoutEvents from '../../lib/LayoutEvents';
@@ -36,22 +35,6 @@ export interface StickyState {
 
 export class Sticky extends React.Component<StickyProps, StickyState> {
   public static __KONTUR_REACT_UI__ = 'Sticky';
-
-  public static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-
-    /**
-     * Функция, которая возвращает DOM-элемент, который нельзя пересекать.
-     */
-    getStop: PropTypes.func,
-
-    /**
-     * Отступ от границы в пикселях
-     */
-    offset: PropTypes.number,
-
-    side: PropTypes.oneOf(['top', 'bottom']).isRequired,
-  };
 
   public static defaultProps = { offset: 0 };
 

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { isKeyArrowHorizontal, isKeyArrowLeft, isKeyEnter } from '../../lib/events/keyboard/identifiers';
 import { Group } from '../Group';
@@ -46,23 +45,6 @@ interface SwitcherItem {
 
 export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
   public static __KONTUR_REACT_UI__ = 'Switcher';
-
-  public static propTypes = {
-    error: PropTypes.bool,
-    disabled: PropTypes.bool,
-    items: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.arrayOf(
-        PropTypes.shape({
-          label: PropTypes.string,
-          value: PropTypes.string,
-        }),
-      ),
-    ]).isRequired,
-    label: PropTypes.string,
-    value: PropTypes.string,
-    onValueChange: PropTypes.func,
-  };
 
   public state: SwitcherState = {
     focusedIndex: null,

--- a/packages/react-ui/components/Tabs/Tab.tsx
+++ b/packages/react-ui/components/Tabs/Tab.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import invariant from 'invariant';
 
 import { ResizeDetector } from '../../internal/ResizeDetector';
@@ -78,11 +77,6 @@ export interface TabProps<T extends string = string> extends CommonProps {
    * Primary indicator
    */
   primary?: boolean;
-
-  /**
-   * Style property
-   */
-  style?: React.CSSProperties;
 }
 
 export interface TabState {
@@ -109,14 +103,6 @@ export class Tab<T extends string = string> extends React.Component<TabProps<T>,
 
   public static contextType = TabsContext;
   public context: TabsContextType = this.context;
-
-  public static propTypes = {
-    children: PropTypes.node,
-    disabled: PropTypes.bool,
-    href: PropTypes.string.isRequired,
-    onClick: PropTypes.func,
-    onKeyDown: PropTypes.func,
-  };
 
   public static defaultProps = {
     component: 'a',

--- a/packages/react-ui/components/Tabs/Tabs.tsx
+++ b/packages/react-ui/components/Tabs/Tabs.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
-import PropTypes from 'prop-types';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -53,13 +52,6 @@ export interface TabsProps<T extends string = string> extends CommonProps {
 export class Tabs<T extends string = string> extends React.Component<TabsProps<T>> {
   public static __KONTUR_REACT_UI__ = 'Tabs';
 
-  public static propTypes = {
-    children: PropTypes.node,
-    indicatorClassName: PropTypes.string,
-    value: PropTypes.string.isRequired,
-    vertical: PropTypes.bool,
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  };
   public static defaultProps = {
     vertical: false,
   };

--- a/packages/react-ui/components/Textarea/Textarea.tsx
+++ b/packages/react-ui/components/Textarea/Textarea.tsx
@@ -1,12 +1,11 @@
 import React, { ReactNode } from 'react';
-import PropTypes from 'prop-types';
 import throttle from 'lodash.throttle';
 import raf from 'raf';
 
 import { isKeyEnter } from '../../lib/events/keyboard/identifiers';
 import { polyfillPlaceholder } from '../../lib/polyfillPlaceholder';
 import * as LayoutEvents from '../../lib/LayoutEvents';
-import { Nullable, Override } from '../../typings/utility-types';
+import { Nullable } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { RenderLayer } from '../../internal/RenderLayer';
@@ -23,87 +22,86 @@ import { TextareaCounter, TextareaCounterRef } from './TextareaCounter';
 const DEFAULT_WIDTH = 250;
 const AUTORESIZE_THROTTLE_DEFAULT_WAIT = 100;
 
-export interface TextareaProps
-  extends CommonProps,
-    Override<
-      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-      {
-        /**
-         * Cостояние валидации при ошибке.
-         */
-        error?: boolean;
-        /**
-         * Cостояние валидации при предупреждении.
-         */
-        warning?: boolean;
-        /** Не активное состояние */
-        disabled?: boolean;
+interface TextareaInterface {
+  /**
+   * Cостояние валидации при ошибке.
+   */
+  error?: boolean;
+  /**
+   * Cостояние валидации при предупреждении.
+   */
+  warning?: boolean;
+  /** Не активное состояние */
+  disabled?: boolean;
 
-        /**
-         * Атоматический ресайз
-         * в зависимости от содержимого
-         */
-        autoResize?: boolean;
-        /**
-         * Число строк
-         */
-        rows: number;
-        /**
-         * Максимальное число строк при
-         * автоматическом ресайзе
-         */
-        maxRows: string | number;
+  /**
+   * Атоматический ресайз
+   * в зависимости от содержимого
+   */
+  autoResize?: boolean;
+  /**
+   * Число строк
+   */
+  rows: number;
+  /**
+   * Максимальное число строк при
+   * автоматическом ресайзе
+   */
+  maxRows: string | number;
 
-        /**
-         * Стандартный ресайз
-         * Попадает в `style`
-         */
-        resize?: React.CSSProperties['resize'];
+  /**
+   * Стандартный ресайз
+   * Попадает в `style`
+   */
+  resize?: React.CSSProperties['resize'];
 
-        /**
-         * Ширина
-         */
-        width?: React.CSSProperties['width'];
+  /**
+   * Ширина
+   */
+  width?: React.CSSProperties['width'];
 
-        /**
-         * Вызывается при изменении `value`
-         */
-        onValueChange?: (value: string) => void;
+  /**
+   * Вызывается при изменении `value`
+   */
+  onValueChange?: (value: string) => void;
 
-        /** Выделение значения при фокусе */
-        selectAllOnFocus?: boolean;
+  /** Выделение значения при фокусе */
+  selectAllOnFocus?: boolean;
 
-        /** Показывать счетчик символов */
-        showLengthCounter?: boolean;
+  /** Показывать счетчик символов */
+  showLengthCounter?: boolean;
 
-        /** Допустимое количество символов в поле. Отображается в счетчике.
-         * Если не указано, равно `maxLength`
-         */
-        lengthCounter?: number;
+  /** Допустимое количество символов в поле. Отображается в счетчике.
+   * Если не указано, равно `maxLength`
+   */
+  lengthCounter?: number;
 
-        /** Подсказка к счетчику символов.
-         *
-         * По умолчанию - тултип с содежимым из пропа, если передан`ReactNode`.
-         *
-         * Передав функцию, можно переопределить подсказку целиком, вместе с иконкой. Например,
-         *
-         * ```
-         * counterHelp={() => <Tooltip render={...}><HelpIcon /></Tooltip>}
-         * ```
-         * */
-        counterHelp?: ReactNode | (() => ReactNode);
+  /** Подсказка к счетчику символов.
+   *
+   * По умолчанию - тултип с содежимым из пропа, если передан`ReactNode`.
+   *
+   * Передав функцию, можно переопределить подсказку целиком, вместе с иконкой. Например,
+   *
+   * ```
+   * counterHelp={() => <Tooltip render={...}><HelpIcon /></Tooltip>}
+   * ```
+   * */
+  counterHelp?: ReactNode | (() => ReactNode);
 
-        /** Добавлять дополнительную свободную строку при авто-ресайзе.
-         * @see https://guides.kontur.ru/components/textarea/#04
-         * */
-        extraRow: boolean;
+  /** Добавлять дополнительную свободную строку при авто-ресайзе.
+   * @see https://guides.kontur.ru/components/textarea/#04
+   * */
+  extraRow: boolean;
 
-        /** Отключать анимацию при авто-ресайзе.
-         * Автоматически отключается когда в `extraRow` передан `false`.
-         */
-        disableAnimations: boolean;
-      }
-    > {}
+  /** Отключать анимацию при авто-ресайзе.
+   * Автоматически отключается когда в `extraRow` передан `false`.
+   */
+  disableAnimations: boolean;
+}
+
+export type TextareaProps = CommonProps &
+  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, keyof TextareaInterface> &
+  TextareaInterface;
 
 export interface TextareaState {
   polyfillPlaceholder: boolean;
@@ -119,60 +117,6 @@ export interface TextareaState {
  */
 export class Textarea extends React.Component<TextareaProps, TextareaState> {
   public static __KONTUR_REACT_UI__ = 'Textarea';
-
-  public static propTypes = {
-    error: PropTypes.bool,
-    warning: PropTypes.bool,
-    disabled: PropTypes.bool,
-
-    autoResize: PropTypes.bool,
-    extraRow: PropTypes.bool,
-    disableAnimations: PropTypes.bool,
-    maxRows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    resize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-
-    id: PropTypes.string,
-    name: PropTypes.string,
-    title: PropTypes.string,
-    spellCheck: PropTypes.bool,
-    role: PropTypes.string,
-    maxLength: PropTypes.number,
-    tabIndex: PropTypes.number,
-    rows: PropTypes.number,
-    placeholder: PropTypes.string,
-
-    value: PropTypes.string,
-    defaultValue: PropTypes.string,
-    onValueChange: PropTypes.func,
-
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    onMouseOver: PropTypes.func,
-    onMouseMove: PropTypes.func,
-    onMouseOut: PropTypes.func,
-
-    onMouseUp: PropTypes.func,
-    onMouseDown: PropTypes.func,
-    onClick: PropTypes.func,
-    onDoubleClick: PropTypes.func,
-
-    onKeyDown: PropTypes.func,
-    onKeyPress: PropTypes.func,
-    onKeyUp: PropTypes.func,
-    onInput: PropTypes.func,
-
-    onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
-
-    onScroll: PropTypes.func,
-    onWheel: PropTypes.func,
-
-    onCut: PropTypes.func,
-    onPaste: PropTypes.func,
-    onCopy: PropTypes.func,
-  };
 
   public static defaultProps = {
     rows: 3,

--- a/packages/react-ui/components/Toggle/Toggle.tsx
+++ b/packages/react-ui/components/Toggle/Toggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+// import pt from 'prop-types';
 import warning from 'warning';
 
 import { keyListener } from '../../lib/events/keyListener';
@@ -88,13 +88,6 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
   public static __KONTUR_REACT_UI__ = 'Toggle';
 
   public static propTypes = {
-    checked: PropTypes.bool,
-    defaultChecked: PropTypes.bool,
-    disabled: PropTypes.bool,
-    error: PropTypes.bool,
-    loading: PropTypes.bool,
-    warning: PropTypes.bool,
-    onValueChange: PropTypes.func,
     color(props: ToggleProps) {
       if (props.color && !colorWarningShown) {
         warning(false, `[Toggle]: prop 'color' is deprecated. Please, use theme variable 'toggleBgChecked' instead. `);

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, FocusEvent, FocusEventHandler, KeyboardEvent, MouseEventHandler, ReactNode } from 'react';
+import pt from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import isEqual from 'lodash.isequal';
 
@@ -189,6 +190,10 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     onMouseLeave: emptyHandler,
     menuWidth: 'auto',
     menuAlign: 'cursor',
+  };
+
+  public static propTypes = {
+    menuWidth: pt.oneOf([pt.string, pt.number]),
   };
 
   public state: TokenInputState<T> = DefaultState;

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -49,6 +49,7 @@ export type TooltipTrigger =
   /** Управление через публичные функции show и hide */
   | 'manual';
 
+// TODO: изменить типы pos и allowedPositions после мержа #2623.
 export interface TooltipProps extends CommonProps {
   /**
    * Относительно какого элемента позиционировать тултип

--- a/packages/react-ui/components/TooltipMenu/TooltipMenu.tsx
+++ b/packages/react-ui/components/TooltipMenu/TooltipMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -66,6 +67,11 @@ export class TooltipMenu extends React.Component<TooltipMenuProps> {
   public static defaultProps = {
     disableAnimations: isTestEnv,
   };
+
+  public static propTypes = {
+    caption: pt.oneOfType([pt.node, pt.func]).isRequired,
+  };
+
   constructor(props: TooltipMenuProps) {
     super(props);
 

--- a/packages/react-ui/internal/Calendar/Calendar.tsx
+++ b/packages/react-ui/internal/Calendar/Calendar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 import normalizeWheel from 'normalize-wheel';
 import throttle from 'lodash.throttle';
 
@@ -15,7 +16,7 @@ import { MonthViewModel } from './MonthViewModel';
 import * as CalendarScrollEvents from './CalendarScrollEvents';
 import { Month } from './Month';
 import { styles } from './Calendar.styles';
-import { CalendarDateShape, create, isGreater, isLess } from './CalendarDateShape';
+import { CalendarDateShape, create, isGreater, isLess, ptDateShape } from './CalendarDateShape';
 
 export interface CalendarProps {
   initialMonth?: number;
@@ -60,6 +61,12 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
       month: MAX_MONTH,
       date: MAX_DATE,
     },
+  };
+
+  public static propTypes = {
+    value: pt.oneOf([ptDateShape, null, undefined]),
+    minDate: ptDateShape,
+    maxDate: ptDateShape,
   };
 
   private theme!: Theme;

--- a/packages/react-ui/internal/Calendar/CalendarDateShape.ts
+++ b/packages/react-ui/internal/Calendar/CalendarDateShape.ts
@@ -1,3 +1,5 @@
+import pt from 'prop-types';
+
 import { Nullable } from '../../typings/utility-types';
 
 export interface CalendarDateShape {
@@ -5,6 +7,12 @@ export interface CalendarDateShape {
   month: number;
   date: number;
 }
+
+export const ptDateShape = {
+  year: pt.number,
+  month: pt.number,
+  date: pt.number,
+};
 
 export const isEqual = (a: Nullable<CalendarDateShape>, b: Nullable<CalendarDateShape>) =>
   (!a && !b) || (a && b && a.year === b.year && a.month === b.month && a.date === b.date);

--- a/packages/react-ui/internal/Calendar/DayCellView.tsx
+++ b/packages/react-ui/internal/Calendar/DayCellView.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import pt from 'prop-types';
 
 import { Nullable } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -6,6 +7,7 @@ import { cx } from '../../lib/theming/Emotion';
 
 import * as CDS from './CalendarDateShape';
 import { styles } from './DayCellView.styles';
+import { ptDateShape } from '.';
 
 interface DayCellViewProps {
   date: CDS.CalendarDateShape;
@@ -42,3 +44,11 @@ export function DayCellView(props: DayCellViewProps) {
     </button>
   );
 }
+
+DayCellView.propTypes = {
+  date: ptDateShape,
+  today: ptDateShape,
+  value: pt.oneOf([ptDateShape, null, undefined]),
+  minDate: ptDateShape,
+  maxDate: ptDateShape,
+};

--- a/packages/react-ui/internal/Calendar/Month.tsx
+++ b/packages/react-ui/internal/Calendar/Month.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -12,6 +13,7 @@ import { DayCellViewModel } from './DayCellViewModel';
 import { MonthView } from './MonthView';
 import { DayCellView } from './DayCellView';
 import * as CalendarScrollEvents from './CalendarScrollEvents';
+import { ptDateShape } from './CalendarDateShape';
 
 interface MonthProps {
   top: number;
@@ -30,6 +32,13 @@ export class Month extends React.Component<MonthProps> {
 
   private monthSelect: DateSelect | null = null;
   private yearSelect: DateSelect | null = null;
+
+  public static propTypes = {
+    minDate: ptDateShape,
+    maxDate: ptDateShape,
+    today: ptDateShape,
+    value: pt.oneOf([ptDateShape, null, undefined]),
+  };
 
   public shouldComponentUpdate(nextProps: MonthProps) {
     if (this.props.top !== nextProps.top) {

--- a/packages/react-ui/internal/Calendar/MonthView.tsx
+++ b/packages/react-ui/internal/Calendar/MonthView.tsx
@@ -8,6 +8,7 @@ import { cx } from '../../lib/theming/Emotion';
 import { styles } from './MonthView.styles';
 import { themeConfig } from './config';
 import * as CDS from './CalendarDateShape';
+import { ptDateShape } from './CalendarDateShape';
 
 interface MonthViewProps {
   children: React.ReactNode;
@@ -119,3 +120,8 @@ export function MonthView(props: MonthViewProps) {
     </div>
   );
 }
+
+MonthView.propTypes = {
+  minDate: ptDateShape,
+  maxDate: ptDateShape,
+};

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxMenu.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxMenu.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import pt from 'prop-types';
 
 import { locale } from '../../lib/locale/decorators';
 import { isReactUINode } from '../../lib/utils';
@@ -35,6 +36,10 @@ export class ComboBoxMenu<T> extends Component<ComboBoxMenuProps<T>> {
   public static defaultProps = {
     repeatRequest: () => undefined,
     requestStatus: ComboBoxRequestStatus.Unknown,
+  };
+
+  public static propTypes = {
+    items: pt.arrayOf(pt.any),
   };
 
   private readonly locale!: ComboBoxLocale;

--- a/packages/react-ui/internal/DateSelect/DateSelect.tsx
+++ b/packages/react-ui/internal/DateSelect/DateSelect.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { isKeyEscape } from '../../lib/events/keyboard/identifiers';
 import { DatePickerLocale, DatePickerLocaleHelper } from '../../components/DatePicker/locale';
@@ -47,22 +46,6 @@ export interface DateSelectState {
 @locale('DatePicker', DatePickerLocaleHelper)
 export class DateSelect extends React.Component<DateSelectProps, DateSelectState> {
   public static __KONTUR_REACT_UI__ = 'DateSelect';
-
-  public static propTypes = {
-    disabled: PropTypes.bool,
-
-    type: PropTypes.string,
-
-    value: PropTypes.number.isRequired,
-
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-
-    onValueChange: PropTypes.func,
-
-    minValue: PropTypes.number,
-
-    maxValue: PropTypes.number,
-  };
 
   public static defaultProps = {
     type: 'year',

--- a/packages/react-ui/internal/InputLikeText/HiddenInput.tsx
+++ b/packages/react-ui/internal/InputLikeText/HiddenInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { css } from '../../lib/theming/Emotion';
 
-interface Props extends React.HTMLAttributes<HTMLInputElement> {
+interface HiddenInputProps extends React.HTMLAttributes<HTMLInputElement> {
   nodeRef: (ref: HTMLInputElement | null) => void;
 }
 
@@ -25,7 +25,7 @@ const className = css`
  * Для решения этой проблемы, перед "вставкой" фокусируемся на инпуте
  * после этого `onPaste` вызывается у инпута и всплывает.
  */
-export class HiddenInput extends React.Component<Props> {
+export class HiddenInput extends React.Component<HiddenInputProps> {
   public render() {
     const { nodeRef, ...props } = this.props;
     return (

--- a/packages/react-ui/internal/NativeDateInput/NativeDateInput.tsx
+++ b/packages/react-ui/internal/NativeDateInput/NativeDateInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 
 import { Nullable } from '../../typings/utility-types';
 
@@ -19,6 +20,12 @@ const DEFAULT_MAX_DATE = '2099-12-31';
 export class NativeDateInput extends React.Component<NativeDateInputProps> {
   public static __KONTUR_REACT_UI__ = 'NativeDatePicker';
   private input: Nullable<HTMLInputElement>;
+
+  public static propTypes = {
+    value: pt.oneOf([pt.string, null, undefined]).isRequired,
+    minDate: pt.oneOf([pt.string, null, undefined]),
+    maxDate: pt.oneOf([pt.string, null, undefined]),
+  };
 
   public render() {
     return (

--- a/packages/react-ui/internal/Popup/PopupPin.tsx
+++ b/packages/react-ui/internal/Popup/PopupPin.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { Nullable } from '../../typings/utility-types';
 
@@ -16,56 +15,40 @@ const borderStyles = {
 };
 
 interface Props {
+  /**
+   * Цвет фон пина.
+   */
   backgroundColor: string;
+  /**
+   * Цвет границы пина.
+   */
   borderColor: string;
+  /**
+   * Ширина границы пина.
+   */
   borderWidth: number;
+  /**
+   * Смещение пина от края попапа. Край задаётся в пропе position вторым словом.
+   */
   offset: number;
+  /**
+   * Ссылка на попап.
+   */
   popupElement: Nullable<HTMLElement>;
+  /**
+   * Позиция поапа, по которой будет вычеслено положение пина.
+   */
   popupPosition: string;
+  /**
+   * Сторона пина без учёта границы.
+   * Пин представляет собой равносторонний треугольник, высота от попапа
+   * до "носика" пина будет соответствовать формуле (size* √3)/2.
+   */
   size: number;
 }
 
 export class PopupPin extends React.Component<Props> {
   public static __KONTUR_REACT_UI__ = 'PopupPin';
-
-  public static propTypes = {
-    /**
-     * Цвет фон пина
-     */
-    backgroundColor: PropTypes.string,
-
-    /**
-     * Цвет границы пина
-     */
-    borderColor: PropTypes.string,
-
-    /**
-     * Ширина границы пина
-     */
-    borderWidth: PropTypes.number,
-
-    /**
-     * Смещение пина от края попапа. Край задаётся в пропе position вторым словом
-     */
-    offset: PropTypes.number,
-
-    /**
-     * Ссылка на попап
-     */
-    popupElement: PropTypes.any,
-
-    /**
-     * Позиция поапа, по которой будет вычеслено положение пина
-     */
-    popupPosition: PropTypes.string,
-
-    /**
-     * Сторона пина без учёта границы.
-     * Пин представляет собой равносторонний треугольник, высота от попапа
-     * до "носика" пина будет соответствовать формуле (size* √3)/2
-     */
-    size: PropTypes.number,
-  };
 
   public render() {
     if (!this.props.popupElement) {

--- a/packages/react-ui/internal/ZIndex/ZIndex.tsx
+++ b/packages/react-ui/internal/ZIndex/ZIndex.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import pt from 'prop-types';
 
 import { isBrowser } from '../../lib/client';
 
@@ -43,6 +44,7 @@ export class ZIndex extends React.Component<ZIndexProps> {
         return new Error(`[ZIndex]: Prop 'delta' must be integer, received ${props.delta}`);
       }
     },
+    priority: pt.oneOfType([pt.number, pt.string]),
   };
 
   private zIndex = 0;

--- a/packages/react-ui/lib/forwardRefAndName.ts
+++ b/packages/react-ui/lib/forwardRefAndName.ts
@@ -3,6 +3,7 @@ import { forwardRef } from 'react';
 export interface ReactUIComponentWithRef<T, P>
   extends React.NamedExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> {
   __KONTUR_REACT_UI__: string;
+  propTypes?: React.WeakValidationMap<P>;
 }
 
 function forwardName<ElementType, Props>(

--- a/packages/react-ui/lib/forwardRefAndName.ts
+++ b/packages/react-ui/lib/forwardRefAndName.ts
@@ -1,8 +1,7 @@
 import { forwardRef } from 'react';
 
 export interface ReactUIComponentWithRef<T, P>
-  extends React.NamedExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>,
-    Pick<React.ForwardRefExoticComponent<P>, 'propTypes'> {
+  extends React.NamedExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> {
   __KONTUR_REACT_UI__: string;
 }
 

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -94,6 +94,7 @@
     "@types/react-transition-group": "^4.2.3",
     "@types/shallowequal": "^1.1.1",
     "@types/warning": "^3.0.0",
+    "babel-plugin-typescript-to-proptypes": "2.0.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "chalk": "4.1.0",

--- a/packages/react-ui/typings/utility-types.d.ts
+++ b/packages/react-ui/typings/utility-types.d.ts
@@ -2,12 +2,10 @@ export type Nullable<T> = T | null | undefined;
 
 export type Shape<T> = Pick<T, keyof T>;
 
-type ObjectKeyType = string | number | symbol;
-
-export type Diff<T extends ObjectKeyType, U extends ObjectKeyType> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T];
-
-export type Override<T, U> = Pick<T, Diff<keyof T, keyof U>> & U;
+// * DO NOT use Override for defining type of component's props.
+// * That will not let PropTypes generate automatically.
+// * Explicitly use the right side of the expression below instead.
+export type Override<T, U> = Omit<T, keyof U> & U;
 
 export type Entries<T, K> = (o: { [k: string]: K }) => Array<[T, K]>;
 

--- a/packages/react-ui/typings/utility-types.d.ts
+++ b/packages/react-ui/typings/utility-types.d.ts
@@ -2,11 +2,6 @@ export type Nullable<T> = T | null | undefined;
 
 export type Shape<T> = Pick<T, keyof T>;
 
-// * DO NOT use Override for defining type of component's props.
-// * That will not let PropTypes generate automatically.
-// * Explicitly use the right side of the expression below instead.
-export type Override<T, U> = Omit<T, keyof U> & U;
-
 export type Entries<T, K> = (o: { [k: string]: K }) => Array<[T, K]>;
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,6 +381,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-module-imports@^7.12.5":
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
+  integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-module-imports@^7.13.12", "@babel/helper-module-imports@^7.7.0":
   version "7.13.12"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
@@ -1141,6 +1148,13 @@
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c"
   integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.12.1":
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz#2feeb13d9334cc582ea9111d3506f773174179bb"
+  integrity sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
@@ -2321,6 +2335,14 @@
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.6", "@babel/types@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
+  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.13.12", "@babel/types@^7.13.13", "@babel/types@^7.13.14":
@@ -6873,6 +6895,15 @@ babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
+babel-plugin-typescript-to-proptypes@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/babel-plugin-typescript-to-proptypes/-/babel-plugin-typescript-to-proptypes-2.0.0.tgz#4a1aaf15ce2269a79492b24178dc4181f576489d"
+  integrity sha512-LmXrkeqg4bzq0CiCOV/zN3hrvAvJOvoP9sEw0YgtkU6lIbqA5/RAY0bA6C6+i5/e5Wp/taJ68XKp2i8pkU+Qmw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.5"
+    "@babel/plugin-syntax-typescript" "^7.12.1"
+    "@babel/types" "^7.12.6"
 
 babel-preset-current-node-syntax@^0.1.2:
   version "0.1.4"


### PR DESCRIPTION
Добавил бабель-плагин для генерации `PropTypes` на основе `TypeScript` типов.