### PR TITLE
[SidePageHeader] Исправил баги с залипшим заголовком

### DIFF
--- a/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/chrome/sticky header, open and close internal side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/chrome/sticky header, open and close internal side-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b7876512c086be210a53643968785a96d665c2f88ecae0d74d4560b40ba1d50
+size 20951

--- a/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/chrome8px/sticky header, open and close internal side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/chrome8px/sticky header, open and close internal side-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7dcb6414cb2d7c1b9d3e9ea72e4bb2b91ac5a1d036cf2b25f7843c3c3f4f232
+size 20837

--- a/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/firefox/sticky header, open and close internal side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/firefox/sticky header, open and close internal side-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15149f64e78ca68283317e34d3a911496c014de440c059f0d518db1154c8aece
+size 20513

--- a/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/firefox8px/sticky header, open and close internal side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/firefox8px/sticky header, open and close internal side-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63c78c79bd80fed51f16edfdddf1814cd82108c5e977f33ed194266868a8f90d
+size 20400

--- a/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/ie11/sticky header, open and close internal side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/ie11/sticky header, open and close internal side-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:398109191f76a663ff02a50847e39f38af15ea8750c69e8e1e1f15e28726e573
+size 48855

--- a/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/ie118px/sticky header, open and close internal side-page.png
+++ b/packages/react-ui/.creevey/images/SidePage/Sticky SidePageHeader when another SidePage/sticky header, open and close internal side-page/ie118px/sticky header, open and close internal side-page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bc42ba9ed63071eacba36c951e2b02170ffe7da67629a8730ea4aa417fd3853
+size 47958

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -109,6 +109,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   private theme!: Theme;
   private stackSubscription: ModalStackSubscription | null = null;
   private layoutRef: HTMLElement | null = null;
+  private header: SidePageHeader | null = null;
   private footer: SidePageFooter | null = null;
   private rootRef = React.createRef<HTMLDivElement>();
 
@@ -132,6 +133,9 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
    * @public
    */
   public updateLayout = (): void => {
+    if (this.header) {
+      this.header.update();
+    }
     if (this.footer) {
       this.footer.update();
     }
@@ -242,6 +246,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
       requestClose: this.requestClose,
       getWidth: this.getWidth,
       updateLayout: this.updateLayout,
+      headerRef: this.headerRef,
       footerRef: this.footerRef,
       setHasHeader: this.setHasHeader,
       setHasFooter: this.setHasFooter,
@@ -327,6 +332,10 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     if (this.props.onClose) {
       this.props.onClose();
     }
+  };
+
+  private headerRef = (ref: SidePageHeader | null) => {
+    this.header = ref;
   };
 
   private footerRef = (ref: SidePageFooter | null) => {

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -108,7 +108,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   };
   private theme!: Theme;
   private stackSubscription: ModalStackSubscription | null = null;
-  private layoutRef: HTMLElement | null = null;
+  private layout: HTMLElement | null = null;
   private header: SidePageHeader | null = null;
   private footer: SidePageFooter | null = null;
   private rootRef = React.createRef<HTMLDivElement>();
@@ -211,7 +211,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
                 [styles.wrapperMarginRight()]: this.state.hasMargin && !fromLeft,
                 [styles.shadow(this.theme)]: this.state.hasShadow,
               })}
-              ref={(_) => (this.layoutRef = _)}
+              ref={this.layoutRef}
             >
               <SidePageContext.Provider value={this.getSidePageContextProps()}>
                 {this.props.children}
