### PR TITLE
:fire: chore(extractDataProps): utility for extracting data props out of all props

### DIFF
--- a/packages/react-ui/lib/__tests__/extractDataProps-test.ts
+++ b/packages/react-ui/lib/__tests__/extractDataProps-test.ts
@@ -1,0 +1,35 @@
+import { extractDataProps } from '../utils';
+
+describe('extractDataProps', () => {
+  it('correctly extracts data props', () => {
+    const testDataProps = {
+      'data-tid': 1,
+      'data-testid': 2,
+      'data-tip': 3,
+    };
+    const otherProps = {
+      value: 'string',
+      number: 2,
+    };
+
+    const { dataProps } = extractDataProps({ ...testDataProps, ...otherProps });
+
+    expect(testDataProps).toMatchObject(dataProps);
+  });
+
+  it('correctly extracts all other props', () => {
+    const testDataProps = {
+      'data-tid': 1,
+      'data-testid': 2,
+      'data-tip': 3,
+    };
+    const otherProps = {
+      value: 'string',
+      number: 2,
+    };
+
+    const { restWithoutDataProps } = extractDataProps({ ...testDataProps, ...otherProps });
+
+    expect(otherProps).toMatchObject(restWithoutDataProps);
+  });
+});

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -92,3 +92,24 @@ export const isReactUINode = (componentName: string, node: React.ReactNode): boo
 export const isNonNullable = <T>(value: T): value is NonNullable<T> => {
   return value !== null && value !== undefined;
 };
+
+/**
+ * Extracts all data attributes from props and returns them as well as props.
+ *
+ * @param props Props object to extract data attributes from.
+ * @returns Separated data attributes and all other props.
+ */
+export const extractDataProps = <T>(props: T) => {
+  const dataProps: Record<string, any> = {};
+  const restWithoutDataProps: Record<string, any> = {};
+
+  Object.entries(props).map(([name, value]) => {
+    if (name.startsWith('data-')) {
+      dataProps[name] = value;
+    } else {
+      restWithoutDataProps[name] = value;
+    }
+  });
+
+  return { dataProps, restWithoutDataProps };
+};


### PR DESCRIPTION
Создал утилиту для извлечения `data-` атрибутов из пропов. 

Эта утилита нужна, когда нужно прокинуть `data-` атрибуты не на тот компонент, на который падают `...rest` пропы.
Такая нужда есть например у компонента `Checkbox`(#2744) и `Radio` (#2752). Конкретно в этих двух компонентах уже есть эта утилита, добавил её, чтобы не забыть, что эти компоненты в ней нуждаются: проще пофиксить возможные конфликты, чем неправильную передачу пропов.