### PR TITLE
fix(Loader): use `forEach` from `Array`

### DIFF
--- a/packages/react-ui/components/Loader/Loader.tsx
+++ b/packages/react-ui/components/Loader/Loader.tsx
@@ -362,7 +362,8 @@ export class Loader extends React.Component<LoaderProps, LoaderState> {
 
   private enableChildrenFocus = () => {
     this.makeUnobservable();
-    document.querySelectorAll('[origin-tabindex]').forEach((el) => {
+    // NOTE: NodeList doesn't support 'forEach' method in IE11 and other older browsers
+    Array.from(document.querySelectorAll('[origin-tabindex]')).forEach((el) => {
       el.setAttribute('tabindex', el.getAttribute('origin-tabindex') ?? '0');
       el.removeAttribute('origin-tabindex');
     });


### PR DESCRIPTION
IE11 и старые браузеры не поддерживают `NodeList.prototype.forEach`.

Fix #2697