### PR TITLE
chore(eslint): enable react/no-find-dom-node rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,7 @@
     "import/no-unresolved": 0,
     "import/no-duplicates": 2,
     "import/no-default-export": 2,
-    "react/no-find-dom-node": 0,
+    "react/no-find-dom-node": 2,
     "react/display-name": 0,
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/no-explicit-any": 0,

--- a/packages/react-ui/lib/rootNode/getRootNode.ts
+++ b/packages/react-ui/lib/rootNode/getRootNode.ts
@@ -22,6 +22,7 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<H
     return node;
   }
 
+  // eslint-disable-next-line react/no-find-dom-node
   node = findDOMNode(instance);
   return node instanceof HTMLElement ? node : null;
 };


### PR DESCRIPTION
Включил правило `react/no-find-dom-node` в глобальном `.eslintrc`.
Отключил правило на единственной строке, где `findDOMNode` законно используется.