### PR TITLE
fix(DatePicker): fix focus and fragments selection

### DIFF
--- a/packages/react-ui/components/DateInput/DateInput.styles.ts
+++ b/packages/react-ui/components/DateInput/DateInput.styles.ts
@@ -36,13 +36,13 @@ export const styles = {
 
   value() {
     return css`
-      opacity: 0;
+      visibility: hidden;
     `;
   },
 
   valueVisible() {
     return css`
-      opacity: 1;
+      visibility: visible;
     `;
   },
 };


### PR DESCRIPTION
fixes [IF-441](https://yt.skbkontur.ru/issue/IF-441).

Фикс проблемы [из чата](https://kontur.slack.com/archives/C013HTCE18Q/p1649661864438279). Фрагменты даты перестали выделяться при первом фокусе, что блокировало ввод с клавиатуры.

Сломалось в #2614 (3.8.4). Там дата стала выводиться всегда, вне зависимости от фокуса и переданного value, но визуально скрывалась через прозрачность, когда ненужна. Это было сделано для стабилизации ширины контрола. Однако, клики по полю стали попадать на фрагменты этой скрытой даты, что приводило к инверсии `this.isMouseDown` и попаданию `null` в `state.selected`, вместо `this.iDateMediator.getLeftmostType()`.

https://github.com/skbkontur/retail-ui/blob/e7daa6f102653bc642bbb1954abd3be1228f4c92/packages/react-ui/components/DateInput/DateInput.tsx#L250-L254

Полечил через использование `visibility` вместо `opacity` для скрытия даты, который не пропускает клики.