### PR TITLE
fix urls for http://tech.skbkontur.ru/react-ui-testing/

### DIFF
--- a/packages/react-ui-testing/README.md
+++ b/packages/react-ui-testing/README.md
@@ -9,12 +9,12 @@
 
 Библиотека состоит из двух частей:
 
--   [Скрипт](https://tech.skbkontur.ru/react-ui-testing/#/expose-tids-to-dom), поключаемый на страницу, который транслирует props и другую полезную информацию о React-компонентах в DOM.
--   [Набор PageObject'ов](https://tech.skbkontur.ru/react-ui-testing/#/page-objects-dot-net) для доступа к [компонентам react-ui](https://github.com/skbkontur/retail-ui) через [Selenium для .NET](http://www.seleniumhq.org/docs/03_webdriver.jsp#c).
+-   [Скрипт](http://tech.skbkontur.ru/react-ui-testing/#/expose-tids-to-dom), поключаемый на страницу, который транслирует props и другую полезную информацию о React-компонентах в DOM.
+-   [Набор PageObject'ов](http://tech.skbkontur.ru/react-ui-testing/#/page-objects-dot-net) для доступа к [компонентам react-ui](https://github.com/skbkontur/retail-ui) через [Selenium для .NET](https://www.seleniumhq.org/docs/03_webdriver.jsp#c).
 
 ## А что дальше?
 
--   Прочитайте [инструкцию по быстрому старту](https://tech.skbkontur.ru/react-ui-testing/#/quick-start), чтобы проверить что всё работает
--   Узнайте как [подключить скрипт](https://tech.skbkontur.ru/react-ui-testing/#/expose-tids-to-dom) к своему приложению
--   Используйте [API reference по PageObject'ам для .NET](https://tech.skbkontur.ru/react-ui-testing/#/page-objects-dot-net)
--   Используйте [Bookmarket](https://tech.skbkontur.ru/react-ui-testing/#/bookmarklet) для просмотра tid-атрибутов страницы.
+-   Прочитайте [инструкцию по быстрому старту](http://tech.skbkontur.ru/react-ui-testing/#/quick-start), чтобы проверить что всё работает
+-   Узнайте как [подключить скрипт](http://tech.skbkontur.ru/react-ui-testing/#/expose-tids-to-dom) к своему приложению
+-   Используйте [API reference по PageObject'ам для .NET](http://tech.skbkontur.ru/react-ui-testing/#/page-objects-dot-net)
+-   Используйте [Bookmarket](http://tech.skbkontur.ru/react-ui-testing/#/bookmarklet) для просмотра tid-атрибутов страницы.


### PR DESCRIPTION
When url starts with https, `HTTP GET http://tech.skbkontur.ru/react-ui-testing/index.622fd667044f8941ef5f.js` fails to load with strict-origin-when-cross-origin error.

Actually, it is rollback of previous commit https://github.com/skbkontur/retail-ui/commit/69fa1b9743a37d36ceda81e58bc7a9a6a5996ec0#diff-9b03d2191cac33473b1a875409ce883efc63d231ca6a86a07ed115621338fa79
Unfortunately, urls was changed but not tested.

There could be another workaround.
index.html file includes `<script type="text/javascript" src="http://tech.skbkontur.ru/react-ui-testing/index.622fd667044f8941ef5f.js"></script>`
The link of src attribute could be in form `//tech.skbkontur.ru/react-ui-testing/index.622fd667044f8941ef5f.js` to support http and https protocols seamlessly. Unfortunately, I didn't found where it could be configured.

As other tip, what's a shame to have empty `WIP` pages in docs for at least 3 years (actually, more, from start of the project).
What should be happen to really useful docs to be written? Specified urls are useless without docs! **Is it worth to remove all the links to docs because they are actually absent?**