### PR TITLE
fix(Button): use default prop when "use"={null} (#2833)

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -241,7 +241,6 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
       icon,
       _noPadding,
       _noRightPadding,
-      use = Button.defaultProps.use,
       visuallyFocused,
       align,
       disableFocus,
@@ -253,6 +252,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
       width,
       children,
     } = this.props;
+    const use = this.props.use || Button.defaultProps.use;
     const sizeClass = this.getSizeClassName();
 
     const isFocused = this.state.focusedByTab || visuallyFocused;


### PR DESCRIPTION
Пересоздано из #2833 