### PR TITLE
docs(react-ui): fix ThemeShowcase page

### DIFF
--- a/packages/react-ui/internal/ThemeShowcase/ThemeShowcase.tsx
+++ b/packages/react-ui/internal/ThemeShowcase/ThemeShowcase.tsx
@@ -163,7 +163,7 @@ class ComponentShowcase extends React.Component<ComponentShowcaseProps, {}> {
     const { name, description, onVariableSelect, isDebugMode } = this.props;
     const elements = Object.keys(description);
 
-    return (
+    return elements.length ? (
       <ThemeContext.Consumer>
         {(theme) => {
           return (
@@ -213,7 +213,7 @@ class ComponentShowcase extends React.Component<ComponentShowcaseProps, {}> {
           );
         }}
       </ThemeContext.Consumer>
-    );
+    ) : null;
   }
 }
 

--- a/packages/react-ui/internal/ThemeShowcase/VariablesCollector.ts
+++ b/packages/react-ui/internal/ThemeShowcase/VariablesCollector.ts
@@ -106,18 +106,23 @@ if (IS_PROXY_SUPPORTED) {
 function getProxyHandler(accumulator: Set<keyof Theme>, dependencies: VariableDependencies): ProxyHandler<Theme> {
   let accessLevel = 0;
   let rootProp = '';
+  function isThemeVariable<T extends Theme>(theme: T, name: keyof T) {
+    return typeof theme[name] === 'string';
+  }
   return {
     get(target, prop, receiver) {
       const propName = prop as keyof Theme;
-      ALL_USED_VARIABLES_SET.add(propName);
-      if (accessLevel === 0) {
-        rootProp = propName;
-        accumulator.add(propName);
-      } else {
-        if (!dependencies[rootProp]) {
-          dependencies[rootProp] = [propName];
-        } else if (!dependencies[rootProp].includes(propName)) {
-          dependencies[rootProp].push(propName);
+      if (isThemeVariable(target, propName)) {
+        ALL_USED_VARIABLES_SET.add(propName);
+        if (accessLevel === 0) {
+          rootProp = propName;
+          accumulator.add(propName);
+        } else {
+          if (!dependencies[rootProp]) {
+            dependencies[rootProp] = [propName];
+          } else if (!dependencies[rootProp].includes(propName)) {
+            dependencies[rootProp].push(propName);
+          }
         }
       }
       accessLevel++;


### PR DESCRIPTION
Фикс проблемы из [чата](https://kontur.slack.com/archives/C013HTCE18Q/p1646889580346469).

При извлечении всех переменных из объекта темы в список попадают лишние свойства объекта (вроде `_name`, `__emotion_styles`). Они же потом мешаются в таблице значений. Добавил проверку на соответствие свойства реальной переменной перед добавлением в список.