### PR TITLE
Validation text render

### DIFF
--- a/packages/react-ui-validations/docs/Common/Form.tsx
+++ b/packages/react-ui-validations/docs/Common/Form.tsx
@@ -16,6 +16,7 @@ const Title = styled.span`
 
 const Content = styled.span`
   display: inline-flex;
+  position: relative;
 `;
 
 interface FormLineProps {

--- a/packages/react-ui-validations/src/ErrorRenderer.tsx
+++ b/packages/react-ui-validations/src/ErrorRenderer.tsx
@@ -26,18 +26,18 @@ export function text(pos: 'bottom' | 'right' = 'right'): RenderErrorMessage {
   if (pos === 'right') {
     return (control, hasError, validation) => {
       return (
-        <span style={{ display: 'inline-block' }}>
+        <>
           {control}
           <span data-validation-message="text" style={{ marginLeft: '10px', color: '#d43517' }}>
             {(validation && validation.message) || ''}
           </span>
-        </span>
+        </>
       );
     };
   }
   return (control, hasError, validation) => {
     return (
-      <span style={{ position: 'relative', display: 'inline-block' }}>
+      <>
         {control}
         <span style={{ position: 'absolute', bottom: 0, left: 0, height: 0 }}>
           <span
@@ -54,7 +54,7 @@ export function text(pos: 'bottom' | 'right' = 'right'): RenderErrorMessage {
             {(validation && validation.message) || ''}
           </span>
         </span>
-      </span>
+      </>
     );
   };
 }


### PR DESCRIPTION
IF-528
### Проблема:
Валидация текстом сейчас оборачивает контрол и текст валидации в спаны, поэтому у контрола не работает ширина в процентах.
[Песочница](https://codesandbox.io/s/delicate-field-ddrew0?file=/src/index.js)

### Решение: 
Убрать обертки вокруг контролов