### PR TITLE
refactor(Checkbox): simplify API for setting indeterminate state

### DIFF
--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chrome/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chrome/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:925edab30f2ad8934c80dd99e2ba7a5b031e3bdbce3b5f777505486b643824f2
+size 5082

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chrome8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chrome8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b88b8bda37a094071d59129d9f78970d0f1062f514aacc3457d7d3867736f1c1
+size 5177

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chromeDark/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chromeDark/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:134bf9d313b1240621d52c13be37adb65f51b9d48777e46e0a180c5d31201e22
+size 5103

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chromeFlat8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/chromeFlat8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9d9e60950261df440dd427a41bf7835c2a4c78fbf80f7c41e6805468527e99d
+size 5090

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefox/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefox/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02d482d4b3afb97b873ac9046317c2065115a0d7cbab5b746817567406ee0a42
+size 7017

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefox8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefox8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d26e3b8815a6f01c82912f33c288571c70e4023386f9b8d1480a04f04484b09f
+size 7009

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefoxDark/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefoxDark/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40491bbf39b2f22d5909636a88c6a4b0ba7cee4b1a7924b63e2e49df4ffe5191
+size 7007

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefoxFlat8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/firefoxFlat8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f56c2f78f7f0e502a926cf27ec22361158095e4a63e98be8e99971d8e78bbc23
+size 7011

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie11/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie11/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1e3088db01f67fcd249a568c097112cfcd30286d3763d87b17e3ea3cea42c46
+size 3169

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie118px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie118px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6868471566129a89177c62be7624a402d8b67e9eace8f4d2d3f36f0447b78952
+size 3242

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie11Dark/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie11Dark/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3196f594ff64d297095c7794d1c0c650fed1419d473103d2a28d0748bb8d2f9e
+size 3139

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie11Flat8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and reset indeterminate/ie11Flat8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3edbfc0b4e3286b370056bd009b4ac6669c7d0e952f448939eae3d650fbf8b5c
+size 3167

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chrome/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chrome/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:948126a413dc03793e31786c243441443184a9e29b040e90ec631e84cc5e4470
+size 5000

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chrome8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chrome8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6a3f9b0fa9e42e62c4cbe983dd4137644ba41ebc5d1e3bae8da3b04843836fe
+size 5038

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chromeDark/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chromeDark/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45fe48b31edb1963373bbc0e4a36e1a4c26d22ff621a6fedf27a8b06e83c0ce4
+size 5023

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chromeFlat8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/chromeFlat8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b10de882ce9d7f5233c6b46d90ce38bbef6bc0b30490875cb4842bdb90a4c37a
+size 5010

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefox/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefox/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eae6b6225b20538554cfc0bacfb330af4a495114cefc89995f34e2e77700c38
+size 6811

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefox8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefox8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c4aa457da206a75f361f034dd70eb5fc631ec9416a91e3eaa5caadb5d2fd69
+size 6918

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefoxDark/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefoxDark/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4164846c1b40bcc55c8119b68a623e2f09ad99040e8360a5c6cc9f3773c8e48
+size 6787

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefoxFlat8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/firefoxFlat8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0b49819ff960614702490973319116d9334877e1b8a33a4d3c5326db08268c
+size 6818

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie11/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie11/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:368b91feea8c9e8b86140a0a1477caaeac6e38e34283f3676d2f46153398c789
+size 3146

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie118px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie118px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4143e1df3380bbbe534c2dcad9a01a881e6fd54cbd052b95c81ac38c5deecfe
+size 3242

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie11Dark/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie11Dark/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d066f7334cea5e41f07f1bd55539e87d82f164ff7747a4497f0bef447e1e8d52
+size 3098

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie11Flat8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/change value and set indeterminate/ie11Flat8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a945b86d354f726da4289d4b1eeb1b8f9e22b9d7124096f70fc1159f1fa02608
+size 3142

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chrome/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chrome/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4f117ba3879ab192e9b27e58cf1acdfe59cfa0d6fc0c780ad8a0d73568f8805
+size 4978

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chrome8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chrome8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d0b932d639b52a22c543e3554745e83c967dc0fa8307eefbb3a62d39124945
+size 5019

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chromeDark/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chromeDark/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afb63a23f44c468d486b1cd5ca4015e20e915be6a6b8a887376e4b3acb883d79
+size 4994

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chromeFlat8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/chromeFlat8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfa460cafdf8b6218e743c1f653a8ee8b426bd5cbe23ee7611a793cf85dbdb97
+size 4989

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefox/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefox/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67f2e08a15d1fe9ac288926c04b21d51e1f1cb7d1276c0581360772f36152ab9
+size 6104

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefox8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefox8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4136de3e479793756e199f1bbcb6457131e6b71e04acd380569f594fd55ab03
+size 6207

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefoxDark/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefoxDark/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:158d5d37fb7bd50385e39ac3a8cd167e783c6809fde23164fdfbbe25b22634c6
+size 6084

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefoxFlat8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/firefoxFlat8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9a889148571b90f6c31c948fc83ffbed9a6e3249e57a524c2a4b5a8823e5ff
+size 6109

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie11/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie11/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b53c453bdaf22175744a12af1d4fb5256905dc9d206117b6e7ac2285c4eb2c
+size 3078

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie118px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie118px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7ecebce7a5ebd46682b186ec09113a62ec7048abfb37288edcb07ab678b590c
+size 3182

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie11Dark/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie11Dark/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beb86dbb5dff9636520a20da56bff04d398d56706a60a6cf394399b22a457ff0
+size 3063

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie11Flat8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/idle/ie11Flat8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3695c269a5798dc02baf8edd6edd6dbacb979ba4feda9598244012a172a7deff
+size 3079

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chrome/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chrome/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:330fd1ca549a16234979c006e595a5f27d3f3a77b4d59d8af0280ec155820a19
+size 4954

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chrome8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chrome8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2c64caf453e1da34d0a88ce6aed9b71c0444c265b0fb44927eb553c287fe6b
+size 4983

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chromeDark/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chromeDark/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7f0d8c5e2ef37aee48d68c0d8a5e50be2267793f6331459a13535607c9ca06f
+size 4999

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chromeFlat8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/chromeFlat8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08132c5ec0a4eea3fa92ff5bc03390ab48b8aaabf357ff28fc9c197dd6ec7a99
+size 4964

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefox/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefox/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d701dd6cad6074b27153de15a152a915132d16a45ca172c0780055e2c6faa781
+size 6823

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefox8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefox8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4424cc81acd3f63000087c41d8c19762188d7a50cc9643c93114f706cabc8b36
+size 6945

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefoxDark/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefoxDark/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1fa19182259a741766854ec3ec86dbabf60c952de451b5997ae2bcc343e4ceb
+size 6852

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefoxFlat8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/firefoxFlat8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18813ec39ca5a2c80b87aebf2d624e1526a71814485d9e646fb7a130bd2beb56
+size 6811

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie11/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie11/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21976b9ba28f0ec23ae37b8d8f9ab1400b6e3d0589c0a21fbbe03e21333ce6ab
+size 3118

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie118px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie118px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bddfe73a577f3c6c0748e0d3dd8d18489ece5b68821031c888ca29ae7232b3a0
+size 3209

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie11Dark/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie11Dark/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9355dc5eace32c52cca344c60fdf1b3b0ba15ec8c960b6627d12510a4eadc50b
+size 3084

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie11Flat8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/reset indeterminate/ie11Flat8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e8b39180422ea03d4b391a0fbf6232c5850492df89997b22ac329da27eb89e1
+size 3119

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chrome/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chrome/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40087ae36687bae370f72bf194fdb82999db3d78b16dd448420cf52fbdb9696b
+size 4989

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chrome8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chrome8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05d66c4026070e36cb5d1b56b889ac33e21a82d1fd3f390926f9b0c176f74ca5
+size 5037

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chromeDark/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chromeDark/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa237cc390ec00990d91c49acefd82023de8ab85169850d192aaecb0a703c9ef
+size 5010

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chromeFlat8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/chromeFlat8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:575cfeb360020f34fb89758bb8dd2e980335666ae67046c76dbb14fb3135ee07
+size 4999

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefox/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefox/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eae6b6225b20538554cfc0bacfb330af4a495114cefc89995f34e2e77700c38
+size 6811

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefox8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefox8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c4aa457da206a75f361f034dd70eb5fc631ec9416a91e3eaa5caadb5d2fd69
+size 6918

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefoxDark/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefoxDark/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4164846c1b40bcc55c8119b68a623e2f09ad99040e8360a5c6cc9f3773c8e48
+size 6787

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefoxFlat8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/firefoxFlat8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0b49819ff960614702490973319116d9334877e1b8a33a4d3c5326db08268c
+size 6818

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie11/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie11/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:368b91feea8c9e8b86140a0a1477caaeac6e38e34283f3676d2f46153398c789
+size 3146

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie118px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie118px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4143e1df3380bbbe534c2dcad9a01a881e6fd54cbd052b95c81ac38c5deecfe
+size 3242

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie11Dark/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie11Dark/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d066f7334cea5e41f07f1bd55539e87d82f164ff7747a4497f0bef447e1e8d52
+size 3098

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie11Flat8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate LEGACY/set indeterminate/ie11Flat8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a945b86d354f726da4289d4b1eeb1b8f9e22b9d7124096f70fc1159f1fa02608
+size 3142

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chrome/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chrome/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:925edab30f2ad8934c80dd99e2ba7a5b031e3bdbce3b5f777505486b643824f2
+size 5082

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chrome8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chrome8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b88b8bda37a094071d59129d9f78970d0f1062f514aacc3457d7d3867736f1c1
+size 5177

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chromeDark/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chromeDark/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:134bf9d313b1240621d52c13be37adb65f51b9d48777e46e0a180c5d31201e22
+size 5103

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chromeFlat8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/chromeFlat8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9d9e60950261df440dd427a41bf7835c2a4c78fbf80f7c41e6805468527e99d
+size 5090

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefox/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefox/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02d482d4b3afb97b873ac9046317c2065115a0d7cbab5b746817567406ee0a42
+size 7017

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefox8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefox8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d26e3b8815a6f01c82912f33c288571c70e4023386f9b8d1480a04f04484b09f
+size 7009

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefoxDark/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefoxDark/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40491bbf39b2f22d5909636a88c6a4b0ba7cee4b1a7924b63e2e49df4ffe5191
+size 7007

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefoxFlat8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/firefoxFlat8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f56c2f78f7f0e502a926cf27ec22361158095e4a63e98be8e99971d8e78bbc23
+size 7011

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie11/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie11/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1e3088db01f67fcd249a568c097112cfcd30286d3763d87b17e3ea3cea42c46
+size 3169

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie118px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie118px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6868471566129a89177c62be7624a402d8b67e9eace8f4d2d3f36f0447b78952
+size 3242

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie11Dark/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie11Dark/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3196f594ff64d297095c7794d1c0c650fed1419d473103d2a28d0748bb8d2f9e
+size 3139

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie11Flat8px/change value and reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and reset indeterminate/ie11Flat8px/change value and reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3edbfc0b4e3286b370056bd009b4ac6669c7d0e952f448939eae3d650fbf8b5c
+size 3167

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chrome/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chrome/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:948126a413dc03793e31786c243441443184a9e29b040e90ec631e84cc5e4470
+size 5000

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chrome8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chrome8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6a3f9b0fa9e42e62c4cbe983dd4137644ba41ebc5d1e3bae8da3b04843836fe
+size 5038

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chromeDark/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chromeDark/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45fe48b31edb1963373bbc0e4a36e1a4c26d22ff621a6fedf27a8b06e83c0ce4
+size 5023

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chromeFlat8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/chromeFlat8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b10de882ce9d7f5233c6b46d90ce38bbef6bc0b30490875cb4842bdb90a4c37a
+size 5010

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefox/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefox/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eae6b6225b20538554cfc0bacfb330af4a495114cefc89995f34e2e77700c38
+size 6811

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefox8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefox8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c4aa457da206a75f361f034dd70eb5fc631ec9416a91e3eaa5caadb5d2fd69
+size 6918

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefoxDark/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefoxDark/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4164846c1b40bcc55c8119b68a623e2f09ad99040e8360a5c6cc9f3773c8e48
+size 6787

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefoxFlat8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/firefoxFlat8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0b49819ff960614702490973319116d9334877e1b8a33a4d3c5326db08268c
+size 6818

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie11/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie11/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:368b91feea8c9e8b86140a0a1477caaeac6e38e34283f3676d2f46153398c789
+size 3146

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie118px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie118px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4143e1df3380bbbe534c2dcad9a01a881e6fd54cbd052b95c81ac38c5deecfe
+size 3242

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie11Dark/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie11Dark/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d066f7334cea5e41f07f1bd55539e87d82f164ff7747a4497f0bef447e1e8d52
+size 3098

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie11Flat8px/change value and set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/change value and set indeterminate/ie11Flat8px/change value and set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a945b86d354f726da4289d4b1eeb1b8f9e22b9d7124096f70fc1159f1fa02608
+size 3142

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chrome/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chrome/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4f117ba3879ab192e9b27e58cf1acdfe59cfa0d6fc0c780ad8a0d73568f8805
+size 4978

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chrome8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chrome8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d0b932d639b52a22c543e3554745e83c967dc0fa8307eefbb3a62d39124945
+size 5019

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chromeDark/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chromeDark/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afb63a23f44c468d486b1cd5ca4015e20e915be6a6b8a887376e4b3acb883d79
+size 4994

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chromeFlat8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/chromeFlat8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfa460cafdf8b6218e743c1f653a8ee8b426bd5cbe23ee7611a793cf85dbdb97
+size 4989

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefox/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefox/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67f2e08a15d1fe9ac288926c04b21d51e1f1cb7d1276c0581360772f36152ab9
+size 6104

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefox8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefox8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4136de3e479793756e199f1bbcb6457131e6b71e04acd380569f594fd55ab03
+size 6207

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefoxDark/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefoxDark/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:158d5d37fb7bd50385e39ac3a8cd167e783c6809fde23164fdfbbe25b22634c6
+size 6084

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefoxFlat8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/firefoxFlat8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9a889148571b90f6c31c948fc83ffbed9a6e3249e57a524c2a4b5a8823e5ff
+size 6109

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie11/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie11/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b53c453bdaf22175744a12af1d4fb5256905dc9d206117b6e7ac2285c4eb2c
+size 3078

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie118px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie118px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7ecebce7a5ebd46682b186ec09113a62ec7048abfb37288edcb07ab678b590c
+size 3182

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie11Dark/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie11Dark/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beb86dbb5dff9636520a20da56bff04d398d56706a60a6cf394399b22a457ff0
+size 3063

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie11Flat8px/idle.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/idle/ie11Flat8px/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3695c269a5798dc02baf8edd6edd6dbacb979ba4feda9598244012a172a7deff
+size 3079

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chrome/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chrome/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:330fd1ca549a16234979c006e595a5f27d3f3a77b4d59d8af0280ec155820a19
+size 4954

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chrome8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chrome8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2c64caf453e1da34d0a88ce6aed9b71c0444c265b0fb44927eb553c287fe6b
+size 4983

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chromeDark/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chromeDark/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7f0d8c5e2ef37aee48d68c0d8a5e50be2267793f6331459a13535607c9ca06f
+size 4999

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chromeFlat8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/chromeFlat8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08132c5ec0a4eea3fa92ff5bc03390ab48b8aaabf357ff28fc9c197dd6ec7a99
+size 4964

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefox/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefox/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d701dd6cad6074b27153de15a152a915132d16a45ca172c0780055e2c6faa781
+size 6823

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefox8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefox8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4424cc81acd3f63000087c41d8c19762188d7a50cc9643c93114f706cabc8b36
+size 6945

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefoxDark/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefoxDark/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1fa19182259a741766854ec3ec86dbabf60c952de451b5997ae2bcc343e4ceb
+size 6852

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefoxFlat8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/firefoxFlat8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18813ec39ca5a2c80b87aebf2d624e1526a71814485d9e646fb7a130bd2beb56
+size 6811

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie11/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie11/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21976b9ba28f0ec23ae37b8d8f9ab1400b6e3d0589c0a21fbbe03e21333ce6ab
+size 3118

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie118px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie118px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bddfe73a577f3c6c0748e0d3dd8d18489ece5b68821031c888ca29ae7232b3a0
+size 3209

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie11Dark/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie11Dark/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9355dc5eace32c52cca344c60fdf1b3b0ba15ec8c960b6627d12510a4eadc50b
+size 3084

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie11Flat8px/reset indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/reset indeterminate/ie11Flat8px/reset indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e8b39180422ea03d4b391a0fbf6232c5850492df89997b22ac329da27eb89e1
+size 3119

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chrome/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chrome/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cdf049f49537847226a5a8473f7ad32df5c07c1ea0546f8e50e3b55a1e0ef84
+size 4997

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chrome8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chrome8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff3855525a3b21f71af19730bbde87e60a612c33450dc65f3ba9a87dc77d7b12
+size 5030

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chromeDark/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chromeDark/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa237cc390ec00990d91c49acefd82023de8ab85169850d192aaecb0a703c9ef
+size 5010

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chromeFlat8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/chromeFlat8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:575cfeb360020f34fb89758bb8dd2e980335666ae67046c76dbb14fb3135ee07
+size 4999

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefox/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefox/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eae6b6225b20538554cfc0bacfb330af4a495114cefc89995f34e2e77700c38
+size 6811

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefox8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefox8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c4aa457da206a75f361f034dd70eb5fc631ec9416a91e3eaa5caadb5d2fd69
+size 6918

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefoxDark/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefoxDark/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4164846c1b40bcc55c8119b68a623e2f09ad99040e8360a5c6cc9f3773c8e48
+size 6787

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefoxFlat8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/firefoxFlat8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0b49819ff960614702490973319116d9334877e1b8a33a4d3c5326db08268c
+size 6818

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie11/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie11/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:368b91feea8c9e8b86140a0a1477caaeac6e38e34283f3676d2f46153398c789
+size 3146

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie118px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie118px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4143e1df3380bbbe534c2dcad9a01a881e6fd54cbd052b95c81ac38c5deecfe
+size 3242

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie11Dark/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie11Dark/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d066f7334cea5e41f07f1bd55539e87d82f164ff7747a4497f0bef447e1e8d52
+size 3098