@@ -224,7 +224,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   }
 
   private disablePageScroll = (e: WheelEvent) => {
-    const layout = this.layoutRef;
+    const layout = this.layout;
     if (!layout) return;
     const reachedTop = layout.scrollTop <= 0 && e.deltaY < 0;
     const reachedBottom = layout.scrollTop >= layout.scrollHeight - layout.offsetHeight && e.deltaY > 0;
@@ -251,10 +251,10 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   };
 
   private getWidth = () => {
-    if (!this.layoutRef) {
+    if (!this.layout) {
       return 'auto';
     }
-    return this.layoutRef.clientWidth;
+    return this.layout.clientWidth;
   };
 
   private renderShadow(): JSX.Element {
@@ -336,6 +336,10 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
 
   private footerRef = (ref: SidePageFooter | null) => {
     this.footer = ref;
+  };
+
+  private layoutRef = (ref: HTMLDivElement | null) => {
+    this.layout = ref;
   };
 
   private setHasHeader = (hasHeader = true) => {

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -133,12 +133,8 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
    * @public
    */
   public updateLayout = (): void => {
-    if (this.header) {
-      this.header.update();
-    }
-    if (this.footer) {
-      this.footer.update();
-    }
+    this.header?.update();
+    this.footer?.update();
   };
 
   public static defaultProps = {

--- a/packages/react-ui/components/SidePage/SidePageContext.ts
+++ b/packages/react-ui/components/SidePage/SidePageContext.ts
@@ -1,11 +1,13 @@
 import React from 'react';
 
 import { SidePageFooter } from './SidePageFooter';
+import { SidePageHeader } from './SidePageHeader';
 
 export interface SidePageContextType {
   requestClose: () => void;
   getWidth: () => number | string;
   updateLayout: () => void;
+  headerRef: (ref: SidePageHeader | null) => void;
   footerRef: (ref: SidePageFooter | null) => void;
   hasHeader?: boolean;
   hasFooter?: boolean;
@@ -19,6 +21,7 @@ export const SidePageContext = React.createContext<SidePageContextType>({
   requestClose: () => undefined,
   getWidth: () => 'auto',
   updateLayout: () => undefined,
+  headerRef: () => undefined,
   footerRef: () => undefined,
 });
 

--- a/packages/react-ui/components/SidePage/SidePageHeader.tsx
+++ b/packages/react-ui/components/SidePage/SidePageHeader.tsx
@@ -41,6 +41,7 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
 
   private theme!: Theme;
   private wrapper: HTMLElement | null = null;
+  private sticky: Sticky | null = null;
   private lastRegularHeight = 0;
   private setRootNode!: TSetRootNode;
 
@@ -63,14 +64,17 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
   public componentDidMount = () => {
     window.addEventListener('scroll', this.update, true);
     this.context.setHasHeader?.();
+    this.context.headerRef(this);
   };
 
   public componentWillUnmount = () => {
     window.removeEventListener('scroll', this.update, true);
     this.context.setHasHeader?.(false);
+    this.context.headerRef(null);
   };
 
   public update = () => {
+    this.sticky?.reflow();
     this.updateReadyToFix();
   };
 
@@ -90,7 +94,13 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <div ref={this.wrapperRef} className={styles.headerWrapper()}>
-          {isReadyToFix ? <Sticky side="top">{this.renderHeader}</Sticky> : this.renderHeader()}
+          {isReadyToFix ? (
+            <Sticky ref={this.stickyRef} side="top">
+              {this.renderHeader}
+            </Sticky>
+          ) : (
+            this.renderHeader()
+          )}
         </div>
       </CommonWrapper>
     );
@@ -144,6 +154,10 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
 
   private wrapperRef = (el: HTMLElement | null) => {
     this.wrapper = el;
+  };
+
+  private stickyRef = (el: Sticky | null) => {
+    this.sticky = el;
   };
 
   private handleFocus = () => {

--- a/packages/react-ui/components/SidePage/SidePageHeader.tsx
+++ b/packages/react-ui/components/SidePage/SidePageHeader.tsx
@@ -123,26 +123,30 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
     return (
       <div className={cx(styles.wrapperClose(this.theme), fixed && styles.fixed(this.theme))}>
         <Sticky side="top" offset={stickyOffset}>
-          <SidePageContext.Consumer>
-            {({ requestClose }) => (
-              <button
-                className={cx(styles.close(this.theme), {
-                  [styles.closeFocus(this.theme)]: this.state.focusedByTab,
-                })}
-                onFocus={this.handleFocus}
-                onBlur={this.handleBlur}
-                onClick={requestClose}
-                data-tid="SidePage__close"
-                tabIndex={0}
-              >
-                <CrossIcon />
-              </button>
-            )}
-          </SidePageContext.Consumer>
+          {this.closeIcon}
         </Sticky>
       </div>
     );
   };
+
+  private closeIcon = () => (
+    <SidePageContext.Consumer>
+      {({ requestClose }) => (
+        <button
+          className={cx(styles.close(this.theme), {
+            [styles.closeFocus(this.theme)]: this.state.focusedByTab,
+          })}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
+          onClick={requestClose}
+          data-tid="SidePage__close"
+          tabIndex={0}
+        >
+          <CrossIcon />
+        </button>
+      )}
+    </SidePageContext.Consumer>
+  );
 
   private updateReadyToFix = () => {
     if (this.wrapper) {

--- a/packages/react-ui/components/SidePage/__stories__/SidePage.stories.tsx
+++ b/packages/react-ui/components/SidePage/__stories__/SidePage.stories.tsx
@@ -216,6 +216,12 @@ class SidePageOverAnotherSidePage extends React.Component<{}> {
   }
 }
 
+class StickySidePageHeaderWhenAnotherSidePage extends React.Component<{}> {
+  public render() {
+    return <Sample current={1} total={2} ignoreBackgroundClick blockBackground withContent withLongBody />;
+  }
+}
+
 interface SidePageWithCloseConfigurationState {
   ignoreBackgroundClick: boolean;
   blockBackground: boolean;
@@ -627,6 +633,39 @@ SidePageOverAnotherSidePageStory.parameters = {
           .click(this.browser.findElement({ css: '.react-ui:last-child [data-comp-name~="SidePageFooter"] button' }))
           .perform();
         await this.expect(await this.browser.takeScreenshot()).to.matchImage('close internal side-page');
+      },
+    },
+  },
+};
+
+export const StickySidePageHeaderWhenAnotherSidePageStory: Story = () => <StickySidePageHeaderWhenAnotherSidePage />;
+StickySidePageHeaderWhenAnotherSidePageStory.storyName = 'Sticky SidePageHeader when another SidePage';
+
+StickySidePageHeaderWhenAnotherSidePageStory.parameters = {
+  creevey: {
+    tests: {
+      async ['sticky header, open and close internal side-page']() {
+        await this.browser
+          .actions({ bridge: true })
+          .click(this.browser.findElement({ css: 'button' }))
+          .perform();
+        await this.browser
+          .actions({ bridge: true })
+          .click(this.browser.findElement({ css: '[data-comp-name~="SidePageBody"] button' }))
+          .perform();
+        await this.browser.executeScript(function () {
+          const sidepageContainer = window.document.querySelector('[data-tid="SidePage__container"]');
+
+          // @ts-ignore
+          sidepageContainer.scrollTop = 3000;
+        });
+        await this.browser
+          .actions({ bridge: true })
+          .click(this.browser.findElement({ css: '.react-ui:last-child [data-comp-name~="SidePageFooter"] button' }))
+          .perform();
+        await this.expect(await this.browser.takeScreenshot()).to.matchImage(
+          'sticky header, open and close internal side-page',
+        );
       },
     },
   },

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -139,7 +139,12 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
 
   private refInner = (ref: Nullable<HTMLElement>) => (this.inner = ref);
 
-  private reflow = () => {
+  /**
+   * Пересчитать габариты и позицию залипшего элемента
+   *
+   * @public
+   */
+  public reflow = () => {
     const { documentElement } = document;
 
     if (!documentElement) {


### PR DESCRIPTION
## Суть дела

Из [чата](https://kontur.slack.com/archives/C013HTCE18Q/p1644214047162429).

Вплоть до версии `3.7.0` была проблема с несколькими экземплярами (это когда один поверх другого). 
![image](https://user-images.githubusercontent.com/2708211/153045088-7fbecd61-c276-49f9-ac0d-07a7c106e64a.png)

Когда появляется скроллбар, то `SidePadeHeader` залипает сверху. Если в это время открыть второй `SidePage`, то первый сдвинется на 20px, вместе с залипшим заголовком. А при закрытии второго, заголовок первого останется на месте.
![image](https://user-images.githubusercontent.com/2708211/153045192-34da6db5-ccde-4924-949c-8f57ad850dfe.png)

Однако после этого коммита https://github.com/skbkontur/retail-ui/pull/2478/commits/4458332a79a143295e42ec9388ea27d0b94a7b21 баг как-бы пропал. Но только если второй `SidePage` открыть и сразу закрыть. Если в нём будет скроллбар, то при попытке поскролить Реакт развалиться из-за `Maximum update depth exceeded`.
Тут я не конца разобрался в чём именно причина. Остановился то том, что дело в `Sticky` внутри `Sticky`.

## Решение

- Добавил вызов метода `this.header.update()`, как для ранее было сделано для `SidePadeFooter`.
- Вернул старое решение для иконки, когда в `Sticky` в `children` передаётся функция, вместо JSX элемента. Это решает проблему бесконечных обновлений.
- Сделал метод `reflow()` у `Sticky` публичным.

Fix https://yt.skbkontur.ru/issue/IF-369
Fix https://yt.skbkontur.ru/issue/IF-370

## РусЯз

Дополнительно решил начать писать коммиты на русском. Создание релизных анонсов должно стать проще.