### PR TITLE
chore(react-ui-testing): move SeleniumTesting to WebDriver 4

### DIFF
--- a/packages/react-ui-testing/.gitignore
+++ b/packages/react-ui-testing/.gitignore
@@ -23,3 +23,4 @@ packages
 !packages/repositories.config
 
 .env
+*.sln.DotSettings.user

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -26,8 +26,8 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.2-alpha" />
-    <PackageReference Include="Kontur.Selone" Version="0.0.6-alpha" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
+    <PackageReference Include="Kontur.Selone" Version="1.0.0-alpha" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.2-alpha" />
     <PackageReference Include="Kontur.Selone" Version="1.0.0-alpha" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.2-alpha" />
     <PackageReference Include="Kontur.Selone" Version="1.0.0-alpha" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />

--- a/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
+++ b/packages/react-ui-testing/SeleniumTesting/SeleniumTesting.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="Kontur.RetryableAssertions" Version="0.0.2-alpha" />
-    <PackageReference Include="Kontur.Selone" Version="1.0.0-alpha" />
+    <PackageReference Include="Kontur.Selone" Version="1.0.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
-using SKBKontur.SeleniumTesting.Internals.Commons;
 
 namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
 {
@@ -69,10 +68,10 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
                 var wdHub = "https://frontinfra:frontinfra@grid.testkontur.ru/wd/hub";
                 ChromeOptions options = new ChromeOptions();
 
-                options.AddAdditionalCapability(CapabilityType.Platform, "windows", true);
-                options.AddAdditionalCapability("name", TestContext.CurrentContext.Test.Name, true);
-                options.AddAdditionalCapability("tunnel-identifier", this.tunnelIdentifier, true);
-                options.AddAdditionalCapability("maxDuration", 10800, true);
+                options.AddAdditionalOption(CapabilityType.Platform, "windows");
+                options.AddAdditionalOption("name", TestContext.CurrentContext.Test.Name);
+                options.AddAdditionalOption("tunnel-identifier", this.tunnelIdentifier);
+                options.AddAdditionalOption("maxDuration", 10800);
 
                 webDriver = new RemoteWebDriver(new Uri(wdHub),
                     options.ToCapabilities(),

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -27,6 +27,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -27,6 +27,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -27,6 +27,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.13.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Пора переезжать на WebDriver 4.

Видимо, будет новая мажорная версия 4.0.0.