--- a/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie11Flat8px/set indeterminate.png
+++ b/packages/react-ui/.creevey/images/Checkbox/indeterminate/set indeterminate/ie11Flat8px/set indeterminate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a945b86d354f726da4289d4b1eeb1b8f9e22b9d7124096f70fc1159f1fa02608
+size 3142

--- a/packages/react-ui/components/Checkbox/Checkbox.md
+++ b/packages/react-ui/components/Checkbox/Checkbox.md
@@ -80,23 +80,23 @@ let checkboxInstance = React.useRef(null);
 import { Button, Checkbox, Gapped } from '@skbkontur/react-ui';
 
 const [checked, setChecked] = React.useState(false);
+const [isIndeterminate, setIsIndeterminate] = React.useState(true);
 
-let checkboxInstance = React.useRef(null);
 
 <Gapped vertical>
   <Checkbox
-    initialIndeterminate
     checked={checked}
     onValueChange={setChecked}
-    ref={el => checkboxInstance = el}
+    isIndeterminate={isIndeterminate}
+    setIsIndeterminate={setIsIndeterminate}
   >
     Неопределённый чекбокс
   </Checkbox>
   <Gapped>
-    <Button onClick={() => checkboxInstance.setIndeterminate()}>
+    <Button onClick={() => setIsIndeterminate(true)}>
       Перевести в неопределённое состояние
     </Button>
