### PR TITLE
[listenFocusOutside] Убрал из текста ошибки id контейнера

### DIFF
--- a/packages/react-ui/lib/listenFocusOutside.ts
+++ b/packages/react-ui/lib/listenFocusOutside.ts
@@ -85,7 +85,7 @@ export function findRenderContainer(node: Element, rootNode: Element, container?
     const nextNode = document.querySelector(`[data-render-container-id~="${newContainerId}"]`);
 
     if (!nextNode) {
-      throw Error(`Origin node for container with id ${newContainerId} was not found`);
+      throw Error(`Origin node for render container was not found`);
     }
 
     return findRenderContainer(nextNode, rootNode, nextNode);


### PR DESCRIPTION
При удалении компонента из DOM можно получить ошибку `Origin node for container with id 34523452345 was not found`. Но такие ошибки не схлапываются в сентри, т.к. есть уникальные символы в строке. Сам id контейнера в тексте ошибки не несет никакой пользы.

Предлагаю выпилить id из текста ошибки.