### PR TITLE
refactor(react-ui, validations): add isObject and hasOwnProperty utils

### DIFF
--- a/packages/react-ui-validations/src/Validations/ValidationBuilder.ts
+++ b/packages/react-ui-validations/src/Validations/ValidationBuilder.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { Nullable } from '../../typings/Types';
 import { ValidationBehaviour, ValidationLevel } from '../ValidationWrapperInternal';
 import { ValidationInfo } from '../ValidationWrapper';
+import { hasOwnProperty, isObject } from '../utils/utils';
 
 import { LambdaPath, PathTokensCache } from './PathHelper';
 import { ValidationWriter } from './ValidationWriter';
@@ -94,4 +95,4 @@ export class ValidationBuilder<TRoot, T> {
 }
 
 const isValidationInfo = (argument: unknown): argument is ValidationInfo =>
-  typeof argument === 'object' && Object.prototype.hasOwnProperty.call(argument, 'message');
+  isObject(argument) && hasOwnProperty(argument, 'message');

--- a/packages/react-ui-validations/src/utils/callChildRef/callChildRef.ts
+++ b/packages/react-ui-validations/src/utils/callChildRef/callChildRef.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Nullable } from '../../../typings/Types';
+import { hasOwnProperty } from '../utils';
 
 export const callChildRef = (
   componentRef: React.RefCallback<any> | React.RefObject<any>,
@@ -12,7 +13,7 @@ export const callChildRef = (
   if (typeof componentRef === 'function') {
     componentRef(instance);
   }
-  if (Object.prototype.hasOwnProperty.call(componentRef, 'current')) {
+  if (hasOwnProperty(componentRef, 'current')) {
     // @ts-ignore
     componentRef.current = instance;
   }

--- a/packages/react-ui-validations/src/utils/utils.ts
+++ b/packages/react-ui-validations/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { Nullable } from '../../typings/Types';
+
 const env: NodeJS.ProcessEnv = (typeof process === 'object' && process && process.env) || {};
 const { enableReactTesting, NODE_ENV, REACT_UI_TEST, REACT_APP_REACT_UI_TEST, STORYBOOK_REACT_UI_TEST } = env;
 
@@ -10,3 +12,11 @@ const isReactUITestEnv =
 export const isTestEnv = NODE_ENV === 'test' || isReactUITestEnv;
 
 export const isBrowser = typeof window !== 'undefined';
+
+export function isObject(x: unknown): x is object {
+  return (typeof x === 'object' && x !== null && !Array.isArray(x)) || typeof x === 'function';
+}
+
+export const hasOwnProperty = (object: Nullable<object>, propertyName: string): boolean => {
+  return Boolean(object) && Object.prototype.hasOwnProperty.call(object, propertyName);
+};

--- a/packages/react-ui/components/MenuHeader/MenuHeader.tsx
+++ b/packages/react-ui/components/MenuHeader/MenuHeader.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, useContext } from 'react';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
+import { hasOwnProperty, isObject } from '../../lib/utils';
 
 import { styles } from './MenuHeader.styles';
 
@@ -41,7 +42,7 @@ MenuHeader.__MENU_HEADER__ = true;
 export { MenuHeader };
 
 export const isMenuHeader = (child: React.ReactNode): child is React.ReactElement<MenuHeaderProps> => {
-  return React.isValidElement<MenuHeaderProps>(child)
-    ? Object.prototype.hasOwnProperty.call(child.type, '__MENU_HEADER__')
+  return React.isValidElement<MenuHeaderProps>(child) && isObject(child.type)
+    ? hasOwnProperty(child.type, '__MENU_HEADER__')
     : false;
 };

--- a/packages/react-ui/components/ScrollContainer/ScrollBar.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollBar.tsx
@@ -4,6 +4,7 @@ import { Nullable } from '../../typings/utility-types';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { cx } from '../../lib/theming/Emotion';
+import { hasOwnProperty } from '../../lib/utils';
 
 import { defaultScrollbarState, scrollSizeParametersNames } from './ScrollContainer.constants';
 import { styles, globalClasses } from './ScrollContainer.styles';
@@ -184,7 +185,7 @@ export class ScrollBar extends React.Component<ScrollBarProps, ScrollBarState> {
         mouseMoveEvent.preventDefault();
       }
 
-      if (Object.prototype.hasOwnProperty.call(mouseMoveEvent, 'returnValue')) {
+      if (hasOwnProperty(mouseMoveEvent, 'returnValue')) {
         (
           mouseMoveEvent as MouseEvent & {
             returnValue: boolean;

--- a/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
+++ b/packages/react-ui/components/__tests__/PropsForwarding-test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
 import * as ReactUI from '../../index';
+import { hasOwnProperty } from '../../lib/utils';
 
 // all components that are available for import from the react-ui
 const PUBLIC_COMPONENTS = Object.keys(ReactUI).filter((name) => {
@@ -179,6 +180,6 @@ export function isPublicComponent(component: any) {
   // it's either ClassComponent or FunctionalComponent with Kontur's mark
   return (
     typeof component === 'function' &&
-    (component.prototype.isReactComponent || Object.prototype.hasOwnProperty.call(component, '__KONTUR_REACT_UI__'))
+    (component.prototype.isReactComponent || hasOwnProperty(component, '__KONTUR_REACT_UI__'))
   );
 }

--- a/packages/react-ui/internal/ThemePlayground/ThemeEditor.tsx
+++ b/packages/react-ui/internal/ThemePlayground/ThemeEditor.tsx
@@ -4,6 +4,7 @@ import { ThemeFactory } from '../../lib/theming/ThemeFactory';
 import { Theme } from '../../lib/theming/Theme';
 import { Gapped } from '../../components/Gapped';
 import { Loader } from '../../components/Loader';
+import { hasOwnProperty } from '../../lib/utils';
 
 import { VariableValue } from './VariableValue';
 import { VARIABLES_GROUPS, DEPRECATED_VARIABLES } from './constants';
@@ -152,7 +153,7 @@ const prefixesReducer = (acc: string[], current: { title: string; prefix: string
 type GetBaseVariablesReturnType = Array<keyof Theme>;
 const getBaseVariables = (theme: Theme, variable: keyof Theme): GetBaseVariablesReturnType => {
   for (; theme != null; theme = Object.getPrototypeOf(theme)) {
-    if (Object.prototype.hasOwnProperty.call(theme, variable)) {
+    if (hasOwnProperty(theme, variable)) {
       const descriptor = Object.getOwnPropertyDescriptor(theme, variable);
 
       if (descriptor && typeof descriptor.get !== 'undefined') {

--- a/packages/react-ui/lib/InstanceWithAnchorElement.ts
+++ b/packages/react-ui/lib/InstanceWithAnchorElement.ts
@@ -1,9 +1,11 @@
 import { Nullable } from '../typings/utility-types';
 
+import { hasOwnProperty } from './utils';
+
 export interface InstanceWithAnchorElement {
   getAnchorElement: () => Nullable<HTMLElement>;
 }
 
-export const isInstanceWithAnchorElement = (instance: unknown): instance is InstanceWithAnchorElement => {
-  return Boolean(instance) && Object.prototype.hasOwnProperty.call(instance, 'getAnchorElement');
+export const isInstanceWithAnchorElement = (instance: Nullable<object>): instance is InstanceWithAnchorElement => {
+  return hasOwnProperty(instance, 'getAnchorElement');
 };

--- a/packages/react-ui/lib/ModalStack.ts
+++ b/packages/react-ui/lib/ModalStack.ts
@@ -4,6 +4,8 @@ import EventEmitter from 'eventemitter3';
 import { SidePageProps } from '../components/SidePage';
 import { ModalProps } from '../components/Modal';
 
+import { hasOwnProperty } from './utils';
+
 interface StackInfo {
   emitter: EventEmitter;
   mounted: React.Component[];
@@ -99,7 +101,7 @@ const isReactUIInstance = <T>(componentName: string) => {
     const { constructor } = instance;
 
     return (
-      Object.prototype.hasOwnProperty.call(constructor, '__KONTUR_REACT_UI__') &&
+      hasOwnProperty(constructor, '__KONTUR_REACT_UI__') &&
       // @ts-ignore
       constructor.__KONTUR_REACT_UI__ === componentName
     );

--- a/packages/react-ui/lib/callChildRef/callChildRef.ts
+++ b/packages/react-ui/lib/callChildRef/callChildRef.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Nullable } from '../../typings/utility-types';
+import { hasOwnProperty } from '../utils';
 
 export const callChildRef = (
   componentRef: React.RefCallback<any> | React.RefObject<any>,
@@ -12,7 +13,7 @@ export const callChildRef = (
   if (typeof componentRef === 'function') {
     componentRef(instance);
   }
-  if (Object.prototype.hasOwnProperty.call(componentRef, 'current')) {
+  if (hasOwnProperty(componentRef, 'current')) {
     // @ts-ignore
     componentRef.current = instance;
   }

--- a/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
+++ b/packages/react-ui/lib/rootNode/rootNodeDecorator.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import EventEmitter from 'eventemitter3';
 
 import { Nullable } from '../../typings/utility-types';
+import { hasOwnProperty } from '../utils';
 
 import { getRootNode } from './getRootNode';
 
@@ -54,6 +55,6 @@ export function rootNode<T extends new (...args: any[]) => React.Component>(Comp
   return rootNode;
 }
 
-export const isInstanceWithRootNode = (instance: unknown): instance is InstanceWithRootNode => {
-  return Boolean(instance) && Object.prototype.hasOwnProperty.call(instance, 'getRootNode');
+export const isInstanceWithRootNode = (instance: Nullable<object>): instance is InstanceWithRootNode => {
+  return hasOwnProperty(instance, 'getRootNode');
 };

--- a/packages/react-ui/lib/styles/ColorFactory.ts
+++ b/packages/react-ui/lib/styles/ColorFactory.ts
@@ -1,5 +1,7 @@
 import warning from 'warning';
 
+import { hasOwnProperty } from '../utils';
+
 import { clamp, extractColorParts, hue2rgb, parseHSLParts, parseRGBParts } from './ColorHelpers';
 import { ColorKeywords } from './ColorKeywords';
 import { ColorKeywordsType, ColorObject, ColorType, RGBTuple } from './ColorObject';
@@ -66,7 +68,7 @@ export class ColorFactory {
   }
 
   private static isKeyword(input: string): input is ColorKeywordsType {
-    return Object.prototype.hasOwnProperty.call(ColorKeywords, input);
+    return hasOwnProperty(ColorKeywords, input);
   }
 
   private static fromKeyword(keyword: ColorKeywordsType) {

--- a/packages/react-ui/lib/theming/ThemeHelpers.ts
+++ b/packages/react-ui/lib/theming/ThemeHelpers.ts
@@ -1,3 +1,5 @@
+import { hasOwnProperty } from '../utils';
+
 import { Theme, ThemeIn } from './Theme';
 
 export const exposeGetters = <T extends object>(theme: T): T => {
@@ -32,7 +34,7 @@ export const markAsDarkTheme = <T extends object>(theme: T): T => {
 
 export function findPropertyDescriptor(theme: Theme, propName: keyof Theme) {
   for (; theme != null; theme = Object.getPrototypeOf(theme)) {
-    if (Object.prototype.hasOwnProperty.call(theme, propName)) {
+    if (hasOwnProperty(theme, propName)) {
       return Object.getOwnPropertyDescriptor(theme, propName) || {};
     }
   }

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -2,6 +2,8 @@ import { ReactComponentLike } from 'prop-types';
 import React from 'react';
 import { isForwardRef } from 'react-is';
 
+import { Nullable } from '../typings/utility-types';
+
 import { isBrowser } from './client';
 
 // NOTE: Copy-paste from @types/react
@@ -42,6 +44,10 @@ export function isFunction<T>(x: T | Function): x is Function {
   return typeof x === 'function';
 }
 
+export function isObject(x: unknown): x is object {
+  return (typeof x === 'object' && x !== null && !Array.isArray(x)) || typeof x === 'function';
+}
+
 export function isFunctionalComponent(Component: ReactComponentLike): boolean {
   return Boolean(typeof Component === 'function' && !(Component.prototype && Component.prototype.isReactComponent));
 }
@@ -72,15 +78,19 @@ export const isExternalLink = (link: string): boolean => {
  * Check if the given ReactNode is an element of the specified ReactUI component
  */
 export const isReactUINode = (componentName: string, node: React.ReactNode): boolean => {
-  if (React.isValidElement(node)) {
+  if (React.isValidElement(node) && isObject(node.type)) {
     return (
-      Object.prototype.hasOwnProperty.call(node.type, '__KONTUR_REACT_UI__') &&
+      hasOwnProperty(node.type, '__KONTUR_REACT_UI__') &&
       // @ts-ignore
       node.type.__KONTUR_REACT_UI__ === componentName
     );
   }
 
   return false;
+};
+
+export const hasOwnProperty = (object: Nullable<object>, propertyName: string): boolean => {
+  return Boolean(object) && Object.prototype.hasOwnProperty.call(object, propertyName);
 };
 
 const KB = 1024;


### PR DESCRIPTION
Добавил утилиты `isObject` и `hasOwnProperty` для упрощения кода. Отрефакторил все места.

---

ps: `object` это [любой непримитивный тип](https://exploringjs.com/tackling-ts/ch_typing-objects.html#:~:text=In%20TypeScript%2C%20object%20is%20the,any%20properties%20of%20a%20value.), который включает функции.