-    <Button onClick={() => checkboxInstance.resetIndeterminate()}>
+    <Button onClick={() => setIsIndeterminate(false)}>
       Сбросить неопределённое состояние
     </Button>
   </Gapped>

--- a/packages/react-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/react-ui/components/Checkbox/Checkbox.tsx
@@ -52,15 +52,29 @@ export interface CheckboxProps
          */
         onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
         /**
-         * [Неопределённое состояние](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-indeterminate) чекбокса из HTML.
+         * @deprecated Это API будет удалено в 5-ой версии библиотеки. Используйте пропы `isIndeterminate` и `setIsIndeterminate`.
          */
         initialIndeterminate?: boolean;
+        /**
+         * Неопределённое состояние(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-indeterminate) чекбокса из HTML.
+         *
+         * Переменная для хранения `indeterminate` состояния
+         *
+         * Для корректной работы проп должен быть использован в паре с пропом `setIsIndeterminate`
+         */
+        isIndeterminate?: boolean;
+        /**
+         * Функция для обновления `indeterminate` состояния
+         *
+         * Для корректной работы проп должен быть использован в паре с пропом `isIndeterminate`
+         */
+        setIsIndeterminate?: React.Dispatch<React.SetStateAction<NonNullable<CheckboxProps['isIndeterminate']>>>;
       }
     > {}
 
 export interface CheckboxState {
   focusedByTab: boolean;
-  indeterminate: boolean;
+  LEGACY_INDETERMINATE: boolean;
   isShiftPressed: boolean;
 }
 
