### PR TITLE
build: use package dotenv to read env vars

### DIFF
--- a/scripts/update-package-registry.js
+++ b/scripts/update-package-registry.js
@@ -1,9 +1,10 @@
 const path = require('path');
-const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 const { execSync } = require('child_process');
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
 
 const LOCK_FILE_PATH = path.join(__dirname, '../yarn.lock');
-const ENV_PACKAGE_REGISTRY = getRegistryFromEnv();
+const ENV_PACKAGE_REGISTRY = process.env.PACKAGE_REGISTRY;
 
 if (ENV_PACKAGE_REGISTRY) {
   const CONFIG_PACKAGE_REGISTRY = execSync('yarn config get registry').toString().trim();
@@ -16,18 +17,4 @@ if (ENV_PACKAGE_REGISTRY) {
 
     writeFileSync(LOCK_FILE_PATH, modifiedLockFile);
   }
-}
-
-function getRegistryFromEnv() {
-  const ENV_VAR_NAME = 'PACKAGE_REGISTRY';
-  const ENV_FILE_PATH = path.join(__dirname, '../.env');
-
-  if (process.env[ENV_VAR_NAME]) return process.env[ENV_VAR_NAME];
-
-  if (!existsSync(ENV_FILE_PATH)) return undefined;
-
-  return readFileSync(ENV_FILE_PATH, 'utf-8')
-    .split('\n')
-    .find((line) => line.startsWith(`${ENV_VAR_NAME}=`))
-    ?.split('=')[1];
 }


### PR DESCRIPTION
Заметил, что в скрипте `update-package-registry.js` вручную парсится файл `.env`.
У нас уже установлен пакет `dotenv` для такого, поэтому решил его заюзать.