### PR TITLE
test(smoke): use react 17

### DIFF
--- a/packages/react-ui-smoke-test/cra-template-react-ui/template.json
+++ b/packages/react-ui-smoke-test/cra-template-react-ui/template.json
@@ -1,6 +1,8 @@
 {
   "package": {
     "dependencies": {
+      "react": "^17.0.0",
+      "react-dom": "^17.0.0",
       "@testing-library/react": "^9.3.2",
       "@testing-library/jest-dom": "^4.2.4",
       "@testing-library/user-event": "^7.1.2",


### PR DESCRIPTION
После выхода React 18 обнаружились [конфликты зависимостей](https://tc.skbkontur.ru/buildConfiguration/FrontendInfrastructure_Packages_ReactUI_LintTest/25513237?buildTab=log&focusLine=5426&linesState=4510.4515) в шаблонном проекте для smoke-тестов. Возможно дело в версии ноды на агенте (16.13.0). Локально на 16.14.0 не воспроизвелось. Временно зафиксировал 17 реакт.