@@ -84,9 +98,9 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
     onMouseOver: PropTypes.func,
   };
 
-  public state = {
+  public state: CheckboxState = {
     focusedByTab: false,
-    indeterminate: this.props.initialIndeterminate || false,
+    LEGACY_INDETERMINATE: this.props.initialIndeterminate || false,
     isShiftPressed: false,
   };
 
@@ -110,7 +124,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
   };
 
   public componentDidMount = () => {
-    if (this.state.indeterminate && this.input.current) {
+    if ((this.state.LEGACY_INDETERMINATE || this.props.isIndeterminate) && this.input.current) {
       this.input.current.indeterminate = true;
     }
 
@@ -166,10 +180,11 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
   /**
    * Устанавливает чекбокс в HTML-состояние `indeterminate`.
    * @public
+   * @deprecated Это API будет удалено в 5-ой версии библиотеки. Используйте пропы `isIndeterminate` и `setIsIndeterminate`.
    */
   public setIndeterminate = () => {
     this.setState({
-      indeterminate: true,
+      LEGACY_INDETERMINATE: true,
     });
     if (this.input.current) {
       this.input.current.indeterminate = true;
@@ -179,11 +194,15 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
   /**
    * Снимает с чекбокса HTML-состояние `indeterminate`.
    * @public
+   * @deprecated Это API будет удалено в 5-ой версии библиотеки. Используйте пропы `isIndeterminate` и `setIsIndeterminate`.
    */
   public resetIndeterminate = () => {
     this.setState({
-      indeterminate: false,
+      LEGACY_INDETERMINATE: false,
     });
+    if (this.props.setIsIndeterminate) {
+      this.props.setIsIndeterminate(false);
+    }
     if (this.input.current) {
       this.input.current.indeterminate = false;
     }
@@ -201,7 +220,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
       initialIndeterminate,
       ...rest
     } = props;
-    const isIndeterminate = this.state.indeterminate;
+    const isIndeterminate = this.state.LEGACY_INDETERMINATE || this.props.isIndeterminate;
 
     const rootClass = cx({
       [styles.root(this.theme)]: true,
@@ -303,7 +322,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps, CheckboxState> 
     this.props.onClick?.(e);
     // support IE11's and old Edge's special behavior
     // https://github.com/jquery/jquery/issues/1698
-    if (this.state.indeterminate && (isIE11 || isEdge)) {
+    if ((this.state.LEGACY_INDETERMINATE || this.props.isIndeterminate) && (isIE11 || isEdge)) {
       this.resetIndeterminate();
       // simulate correct behavior only if onValueChange is used
       // because we cant simulate real native onChange event

--- a/packages/react-ui/components/Checkbox/__stories__/Checkbox.stories.tsx
+++ b/packages/react-ui/components/Checkbox/__stories__/Checkbox.stories.tsx
@@ -21,12 +21,47 @@ class PlainCheckbox extends Component<any, any> {
   }
 }
 
-interface IndeterminatePlaygroundState {
+type IndeterminatePlaygroundProps = {
+  children: React.ReactNode;
+};
+
+const IndeterminatePlayground = ({ children }: IndeterminatePlaygroundProps) => {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isIndeterminate, setIsIndeterminate] = useState(true);
+
+  return (
+    <div>
+      <span style={{ display: 'inline-block', padding: 4 }} id="screenshot-capture">
+        <Checkbox
+          onValueChange={(checked) => setIsChecked(checked)}
+          checked={isChecked}
+          isIndeterminate={isIndeterminate}
+          setIsIndeterminate={setIsIndeterminate}
+        >
+          {children}
+        </Checkbox>
+      </span>
+      <div>
+        <button tabIndex={-1} onClick={() => setIsIndeterminate(true)}>
+          setIndeterminate
+        </button>
+        <button tabIndex={-1} onClick={() => setIsIndeterminate(false)}>
+          resetIndeterminate
+        </button>
+        <button tabIndex={-1} onClick={() => setIsChecked((prev) => !prev)}>
+          changeValue
+        </button>
+      </div>
+    </div>
+  );
+};
+
+interface LEGACY_IndeterminatePlaygroundState {
   checked: boolean;
 }
 
-class IndeterminatePlayground extends Component<{}, IndeterminatePlaygroundState> {
-  public state: IndeterminatePlaygroundState = {
+class LEGACY_IndeterminatePlayground extends Component<{}, LEGACY_IndeterminatePlaygroundState> {
+  public state: LEGACY_IndeterminatePlaygroundState = {
     checked: false,
   };
 
@@ -77,7 +112,7 @@ class IndeterminatePlayground extends Component<{}, IndeterminatePlaygroundState
   };
 
   private changeValue = () => {
-    this.setState((state: IndeterminatePlaygroundState) => ({
+    this.setState((state: LEGACY_IndeterminatePlaygroundState) => ({
       checked: !state.checked,
     }));
   };
@@ -298,59 +333,82 @@ ProgrammaticFocus.parameters = { creevey: { skip: [true] } };
 export const Indeterminate: Story = () => <IndeterminatePlayground>Label</IndeterminatePlayground>;
 Indeterminate.storyName = 'indeterminate';
 
+export const LEGACY_Indeterminate: Story = () => <LEGACY_IndeterminatePlayground>Label</LEGACY_IndeterminatePlayground>;
+LEGACY_Indeterminate.storyName = 'indeterminate LEGACY';
+
+const indeterminateTests: CreeveyTests = {
+  async idle() {
+    await this.expect(await this.takeScreenshot()).to.matchImage('idle');
+  },
+  async 'reset indeterminate'() {
+    const buttons = await this.browser.findElements({ css: 'button' });
+
+    await this.browser
+      .actions({
+        bridge: true,
+      })
+      .click(buttons[1])
+      .perform();
+    await delay(1000);
+
+    await this.expect(await this.takeScreenshot()).to.matchImage('reset indeterminate');
+  },
+  async 'set indeterminate'() {
+    const buttons = await this.browser.findElements({ css: 'button' });
+
+    await this.browser
+      .actions({
+        bridge: true,
+      })
+      .click(buttons[1])
+      .pause(1000)
+      .click(buttons[0])
+      .perform();
+    await delay(1000);
+
+    await this.expect(await this.takeScreenshot()).to.matchImage('set indeterminate');
+  },
+  async 'change value and set indeterminate'() {
+    const buttons = await this.browser.findElements({ css: 'button' });
+
+    await this.browser
+      .actions({
+        bridge: true,
+      })
+      .click(buttons[2])
+      .pause(1000)
+      .click(buttons[0])
+      .perform();
+    await delay(1000);
+
+    await this.expect(await this.takeScreenshot()).to.matchImage('change value and set indeterminate');
+  },
+  async 'change value and reset indeterminate'() {
+    const buttons = await this.browser.findElements({ css: 'button' });
+
+    await this.browser
+      .actions({
+        bridge: true,
+      })
+      .click(buttons[1])
+      .pause(1000)
+      .click(buttons[2])
+      .perform();
+    await delay(1000);
+
+    await this.expect(await this.takeScreenshot()).to.matchImage('change value and reset indeterminate');
+  },
+};
+
 Indeterminate.parameters = {
   creevey: {
-    skip: [
-      { in: ['ie11', 'ie118px', 'ie11Flat8px', 'ie11Dark'], tests: 'hovered' },
-      // TODO @Khlutkova fix after update browsers
-      { in: ['chrome8px', 'chromeFlat8px', 'chrome', 'chromeDark'], tests: ['hovered', 'clicked'] },
-    ],
-    tests: {
-      async plain() {
-        const element = await this.browser.findElement({ css: '#screenshot-capture' });
-        await delay(1000);
+    tests: indeterminateTests,
+  },
+};
 
-        await this.expect(await element.takeScreenshot()).to.matchImage('plain');
-      },
-      async hovered() {
-        const element = await this.browser.findElement({ css: '#screenshot-capture' });
-        await this.browser
-          .actions({
-            bridge: true,
-          })
-          .move({
-            origin: this.browser.findElement({ css: 'label' }),
-          })
-          .perform();
-        await delay(1000);
-
-        await this.expect(await element.takeScreenshot()).to.matchImage('hovered');
-      },
-      async tabPress() {
-        const element = await this.browser.findElement({ css: '#screenshot-capture' });
-        await this.browser
-          .actions({
-            bridge: true,
-          })
-          .sendKeys(this.keys.TAB)
-          .perform();
-        await delay(1000);
-
-        await this.expect(await element.takeScreenshot()).to.matchImage('tabPress');
-      },
-      async clicked() {
-        const element = await this.browser.findElement({ css: '#screenshot-capture' });
-        await this.browser
-          .actions({
-            bridge: true,
-          })
-          .click(this.browser.findElement({ css: 'label' }))
-          .perform();
-        await delay(1000);
-
-        await this.expect(await element.takeScreenshot()).to.matchImage('clicked');
-      },
-    },
+LEGACY_Indeterminate.parameters = {
+  creevey: {
+    tests: indeterminateTests,
   },
 };
 


### PR DESCRIPTION
fixes [IF-548](https://yt.skbkontur.ru/agiles/101-1467/current?issue=IF-548)

1. Добавил и задокументировал новое декларативное API для задания состояния indeterminate. С помощью isIndeterminate и setIndeterminate
2. Обновил пример в доке, чтобы в нём использовалось новое API
3. Задиприкейтил старое API и упомянул, что оно будет удалено в 5-ой версии библиотеки, так как старое API:
	- Менее удобное в использовании
	- Использует императивное API, в связи с чем при переходе на функциональные компоненты придётся использовать такие хаки как useImperativeHandle
4. Поправил старые скриншотные тесты, заменив их содержимое на проверку работоспособности состояния indeterminate
5. Заменил старое API в тестах из первого коммита на новое API