### PR TITLE
test(smoke): bump `typescript` from ~3.7.4 to 4.2.4

### DIFF
--- a/packages/react-ui-smoke-test/cra-template-react-ui/template.json
+++ b/packages/react-ui-smoke-test/cra-template-react-ui/template.json
@@ -4,7 +4,7 @@
       "@testing-library/react": "^9.3.2",
       "@testing-library/jest-dom": "^4.2.4",
       "@testing-library/user-event": "^7.1.2",
-      "typescript": "~3.7.4",
+      "typescript": "4.2.4",
       "@skbkontur/react-icons": "^3.2.0"
     }
   }


### PR DESCRIPTION
Обновить стоило в любом случае, но сейчас поводом стала ошибка:
```diff
-TS2589: Type instantiation is excessively deep and possibly infinite.
```
Подробности здесь https://github.com/skbkontur/retail-ui/pull/2760#issuecomment-1038043977