### PR TITLE
fix(TokenInput): handle Enter for TokenInputType.WithoutReference

### DIFF
--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -657,7 +657,7 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     if (
       (this.type !== TokenInputType.WithReference &&
         this.props.delimiters.some((key) => key === e.key || (key === ',' && isKeyComma(e)))) ||
-      isKeyEnter(e) && this.type === TokenInputType.WithoutReference
+      (isKeyEnter(e) && this.type === TokenInputType.WithoutReference)
     ) {
       e.preventDefault();
       const newValue = this.state.inputValue;

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -655,8 +655,9 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     e.stopPropagation();
 
     if (
-      this.type !== TokenInputType.WithReference &&
-      this.props.delimiters.some((key) => key === e.key || (key === ',' && isKeyComma(e)))
+      (this.type !== TokenInputType.WithReference &&
+        this.props.delimiters.some((key) => key === e.key || (key === ',' && isKeyComma(e)))) ||
+      isKeyEnter(e) && this.type === TokenInputType.WithoutReference
     ) {
       e.preventDefault();
       const newValue = this.state.inputValue;


### PR DESCRIPTION
Дубль #2706  для прогона тестов.