### PR TITLE
build: use registry from env

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "scripts": {
     "commit": "git-cz",
     "release": "env-cmd lerna version",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "preinstall": "node scripts/update-package-registry",
+    "postinstall": "node scripts/update-package-registry back"
   },
   "jest": {
     "projects": [

--- a/scripts/update-package-registry.js
+++ b/scripts/update-package-registry.js
@@ -3,7 +3,6 @@ const { existsSync, readFileSync, writeFileSync } = require('fs');
 const { execSync } = require('child_process');
 
 const LOCK_FILE_PATH = path.join(__dirname, '../yarn.lock');
-const ENV_FILE_PATH = path.join(__dirname, '../.env');
 const ENV_PACKAGE_REGISTRY = getRegistryFromEnv();
 
 if (ENV_PACKAGE_REGISTRY) {
@@ -11,12 +10,9 @@ if (ENV_PACKAGE_REGISTRY) {
   if (/^http(s?):\/\//.test(CONFIG_PACKAGE_REGISTRY) && CONFIG_PACKAGE_REGISTRY !== ENV_PACKAGE_REGISTRY) {
     const lockFile = readFileSync(LOCK_FILE_PATH, 'utf-8');
 
-    let modifiedLockFile;
-    if (process.argv.includes('back')) {
-      modifiedLockFile = lockFile.replaceAll(ENV_PACKAGE_REGISTRY, CONFIG_PACKAGE_REGISTRY);
-    } else {
-      modifiedLockFile = lockFile.replaceAll(CONFIG_PACKAGE_REGISTRY, ENV_PACKAGE_REGISTRY);
-    }
+    const modifiedLockFile = process.argv.includes('back')
+      ? lockFile.replaceAll(ENV_PACKAGE_REGISTRY, CONFIG_PACKAGE_REGISTRY)
+      : lockFile.replaceAll(CONFIG_PACKAGE_REGISTRY, ENV_PACKAGE_REGISTRY);
 
     writeFileSync(LOCK_FILE_PATH, modifiedLockFile);
   }
@@ -24,13 +20,14 @@ if (ENV_PACKAGE_REGISTRY) {
 
 function getRegistryFromEnv() {
   const ENV_VAR_NAME = 'PACKAGE_REGISTRY';
+  const ENV_FILE_PATH = path.join(__dirname, '../.env');
+
   if (process.env[ENV_VAR_NAME]) return process.env[ENV_VAR_NAME];
 
   if (!existsSync(ENV_FILE_PATH)) return undefined;
 
-  const envFile = readFileSync(ENV_FILE_PATH, 'utf-8');
-  return envFile.split('\n').reduce((acc, line) => {
-    const [name, value] = line.split('=');
-    return name === ENV_VAR_NAME ? value : acc;
-  }, undefined);
+  return readFileSync(ENV_FILE_PATH, 'utf-8')
+    .split('\n')
+    .find((line) => line.startsWith(`${ENV_VAR_NAME}=`))
+    ?.split('=')[1];
 }

--- a/scripts/update-package-registry.js
+++ b/scripts/update-package-registry.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { execSync } = require('child_process');
+
+const LOCK_FILE_PATH = path.join(__dirname, '../yarn.lock');
+const ENV_FILE_PATH = path.join(__dirname, '../.env');
+const ENV_PACKAGE_REGISTRY = getRegistryFromEnv();
+
+if (ENV_PACKAGE_REGISTRY) {
+  const CONFIG_PACKAGE_REGISTRY = execSync('yarn config get registry').toString().trim();
+  if (/^http(s?):\/\//.test(CONFIG_PACKAGE_REGISTRY) && CONFIG_PACKAGE_REGISTRY !== ENV_PACKAGE_REGISTRY) {
+    const lockFile = readFileSync(LOCK_FILE_PATH, 'utf-8');
+
+    let modifiedLockFile;
+    if (process.argv.includes('back')) {
+      modifiedLockFile = lockFile.replaceAll(ENV_PACKAGE_REGISTRY, CONFIG_PACKAGE_REGISTRY);
+    } else {
+      modifiedLockFile = lockFile.replaceAll(CONFIG_PACKAGE_REGISTRY, ENV_PACKAGE_REGISTRY);
+    }
+
+    writeFileSync(LOCK_FILE_PATH, modifiedLockFile);
+  }
+}
+
+function getRegistryFromEnv() {
+  const ENV_VAR_NAME = 'PACKAGE_REGISTRY';
+  if (process.env[ENV_VAR_NAME]) return process.env[ENV_VAR_NAME];
+
+  if (!existsSync(ENV_FILE_PATH)) return undefined;
+
+  const envFile = readFileSync(ENV_FILE_PATH, 'utf-8');
+  return envFile.split('\n').reduce((acc, line) => {
+    const [name, value] = line.split('=');
+    return name === ENV_VAR_NAME ? value : acc;
+  }, undefined);
+}


### PR DESCRIPTION
Добавил возможность менять регистр установки пакетов через переменную окружения. На случай временной блокировки npm.  