### PR TITLE
fix(SidePage): Исправил положение залипшего заголовка после закрытия второго SidePage

### DIFF
--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -90,7 +90,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   public state: SidePageState = {};
   private theme!: Theme;
   private stackSubscription: ModalStackSubscription | null = null;
-  private layoutRef: HTMLElement | null = null;
+  private layout: HTMLElement | null = null;
   private footer: SidePageFooter | null = null;
   private header: SidePageHeader | null = null;
 
@@ -175,7 +175,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
             className={cn(jsStyles.wrapper(this.theme), this.state.hasShadow && jsStyles.shadow(this.theme))}
             style={this.getSidebarStyle()}
           >
-            <div ref={(_) => (this.layoutRef = _)} className={jsStyles.layout()}>
+            <div ref={this.layoutRef} className={jsStyles.layout()}>
               <SidePageContext.Provider value={this.getSidePageContextProps()}>
                 {this.props.children}
               </SidePageContext.Provider>
@@ -218,10 +218,10 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   };
 
   private getWidth = () => {
-    if (!this.layoutRef) {
+    if (!this.layout) {
       return 'auto';
     }
-    return this.layoutRef.getBoundingClientRect().width;
+    return this.layout.getBoundingClientRect().width;
   };
 
   private renderShadow(): JSX.Element {
@@ -317,5 +317,9 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
 
   private footerRef = (ref: SidePageFooter | null) => {
     this.footer = ref;
+  };
+
+  private layoutRef = (ref: HTMLDivElement | null) => {
+    this.layout = ref;
   };
 }

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -92,6 +92,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   private stackSubscription: ModalStackSubscription | null = null;
   private layoutRef: HTMLElement | null = null;
   private footer: SidePageFooter | null = null;
+  private header: SidePageHeader | null = null;
 
   public componentDidMount() {
     window.addEventListener('keydown', this.handleKeyDown);
@@ -111,15 +112,14 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
    * @public
    */
   public updateLayout = (): void => {
-    if (this.footer) {
-      this.footer.update();
-    }
+    this.header?.update();
+    this.footer?.update();
   };
 
   public render(): JSX.Element {
     return (
       <ThemeContext.Consumer>
-        {theme => {
+        {(theme) => {
           this.theme = theme;
           return this.renderMain();
         }}
@@ -175,7 +175,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
             className={cn(jsStyles.wrapper(this.theme), this.state.hasShadow && jsStyles.shadow(this.theme))}
             style={this.getSidebarStyle()}
           >
-            <div ref={_ => (this.layoutRef = _)} className={jsStyles.layout()}>
+            <div ref={(_) => (this.layoutRef = _)} className={jsStyles.layout()}>
               <SidePageContext.Provider value={this.getSidePageContextProps()}>
                 {this.props.children}
               </SidePageContext.Provider>
@@ -191,7 +191,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     let hasFooter = false;
     let hasPanel = false;
 
-    React.Children.toArray(this.props.children).forEach(child => {
+    React.Children.toArray(this.props.children).forEach((child) => {
       if (isHeader(child)) {
         hasHeader = true;
       }
@@ -211,6 +211,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
       getWidth: this.getWidth,
       updateLayout: this.updateLayout,
       footerRef: this.footerRef,
+      headerRef: this.headerRef,
     };
 
     return sidePageContextProps;
@@ -266,7 +267,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
   }
 
   private handleStackChange = (stack: ReadonlyArray<React.Component>) => {
-    const sidePages = stack.filter(x => x instanceof SidePage && x.props.fromLeft === this.props.fromLeft);
+    const sidePages = stack.filter((x) => x instanceof SidePage && x.props.fromLeft === this.props.fromLeft);
     const currentSidePagePosition = sidePages.indexOf(this);
 
     const hasMargin = sidePages.length > 1 && currentSidePagePosition === sidePages.length - 1;
@@ -308,6 +309,10 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     if (this.props.onClose) {
       this.props.onClose();
     }
+  };
+
+  private headerRef = (ref: SidePageHeader | null) => {
+    this.header = ref;
   };
 
   private footerRef = (ref: SidePageFooter | null) => {

--- a/packages/react-ui/components/SidePage/SidePageContext.ts
+++ b/packages/react-ui/components/SidePage/SidePageContext.ts
@@ -1,11 +1,13 @@
 import React from 'react';
 
+import { SidePageHeader } from './SidePageHeader';
 import { SidePageFooter } from './SidePageFooter';
 
 export interface SidePageContextType {
   requestClose: () => void;
   getWidth: () => number | string;
   updateLayout: () => void;
+  headerRef: (ref: SidePageHeader | null) => void;
   footerRef: (ref: SidePageFooter | null) => void;
   hasHeader?: boolean;
   hasFooter?: boolean;
@@ -16,6 +18,7 @@ export const SidePageContext = React.createContext<SidePageContextType>({
   requestClose: () => undefined,
   getWidth: () => 'auto',
   updateLayout: () => undefined,
+  headerRef: () => undefined,
   footerRef: () => undefined,
 });
 

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -136,7 +136,7 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
 
   private refInner = (ref: Nullable<HTMLElement>) => (this.inner = ref);
 
-  private reflow = () => {
+  public reflow = () => {
     const { documentElement } = document;
 
     if (!documentElement) {

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -67,6 +67,11 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
   private layoutSubscription: { remove: Nullable<() => void> } = { remove: null };
   private reflowCounter = 0;
 
+  /**
+   * Пересчитать габариты и позицию залипшего элемента
+   *
+   * @public
+   */
   public componentDidMount() {
     this.reflow();
 

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -67,11 +67,6 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
   private layoutSubscription: { remove: Nullable<() => void> } = { remove: null };
   private reflowCounter = 0;
 
-  /**
-   * Пересчитать габариты и позицию залипшего элемента
-   *
-   * @public
-   */
   public componentDidMount() {
     this.reflow();
 
@@ -141,6 +136,11 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
 
   private refInner = (ref: Nullable<HTMLElement>) => (this.inner = ref);
 
+  /**
+   * Пересчитать габариты и позицию залипшего элемента
+   *
+   * @public
+   */
   public reflow = () => {
     const { documentElement } = document;
 


### PR DESCRIPTION
Из [чата](https://kontur.slack.com/archives/C013HTCE18Q/p1644214047162429). Заказчику нужен фикс в `2.17`

Подробности здесь https://github.com/skbkontur/retail-ui/pull/2763

Fix https://yt.skbkontur.ru/issue/IF-369