### PR TITLE
chore(InstanceRefType): create InstanceRefType interface

### DIFF
--- a/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
+++ b/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
@@ -16,10 +16,6 @@ export interface CommonProps {
    * На равне с data-tid транслируются любые data-атрибуты. Они попадают на корневой элемент.
    */
   'data-tid'?: string;
-  /**
-   * @ignore
-   */
-  instanceRef: React.MutableRefObject<any>;
 }
 
 export type NotCommonProps<P> = Omit<P, keyof CommonProps>;

--- a/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
+++ b/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
@@ -16,6 +16,10 @@ export interface CommonProps {
    * На равне с data-tid транслируются любые data-атрибуты. Они попадают на корневой элемент.
    */
   'data-tid'?: string;
+  /**
+   * @ignore
+   */
+  instanceRef: React.MutableRefObject<any>;
 }
 
 export type NotCommonProps<P> = Omit<P, keyof CommonProps>;

--- a/packages/react-ui/lib/withClassWrapper.tsx
+++ b/packages/react-ui/lib/withClassWrapper.tsx
@@ -57,3 +57,7 @@ export function withClassWrapper<T, P>(RFC: ReactUIComponentWithRef<T, P>) {
     }
   };
 }
+
+export interface InstanceRefType<T> {
+  instanceRef: React.MutableRefObject<T>;
+}


### PR DESCRIPTION
При использовании `withClassWrapper` и полной деструктуризации объекта `props`, на `DOM` ноду падает `instanceRef="[object object]"`. Проп `instanceRef` приходит из классовой обёртки.
```tsx
<div {...props} />
```

Один из самых простых вариантов решения проблемы: не пускать проп `instanceRef` на `DOM` ноду.
```tsx
const { instanceRef, ...rest } = props;

return <div {...rest}/>
```
Для этого придётся расширить тип `CommonProps`, что вызовет ещё больше путаницы с деструктурированием пропов в `CommonWrapper`, эта проблема может быть решена используя другой механизм слияния пропов из #2669.