### PR TITLE
fix(SidePage,Toast): fix animation bugs on hot-reloading

### DIFF
--- a/packages/react-ui/components/SidePage/SidePage.styles.ts
+++ b/packages/react-ui/components/SidePage/SidePage.styles.ts
@@ -359,9 +359,9 @@ export const styles = memoizeStyle({
 
   transitionActive() {
     return css`
-      transition: transform 0.18s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 0.18s cubic-bezier(0.22, 0.61, 0.36, 1);
-      opacity: 1;
-      transform: translate(0, 0);
+      transition: transform 0.18s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 18s cubic-bezier(0.22, 0.61, 0.36, 1);
+      opacity: 1 !important;
+      transform: translate(0, 0) !important;
     `;
   },
 
@@ -373,7 +373,9 @@ export const styles = memoizeStyle({
 
   transitionLeaveActive() {
     return css`
-      opacity: 0.01;
+      opacity: 0.01 !important;
+      transform: translateX(-100px) !important;
+
       transition: opacity 0.15s ease-out;
     `;
   },

--- a/packages/react-ui/components/Toast/Toast.styles.ts
+++ b/packages/react-ui/components/Toast/Toast.styles.ts
@@ -9,7 +9,7 @@ export const styles = memoizeStyle({
   enterActive() {
     return css`
       transition: transform 0.2s cubic-bezier(0.22, 0.61, 0.36, 1);
-      transform: translateY(0);
+      transform: translateY(0) !important;
     `;
   },
   exit() {
@@ -20,7 +20,7 @@ export const styles = memoizeStyle({
   },
   exitActive() {
     return css`
-      opacity: 0.01;
+      opacity: 0.01 !important;
       transition: opacity 0.15s ease-out;
     `;
   },


### PR DESCRIPTION
Так как классы внутри компонента CSSTransition применяются в обход Emotion и его [cx](https://github.com/skbkontur/retail-ui/pull/2488), то возможно нарушение порядка применения стилей и возникновение багов в анимации, как в [этом случае](https://kontur.slack.com/archives/C013HTCE18Q/p1647840249775719) (комбинация кастомизации и хот-релоадинга). 