### PR TITLE
:fire: test(test-setup): make jest-dom part of test-setup & change confusing comment

### DIFF
--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -16,11 +16,7 @@ jest.mock('lodash.debounce', () =>
 );
 
 /**
- * Mock MutationObserver for jsdom < 13.2
- * @see https://github.com/jsdom/jsdom/pull/2398
- *
- * TODO: remove when Jest >= 25.1.0
- * @see https://github.com/facebook/jest/blob/master/CHANGELOG.md#2510
+ * Remove this in case if project uses jsdom > 13.2 as dependency
  */
 global.MutationObserver = class {
   disconnect() {

--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len,react/no-deprecated */
 import 'core-js/stable';
+import '@testing-library/jest-dom/extend-expect';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -16,7 +16,11 @@ jest.mock('lodash.debounce', () =>
 );
 
 /**
- * If project ever uses `jsdom` >= 13.2 instead of `react-dom` remove the `MutationObserver` class as it will be not needed.
+ * Mock MutationObserver for `jsdom` < 13.2
+ * @see https://github.com/jsdom/jsdom/pull/2398
+ *
+ * TODO: remove when `jest` >= 25.1.0 (`react-ui-codemod` still has an old version of `jest`)
+ * @see https://github.com/facebook/jest/blob/master/CHANGELOG.md#2510
  */
 global.MutationObserver = class {
   disconnect() {

--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -16,7 +16,7 @@ jest.mock('lodash.debounce', () =>
 );
 
 /**
- * Remove this in case if project uses jsdom > 13.2 as dependency
+ * If project ever uses `jsdom` >= 13.2 instead of `react-dom` remove the `MutationObserver` class as it will be not needed.
  */
 global.MutationObserver = class {
   disconnect() {

--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len,react/no-deprecated */
 import 'core-js/stable';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';


### PR DESCRIPTION
Добавил `jest-dom` в `test-setup`, чтобы не приходилось постоянно её экспортировать.

Также изменил комментарий, в котором говорилось, что если проект использует версию `jest` >= 25.1.0, то нужно удалить `MutationObserver`. Потому что в `jest@25.1.0` [обновили](https://github.com/facebook/jest/blob/main/CHANGELOG.md#chore--maintenance-21) `jsdom` до 15-ой версии:
```
[jest-environment-jsdom] [BREAKING] Upgrade JSDOM from v11 to v15
```
Но нам не подходит это решение, так как в проекте используется `react-dom`, вместо `jsdom`.