### PR TITLE
test(smoke): fix type errors in smoke tests

### DIFF
--- a/packages/react-ui-smoke-test/cra-template-react-ui/template.json
+++ b/packages/react-ui-smoke-test/cra-template-react-ui/template.json
@@ -3,9 +3,8 @@
     "dependencies": {
       "react": "^17.0.0",
       "react-dom": "^17.0.0",
-      "@testing-library/react": "^9.3.2",
-      "@testing-library/jest-dom": "^4.2.4",
-      "@testing-library/user-event": "^7.1.2",
+      "@types/react": "^17.0.0",
+      "@types/react-dom": "^17.0.0",
       "typescript": "4.2.4",
       "@skbkontur/react-icons": "^3.2.0"
     }

--- a/packages/react-ui-smoke-test/cra-template-react-ui/template/src/setupTests.ts
+++ b/packages/react-ui-smoke-test/cra-template-react-ui/template/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/packages/react-ui-smoke-test/smoke.test.ts
+++ b/packages/react-ui-smoke-test/smoke.test.ts
@@ -74,8 +74,6 @@ function buildReactUI(reactUIPackagePath: string) {
 function initApplication(appDirectory: string, templateDirectory: string, reactUIPackagePath: string) {
   execSync(`npx create-react-app@latest ${appDirectory} --template file:${templateDirectory}`, { stdio: 'inherit' });
 
-  execSync(`npm i @types/node @types/react @types/react-dom @types/jest -D`, { cwd: appDirectory, stdio: 'inherit' });
-
   // yarn save and get package from cache
   // https://github.com/yarnpkg/yarn/issues/2165
   execSync(`npm install ${reactUIPackagePath}`, { cwd: appDirectory, stdio: 'inherit' });


### PR DESCRIPTION
Пофиксил smoke-тесты. 

После фиксирования 17-ой версии реакта в #2846 типы продолжили устанавливаться для 18-ой, что вызывало ошибки и падение теста. Зафиксировал их тоже.

Также, удалил неиспользовавшиеся настройки и зависимости.