### PR TITLE
fix(RadioGroup): fix types inference

### DIFF
--- a/packages/react-ui/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react-ui/components/RadioGroup/RadioGroup.tsx
@@ -73,22 +73,21 @@ export interface RadioGroupProps<T = string | number> extends CommonProps {
   onMouseLeave?: () => any;
   onMouseOver?: () => any;
   onMouseEnter?: () => any;
-  /**
-   * Может быть использовано, если не передан параметр `items`
-   *
-   * `children` может содержать любую разметку с компонентами Radio.
-   * Каждому компоненту Radio нужно указать параметр `value`, такого же типа
-   * как и параметр `value` самой радиогруппы.
-   *
-   * Значения активного элемента сравниваются по строгому равенству `===`
-   */
-  children?: React.ReactNode;
 }
 
 export interface RadioGroupState<T> {
   activeItem?: T;
 }
 
+/**
+ *
+ * `children` может содержать любую разметку с компонентами Radio,
+ * если не передан параметр `items`.
+ * Каждому компоненту Radio нужно указать параметр `value`, такого же типа
+ * как и параметр `value` самой радиогруппы.
+ *
+ * Значения активного элемента сравниваются по строгому равенству `===`
+ */
 export class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGroupState<T>> {
   public static __KONTUR_REACT_UI__ = 'RadioGroup';
 


### PR DESCRIPTION
Фикс проблемы с типами [из чата](https://kontur.slack.com/archives/C013HTCE18Q/p1637761453189500). Помогло удаление children из интерфейса пропов, который был добавлен в #2607 (@skbkontur/react-ui@3.8.4).

