### PR TITLE
chore(eslint): enable react/display-name rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,7 @@
     "import/no-duplicates": 2,
     "import/no-default-export": 2,
     "react/no-find-dom-node": 0,
-    "react/display-name": 0,
+    "react/display-name": 1,
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/ban-ts-ignore": 0,

--- a/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
+++ b/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { render } from '@testing-library/react';
 

--- a/packages/react-ui/lib/__tests__/reactGetTextContent-test.tsx
+++ b/packages/react-ui/lib/__tests__/reactGetTextContent-test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 
 import { reactGetTextContent } from '../reactGetTextContent';

--- a/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
+++ b/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 
 import { Nullable } from '../../typings/utility-types';

--- a/packages/react-ui/test-setup.js
+++ b/packages/react-ui/test-setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 /* eslint-disable max-len,react/no-deprecated */
 import 'core-js/stable';
 import '@testing-library/jest-dom';


### PR DESCRIPTION
Включил правило `react/display-name` в глобальном `.eslintrc`.
Отключил правило там, где компонентам не нужен `displayName`.