### PR TITLE
fix(Checkbox,Radio): firing events onChange manually for Firefox (for 1.12)

### DIFF
--- a/packages/retail-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/retail-ui/components/Checkbox/Checkbox.tsx
@@ -9,6 +9,7 @@ import jsStyles, { classes } from './Checkbox.styles';
 import { ThemeConsumer } from '../ThemeConsumer';
 import { ITheme } from '../../lib/theming/Theme';
 import { isEdge, isFirefox, isIE11 } from '../../lib/utils';
+import { fixFirefoxModifiedClickOnLabel } from '../../lib/events/fixFirefoxModifiedClickOnLabel';
 
 export type CheckboxProps = Override<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -196,7 +197,13 @@ class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
     );
 
     return (
-      <label className={rootClass} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onMouseOver={onMouseOver}>
+      <label
+        className={rootClass}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseOver={onMouseOver}
+        onClick={this.handleLabelClick}
+      >
         <input {...inputProps} />
         {box}
         {caption}
@@ -262,6 +269,9 @@ class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
       this.props.onClick(e);
     }
   };
+
+  private handleLabelClick: React.MouseEventHandler<HTMLLabelElement> = e =>
+    fixFirefoxModifiedClickOnLabel(this.input, e);
 }
 
 export default Checkbox;

--- a/packages/retail-ui/components/Radio/Radio.tsx
+++ b/packages/retail-ui/components/Radio/Radio.tsx
@@ -7,6 +7,7 @@ import { cx } from '../../lib/theming/Emotion';
 import jsStyles from './Radio.styles';
 import { ThemeConsumer } from '../ThemeConsumer';
 import { ITheme } from '../../lib/theming/Theme';
+import { fixFirefoxModifiedClickOnLabel } from '../../lib/events/fixFirefoxModifiedClickOnLabel';
 
 export interface SyntheticRadioEvent<T> {
   target: {
@@ -185,6 +186,7 @@ class Radio<T> extends React.Component<RadioProps<T>> {
       onMouseOver: this._handleMouseOver,
       onMouseEnter: this._handleMouseEnter,
       onMouseLeave: this._handleMouseLeave,
+      onClick: this.handleLabelClick,
     };
 
     if (this._isInRadioGroup()) {
@@ -251,6 +253,9 @@ class Radio<T> extends React.Component<RadioProps<T>> {
       this.props.onMouseLeave(event);
     }
   };
+
+  private handleLabelClick: React.MouseEventHandler<HTMLLabelElement> = e =>
+    fixFirefoxModifiedClickOnLabel(this.node, e);
 }
 
 function createSyntheticEvent<T>({ value, id, name, checked, disabled }: RadioProps<T>): SyntheticRadioEvent<T> {

--- a/packages/retail-ui/lib/events/fixFirefoxModifiedClickOnLabel.ts
+++ b/packages/retail-ui/lib/events/fixFirefoxModifiedClickOnLabel.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import { isFirefox } from '../utils';
+import { Nullable } from '../../typings/utility-types';
+
+// Checkbox not checked in Firefox if key of modifier was active
+// shift+click, ctrl+click on Win and cmd+click on Mac
+// https://bugzilla.mozilla.org/show_bug.cgi?id=559506
+export const fixFirefoxModifiedClickOnLabel = (
+  input: Nullable<HTMLInputElement>,
+  e: React.MouseEvent<HTMLLabelElement>,
+) => {
+  if (input && !input.disabled && isFirefox && (e.shiftKey || e.ctrlKey || e.metaKey)) {
+    // Currently only valid for Radio and Checkbox
+    input.checked = !input.checked;
+    const type = input.type;
+    input.type = 'text';
+    e.persist();
+    input.dispatchEvent(new MouseEvent('change', e.nativeEvent));
+    input.type = type;
+  }
+};


### PR DESCRIPTION
Cherry-picked from https://github.com/skbkontur/retail-ui/pull/2686