### PR TITLE
fix(Select): consider undefined an empty value

### DIFF
--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -154,6 +154,7 @@ export interface SelectState<TValue> {
   opened: boolean;
   searchPattern: string;
   value: Nullable<TValue>;
+  isUncontrolled: boolean;
 }
 
 interface FocusableReactElement extends React.ReactElement<any> {
@@ -212,6 +213,7 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
     opened: false,
     value: this.props.defaultValue,
     searchPattern: '',
+    isUncontrolled: false,
   };
 
   private theme!: Theme;
@@ -221,6 +223,12 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
   private buttonElement: FocusableReactElement | null = null;
   private getProps = createPropsGetter(Select.defaultProps);
   private setRootNode!: TSetRootNode;
+
+  public componentDidMount() {
+    // TODO: Replace appealing to `_reactInternals` with `forwardRef` in process of functional refactoring
+    // @ts-expect-error: accesing internal value of React
+    this.setState({ isUncontrolled: !!this._reactInternals?.ref && this.props.value === undefined });
+  }
 
   public componentDidUpdate(_prevProps: SelectProps<TValue, TItem>, prevState: SelectState<TValue>) {
     if (!prevState.opened && this.state.opened) {
@@ -605,10 +613,10 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
   }
 
   private getValue() {
-    if (this.props.value !== undefined) {
-      return this.props.value;
+    if (this.state.isUncontrolled) {
+      return this.state.value;
     }
-    return this.state.value;
+    return this.props.value;
   }
 
   private mapItems(fn: (value: TValue, item: TItem, index: number, comment?: string) => React.ReactNode) {


### PR DESCRIPTION
fixes [IF-546](https://yt.skbkontur.ru/agiles/101-1467/current?issue=IF-546)

При попытке сбросить `value` в `Select`'е через `undefined` - ничего не происходит
Данное поведение воспроизводится во всех версиях библиотеки

Код для воспроизведения в доке:
```tsx
const [value, setValue] = React.useState();

const items = [Select.static(() => <Select.Item>Not selectable</Select.Item>), 'One', 'Two', 'Three', Select.SEP, 'Four'];

<>
  <Select items={items} value={value} onValueChange={setValue} />
  <button onClick={() => setValue(undefined)}>clear</button>
</>
```

Это происходит из-за наивной проверки на неконтролируемость контрола: `value !== undefined`, из-за чего, когда в контролируемый `Select` передаётся `undefined` в качестве `value` - `Select` внутри компонента начинает считаться неконтролируемым

Так как главный атрибут неконтролируемого элемента - это наличие `ref`'ки добавил дополнительную проверку, на то, что в контрол была передана `ref`'ка. Для реализации этой логики пришлось использовать внутренние механизмы `React`'а, но с учётом того, что мы в ближайшее время планируем отказаться от классовых компонентов - это изменение не такое страшное, каким может показаться

К такой реализации всё ещё есть несколько вопросов:
1. Расширенной проверки всё ещё недостаточно для некоторых эдж-кейсов. Например, когда мы пытаемся стереть `value` у контролируемого `Select`'а, в который передана `ref`'ка. Для этого нужно проверять что в `Select` был передан `onValueChange`, но если мы проверяем был ли передан `onValueChange` - это избавляет от нужды проверки того, была ли передана `ref`'ка. Из чего вытекает вопрос: нужно ли нам поддерживать `onValueChange` для неконтролируемых компонентов? Так как де-факто при изменении `value` (даже в неконтролируемом компоненте) `onValueChange` отрабатывает корректно 
2. Не будет ли это ломающим изменением? Сейчас упало некоторое количество скриншотов, но я грешу на то, что все они упали из-за причуд `Creevey`, так как код из упавших тестов корректно отрабатывает, если протестировать его ручками в плейграунде

<hr />

Ну и как обычно для подобных пулл-реквестов: не стал писать тесты до того как полноценно определимся с решением (ну и ещё `Creevey` снова отказывается запускаться локально)