### PR TITLE
fix(Popup): use content container as rootNode instead of anchorElement

### DIFF
--- a/packages/react-ui/components/Hint/Hint.tsx
+++ b/packages/react-ui/components/Hint/Hint.tsx
@@ -11,6 +11,7 @@ import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
 import { responsiveLayout } from '../ResponsiveLayout/decorator';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
+import { InstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 
 import { styles } from './Hint.styles';
 
@@ -88,7 +89,7 @@ const Positions: PopupPositionsType[] = [
  */
 @responsiveLayout
 @rootNode
-export class Hint extends React.PureComponent<HintProps, HintState> {
+export class Hint extends React.PureComponent<HintProps, HintState> implements InstanceWithAnchorElement {
   public static __KONTUR_REACT_UI__ = 'Hint';
 
   private isMobileLayout!: boolean;
@@ -109,6 +110,8 @@ export class Hint extends React.PureComponent<HintProps, HintState> {
   private timer: Nullable<number> = null;
   private theme!: Theme;
   private setRootNode!: TSetRootNode;
+
+  private popupRef = React.createRef<Popup>();
 
   public componentDidUpdate(prevProps: HintProps) {
     if (!this.props.manual) {
@@ -185,12 +188,17 @@ export class Hint extends React.PureComponent<HintProps, HintState> {
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
           useWrapper={this.props.useWrapper}
+          ref={this.popupRef}
         >
           {this.renderContent()}
         </Popup>
       </CommonWrapper>
     );
   }
+
+  public getAnchorElement = (): Nullable<HTMLElement> => {
+    return this.popupRef.current?.anchorElement;
+  };
 
   private renderContent() {
     if (!this.props.text) {

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -14,7 +14,8 @@ import { Theme } from '../../lib/theming/Theme';
 import { isTestEnv } from '../../lib/currentEnvironment';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { responsiveLayout } from '../ResponsiveLayout/decorator';
-import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
+import { rootNode, TSetRootNode } from '../../lib/rootNode';
+import { InstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 
 import { styles } from './Tooltip.styles';
 
@@ -150,7 +151,7 @@ const Positions: PopupPositionsType[] = [
 
 @rootNode
 @responsiveLayout
-export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
+export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> implements InstanceWithAnchorElement {
   public static __KONTUR_REACT_UI__ = 'Tooltip';
 
   private isMobileLayout!: boolean;
@@ -189,6 +190,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
   private clickedOutside = true;
   private setRootNode!: TSetRootNode;
 
+  private popupRef = React.createRef<Popup>();
   public componentDidUpdate(prevProps: TooltipProps) {
     if (this.props.trigger === 'closed' && this.state.opened) {
       this.close();
@@ -266,6 +268,10 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     );
   }
 
+  public getAnchorElement = (): Nullable<HTMLElement> => {
+    return this.popupRef.current?.anchorElement;
+  };
+
   /**
    * Программно открывает тултип.
    * <p>Не действует если проп *trigger* `'opened'` или `'closed'`.</p>
@@ -305,15 +311,11 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     }
 
     return (
-      <RenderLayer {...layerProps} getAnchorElement={this.getRenderLayerAnchorElement}>
+      <RenderLayer {...layerProps} getAnchorElement={this.getAnchorElement}>
         {popup}
       </RenderLayer>
     );
   }
-
-  private getRenderLayerAnchorElement = () => {
-    return getRootNode(this);
-  };
 
   private renderPopup(
     anchorElement: React.ReactNode | HTMLElement,
@@ -335,6 +337,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
           onClose={this.props.onClose}
           mobileOnCloseRequest={this.mobileCloseHandler}
           tryPreserveFirstRenderedPosition
+          ref={this.popupRef}
           {...popupProps}
         >
           {content}

--- a/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
+++ b/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
@@ -38,7 +38,7 @@ export class CommonWrapper<P extends CommonProps & CommonPropsRootNodeRef> exten
 > {
   private child: React.ReactNode;
   private setRootNode!: TSetRootNode;
-  private rootNodeSubscription: TRootNodeSubscription | null = null;
+  private rootNodeSubscription: Nullable<TRootNodeSubscription> = null;
 
   render() {
     const [{ className, style, rootNodeRef, ...dataProps }, { children, ...rest }] = extractCommonProps(this.props);
@@ -66,7 +66,7 @@ export class CommonWrapper<P extends CommonProps & CommonPropsRootNodeRef> exten
     this.rootNodeSubscription = null;
 
     if (instance && isInstanceWithRootNode(instance)) {
-      this.rootNodeSubscription = instance.addRootNodeChangeListener((node) => {
+      this.rootNodeSubscription = instance.addRootNodeChangeListener?.((node) => {
         this.setRootNode(node);
         this.props.rootNodeRef?.(node);
       });

--- a/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
+++ b/packages/react-ui/internal/CommonWrapper/CommonWrapper.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { isFunction, isRefableElement } from '../../lib/utils';
 import { cx } from '../../lib/theming/Emotion';
 import { Nullable } from '../../typings/utility-types';
-import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
+import { getRootNode, rootNode, TSetRootNode, TRootNodeSubscription, isInstanceWithRootNode } from '../../lib/rootNode';
 import { callChildRef } from '../../lib/callChildRef/callChildRef';
 
 export interface CommonProps {
@@ -38,6 +38,7 @@ export class CommonWrapper<P extends CommonProps & CommonPropsRootNodeRef> exten
 > {
   private child: React.ReactNode;
   private setRootNode!: TSetRootNode;
+  private rootNodeSubscription: TRootNodeSubscription | null = null;
 
   render() {
     const [{ className, style, rootNodeRef, ...dataProps }, { children, ...rest }] = extractCommonProps(this.props);
@@ -58,6 +59,19 @@ export class CommonWrapper<P extends CommonProps & CommonPropsRootNodeRef> exten
   private ref = (instance: Nullable<React.ReactInstance>) => {
     this.setRootNode(instance);
     this.props.rootNodeRef?.(getRootNode(instance));
+
+    // refs are called when instances change
+    // so we have to renew or remove old subscription
+    this.rootNodeSubscription?.remove();
+    this.rootNodeSubscription = null;
+
+    if (instance && isInstanceWithRootNode(instance)) {
+      this.rootNodeSubscription = instance.addRootNodeChangeListener((node) => {
+        this.setRootNode(node);
+        this.props.rootNodeRef?.(node);
+      });
+    }
+
     const originalRef = (this.child as React.RefAttributes<any>)?.ref;
     originalRef && callChildRef(originalRef, instance);
   };

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -21,6 +21,7 @@ import { responsiveLayout } from '../../components/ResponsiveLayout/decorator';
 import { MobilePopup } from '../MobilePopup';
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { callChildRef } from '../../lib/callChildRef/callChildRef';
+import { isInstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 
 import { PopupPin } from './PopupPin';
 import { Offset, PopupHelper, PositionObject, Rect } from './PopupHelper';
@@ -194,10 +195,11 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   private layoutEventsToken: Nullable<ReturnType<typeof LayoutEvents.addListener>>;
   private locationUpdateId: Nullable<number> = null;
   private lastPopupElement: Nullable<HTMLElement>;
-  private anchorElement: Nullable<HTMLElement> = null;
   private isMobileLayout!: boolean;
   private setRootNode!: TSetRootNode;
   private refForTransition = React.createRef<HTMLDivElement>();
+
+  public anchorElement: Nullable<HTMLElement> = null;
 
   public componentDidMount() {
     this.updateLocation();
@@ -316,8 +318,8 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     );
   }
 
-  private updateAnchorElement = (childInstance: Nullable<React.ReactInstance>) => {
-    const childDomNode = getRootNode(childInstance);
+  private updateAnchorElement = (instance: Nullable<React.ReactInstance>) => {
+    const childDomNode = isInstanceWithAnchorElement(instance) ? instance.getAnchorElement() : getRootNode(instance);
     const anchorElement = this.anchorElement;
 
     if (childDomNode !== anchorElement) {

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -298,13 +298,17 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     // we need to get anchor's DOM node
     // so we either set our own ref on it via cloning
     // or relay on findDOMNode (inside getRootNode)
-    // which should be called with RenderContainer's ref
+    // which should be called within updateAnchorElement
     // in the case when the anchor is not refable
 
     const canGetAnchorNode = !!anchorWithRef || isHTMLElement(anchorElement);
 
     return (
-      <RenderContainer anchor={anchorWithRef || anchor} ref={canGetAnchorNode ? null : this.renderContainerRef}>
+      <RenderContainer
+        anchor={anchorWithRef || anchor}
+        containerRef={this.setRootNode}
+        ref={canGetAnchorNode ? null : this.updateAnchorElement}
+      >
         {this.isMobileLayout && !this.props.withoutMobile
           ? this.renderMobile()
           : location && this.renderContent(location)}
@@ -312,11 +316,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     );
   }
 
-  private renderContainerRef = (childInstance: Nullable<React.ReactInstance>) => {
-    this.updateAnchorElement(childInstance);
-  };
-
-  private updateAnchorElement(childInstance: Nullable<React.ReactInstance>) {
+  private updateAnchorElement = (childInstance: Nullable<React.ReactInstance>) => {
     const childDomNode = getRootNode(childInstance);
     const anchorElement = this.anchorElement;
 
@@ -324,9 +324,8 @@ export class Popup extends React.Component<PopupProps, PopupState> {
       this.removeEventListeners(anchorElement);
       this.anchorElement = childDomNode;
       this.addEventListeners(childDomNode);
-      this.setRootNode(childDomNode);
     }
-  }
+  };
 
   private addEventListeners(element: Nullable<HTMLElement>) {
     if (element && isHTMLElement(element)) {

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -308,6 +308,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     return (
       <RenderContainer
         anchor={anchorWithRef || anchor}
+        // rootNode for Popup is its content container, see #2873
         containerRef={this.setRootNode}
         ref={canGetAnchorNode ? null : this.updateAnchorElement}
       >

--- a/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
+++ b/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
@@ -4,6 +4,7 @@ import { canUseDOM, isBrowser } from '../../lib/client';
 import { Nullable } from '../../typings/utility-types';
 import { getRandomID } from '../../lib/utils';
 import { Upgrade } from '../../lib/Upgrades';
+import { callChildRef } from '../../lib/callChildRef/callChildRef';
 
 import { RenderInnerContainer } from './RenderInnerContainer';
 import { RenderContainerProps } from './RenderContainerTypes';
@@ -57,6 +58,10 @@ export class RenderContainer extends React.Component<RenderContainerProps> {
     }
     if (this.domContainer && this.domContainer.parentNode !== document.body) {
       document.body.appendChild(this.domContainer);
+
+      if (this.props.containerRef) {
+        callChildRef(this.props.containerRef, this.domContainer);
+      }
       if (window.ReactTesting) {
         window.ReactTesting.addRenderContainer(this.rootId, this);
       }
@@ -73,6 +78,10 @@ export class RenderContainer extends React.Component<RenderContainerProps> {
   private unmountContainer() {
     if (this.domContainer && this.domContainer.parentNode) {
       this.domContainer.parentNode.removeChild(this.domContainer);
+
+      if (this.props.containerRef) {
+        callChildRef(this.props.containerRef, null);
+      }
 
       if (window.ReactTesting) {
         window.ReactTesting.removeRenderContainer(this.rootId);

--- a/packages/react-ui/internal/RenderContainer/RenderContainerTypes.ts
+++ b/packages/react-ui/internal/RenderContainer/RenderContainerTypes.ts
@@ -11,4 +11,5 @@ export interface PortalProps {
 export interface RenderContainerProps extends CommonProps {
   anchor?: React.ReactNode;
   children?: React.ReactNode;
+  containerRef?: React.Ref<HTMLElement>;
 }

--- a/packages/react-ui/lib/InstanceWithAnchorElement.ts
+++ b/packages/react-ui/lib/InstanceWithAnchorElement.ts
@@ -1,0 +1,9 @@
+import { Nullable } from '../typings/utility-types';
+
+export interface InstanceWithAnchorElement {
+  getAnchorElement: () => Nullable<HTMLElement>;
+}
+
+export const isInstanceWithAnchorElement = (instance: unknown): instance is InstanceWithAnchorElement => {
+  return Boolean(instance) && Object.prototype.hasOwnProperty.call(instance, 'getAnchorElement');
+};

--- a/packages/react-ui/lib/SSRSafe.ts
+++ b/packages/react-ui/lib/SSRSafe.ts
@@ -20,6 +20,14 @@ export function isHTMLElement(el: any): el is HTMLElement {
   return false;
 }
 
+export function isNode(node: unknown): node is Node {
+  if (isBrowser) {
+    return node instanceof Node;
+  }
+
+  return false;
+}
+
 export const globalThat: typeof globalThis =
   (typeof globalThis === 'object' && globalThis) ||
   (typeof global === 'object' && global) ||

--- a/packages/react-ui/lib/rootNode/getRootNode.ts
+++ b/packages/react-ui/lib/rootNode/getRootNode.ts
@@ -2,9 +2,10 @@ import { findDOMNode } from 'react-dom';
 import React from 'react';
 
 import { Nullable } from '../../typings/utility-types';
-import { isHTMLElement } from '../SSRSafe';
+import { isHTMLElement, isNode } from '../SSRSafe';
 import { canUseDOM } from '../client';
-import { isFunction } from '../utils';
+
+import { isInstanceWithRootNode } from './rootNodeDecorator';
 
 export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<HTMLElement> => {
   if (!canUseDOM) return null;
@@ -12,16 +13,18 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<H
     return instance;
   }
 
-  const instanceAsAny = instance as any;
-  let node;
-  if (instanceAsAny && isFunction(instanceAsAny.getRootNode)) {
-    node = instanceAsAny.getRootNode();
+  let rootNode;
+
+  // it happened to be that native Node interface also has
+  // the "getRootNode" method, but we dont expect it here
+  if (isInstanceWithRootNode(instance) && !isNode(instance)) {
+    rootNode = instance.getRootNode();
   }
 
-  if (node !== undefined) {
-    return node;
+  if (rootNode !== undefined) {
+    return rootNode;
   }
 
-  node = findDOMNode(instance);
-  return node instanceof HTMLElement ? node : null;
+  rootNode = findDOMNode(instance);
+  return isHTMLElement(rootNode) ? rootNode : null;
 };

--- a/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
+++ b/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import EventEmitter from 'eventemitter3';
 
 import { Nullable } from '../../typings/utility-types';
 
 import { getRootNode } from './getRootNode';
 
 export type TSetRootNode = (e: Nullable<React.ReactNode>) => void;
+
+export type TRootNodeSubscription = {
+  remove: () => void;
+};
 
 export interface InstanceWithRootNode {
   getRootNode: () => Nullable<HTMLElement>;
@@ -13,16 +18,30 @@ export interface InstanceWithRootNode {
 export function rootNode<T extends new (...args: any[]) => React.Component>(Component: T) {
   const rootNode = class extends Component implements InstanceWithRootNode {
     public rootNode: Nullable<HTMLElement> = null;
+    public rootNodeEmitter = new EventEmitter();
     public constructor(...args: any[]) {
       super(args[0]);
     }
 
     public setRootNode = (instance: Nullable<React.ReactInstance>) => {
-      this.rootNode = getRootNode(instance);
+      const rootNode = getRootNode(instance);
+      if (rootNode !== this.rootNode) {
+        this.rootNode = rootNode;
+        this.rootNodeEmitter.emit('change', rootNode);
+      }
     };
 
     public getRootNode = (): Nullable<HTMLElement> => {
       return this.rootNode;
+    };
+
+    public addRootNodeChangeListener = (callback: (node: Nullable<HTMLElement>) => void): TRootNodeSubscription => {
+      this.rootNodeEmitter.addListener('change', callback);
+      return {
+        remove: () => {
+          this.rootNodeEmitter.removeListener('change', callback);
+        },
+      };
     };
   };
 

--- a/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
+++ b/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
@@ -6,9 +6,13 @@ import { getRootNode } from './getRootNode';
 
 export type TSetRootNode = (e: Nullable<React.ReactNode>) => void;
 
+export interface InstanceWithRootNode {
+  getRootNode: () => Nullable<HTMLElement>;
+}
+
 export function rootNode<T extends new (...args: any[]) => React.Component>(Component: T) {
-  const rootNode = class extends Component {
-    public rootNode: Nullable<HTMLElement>;
+  const rootNode = class extends Component implements InstanceWithRootNode {
+    public rootNode: Nullable<HTMLElement> = null;
     public constructor(...args: any[]) {
       super(args[0]);
     }
@@ -29,3 +33,7 @@ export function rootNode<T extends new (...args: any[]) => React.Component>(Comp
 
   return rootNode;
 }
+
+export const isInstanceWithRootNode = (instance: unknown): instance is InstanceWithRootNode => {
+  return Boolean(instance) && Object.prototype.hasOwnProperty.call(instance, 'getRootNode');
+};

--- a/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
+++ b/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
@@ -13,6 +13,7 @@ export type TRootNodeSubscription = {
 
 export interface InstanceWithRootNode {
   getRootNode: () => Nullable<HTMLElement>;
+  addRootNodeChangeListener?: (callback: (node: Nullable<HTMLElement>) => void) => TRootNodeSubscription;
 }
 
 export function rootNode<T extends new (...args: any[]) => React.Component>(Component: T) {


### PR DESCRIPTION
После #2518 с избавлением от `findDOMNode` и реализации своего `getRootNode` во всех компонентах в нашем новом механизме получения корневых DOM-элементов осталось несколько проблем:

1. Неправильно установили, что является корневым элементом у Popup (и Tooltip)
2. Не учли, что корневые элементы могут меняться (и появляться) не только при mount/unmount
3. Некоторые сценарии у Tooltip и Hint не работают в условиях пункта 1)

Сперва было неочевидно, но после обнаружения бага из задачи, стало понятно, что корневым элементом `Popup` (и соответственно `Tooltip` и `Hint`) должен являться контейнер, в который рендерится содержимое `Popup`, а не его `anchorElement`, как мы установили изначально. Это следует из того, что, например, `RenderLayer`, в который оборачивается `Popup` внутри `Tooltip`, слушает клики снаружи корневого элемента своих `children`. И по дизайну он должен ловить клики именно вне контента `Tooltip`. А до этой правки клики слушались вне `anchorElement`, что приводило к закрытию `Tooltip` после клика его контенту (причина бага).

Далее оказалось, что в новых обстоятельствах, когда корневой элемент `Popup` это контейнер с его содержимым, он может появляться не сразу при монтировании `Popup`, а  позже, в любой произвольный момент, когда `Popup` открывается. Но наш механизм с простановкой `rootNode`, построенный на `ref`-ах (внутри `CommonWrapper`), работает только c  mount/unmount.  Поэтому, его пришлось доработать, и добавить подписку на изменение `rootNode`.

Последний нюанс, всплывший после исправления пункта 1), состоял в том, что `Tooltip` и `Hint` могут вкладываться друг в друга. А внутри им бывает нужно получить `anchorElement` из своих `children` (которыми в этом случае тоже будут другие `Tooltip` и `Hint`). Поскольку, для получения `anchorElement` из `children` используется тот же механизм с извлечением корневого элемента, из `Tooltip` и `Hint` теперь начал извлекаться вышеописанный контейнер, а не `anchorElement` как в предыдущем решении, который на самом деле нужен в этой ситуации. Поэтому, конкретно для случая 
```jsx
<Tooltip render={() => 'Tooltip 1'}>
  <Tooltip render={() => 'Tooltip 2'}>
    <Button />
  </Tooltip>
</Tooltip>
``` 
(и аналогично с Hint), был добавлен способ извлечения правильного `anchorElement` (в примере, `<Button />`).

IF-437