### PR TITLE
fix(RadioGroup): Сделал `null` значением для сброса [1.6.x]

### DIFF
--- a/packages/retail-ui/components/RadioGroup/RadioGroup.tsx
+++ b/packages/retail-ui/components/RadioGroup/RadioGroup.tsx
@@ -208,7 +208,7 @@ class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGroupState<
 
   private _getName = () => this.props.name || this._name;
 
-  private _isControlled = () => this.props.value != null;
+  private _isControlled = () => this.props.value !== undefined;
 
   private _handleSelect = (event: SyntheticRadioEvent<T>, value: T) => {
     if (!this._isControlled()) {


### PR DESCRIPTION
Из [чата](https://kontur.slack.com/archives/C013HTCE18Q/p1644295772338949).

Подробности здесь https://github.com/skbkontur/retail-ui/pull/2772
Taken from https://github.com/skbkontur/retail-ui/pull/2772/commits/b545df8ba0700a159c66640a3597a792703c94dd

Fix https://yt.skbkontur.ru/issue/IF-336