### PR TITLE
fix(TokenInput): add handling Enter for TokenInputType.WithoutReference

### DIFF
--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -653,8 +653,9 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     e.stopPropagation();
 
     if (
-      this.type !== TokenInputType.WithReference &&
-      this.props.delimiters.some((key) => key === e.key || (key === ',' && isKeyComma(e)))
+      (this.type !== TokenInputType.WithReference &&
+        this.props.delimiters.some((key) => key === e.key || (key === ',' && isKeyComma(e)))) ||
+      isKeyEnter(e) && this.type === TokenInputType.WithoutReference
     ) {
       e.preventDefault();
       const newValue = this.state.inputValue;


### PR DESCRIPTION
fix(TokenInput): add handling Enter for TokenInputType.WithoutReference

Добавила обработку нажатия Enter в handleInputKeyDown для TokenInputType.WithoutReference.

https://github.com/skbkontur/retail-ui/issues/2527