### PR TITLE
Анимация спиннера в Сафари

### DIFF
--- a/packages/react-ui/lib/theming/AnimationKeyframes.ts
+++ b/packages/react-ui/lib/theming/AnimationKeyframes.ts
@@ -18,8 +18,8 @@ export const AnimationKeyframes = {
   },
   spinnerCircleOffset(t: Theme) {
     return keyframes`
-        0% { stroke-dashoffset: 0; }
-        100% { stroke-dashoffset: -231.25%; }
+        0% { stroke-dashoffset: 231.25%; }
+        100% { stroke-dashoffset: 0%; }
       `;
   },
   spinnerCircleLength(t: Theme) {


### PR DESCRIPTION
### Проблема
Анимация спиннера в Сафари работает неправильно 
### Причина
Нашла информацию, что Сафари [не поддерживает отрицательные значения для `stroke-dashoffset`](https://stackoverflow.com/questions/37246113/svg-stroke-dashoffset-not-working-on-safari)
Но на самом деле большую роль сыграло добавление знака `%` к `stroke-dashoffset: 0%`