### PR TITLE
fix(Tooltip): fix click outside detection

### DIFF
--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -392,7 +392,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
         return {
           layerProps: {
             active: true,
-            onClickOutside: this.handleClickOutsideAnchor,
+            onClickOutside: this.handleClickOutside,
           },
           popupProps: {
             opened: true,
@@ -427,7 +427,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
         return {
           layerProps: {
             active: this.state.opened,
-            onClickOutside: this.handleClickOutsideAnchor,
+            onClickOutside: this.handleClickOutside,
           },
           popupProps: {
             onClick: this.handleClick,
@@ -448,7 +448,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
         return {
           layerProps: {
             active: this.state.opened,
-            onClickOutside: this.handleClickOutsideAnchor,
+            onClickOutside: this.handleClickOutside,
           },
           popupProps: {
             onFocus: this.handleFocus,
@@ -511,8 +511,8 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
     this.open();
   };
 
-  private handleClickOutsideAnchor = (event: Event) => {
-    this.clickedOutside = this.isClickOutsideContent(event);
+  private handleClickOutside = (event: Event) => {
+    this.clickedOutside = this.isClickOutsideContent(event) && this.isClickOutsideAnchor(event);
     if (this.clickedOutside) {
       if (this.props.onCloseRequest) {
         this.props.onCloseRequest();
@@ -522,8 +522,16 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
   };
 
   private isClickOutsideContent(event: Event) {
-    if (this.contentElement && event.target instanceof Element) {
-      return !containsTargetOrRenderContainer(event.target)(this.contentElement);
+    return this.isClickOutside(event, this.contentElement);
+  }
+
+  private isClickOutsideAnchor(event: Event) {
+    return this.isClickOutside(event, this.getAnchorElement());
+  }
+
+  private isClickOutside(event: Event, target: Nullable<HTMLElement>) {
+    if (target && event.target instanceof Element) {
+      return !containsTargetOrRenderContainer(event.target)(target);
     }
 
     return true;

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -137,6 +137,7 @@ export interface TooltipState {
 
 export const TooltipDataTids = {
   root: 'Tooltip__root',
+  content: 'Tooltip__content',
 } as const;
 
 const Positions: PopupPositionsType[] = [
@@ -249,7 +250,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
     }
 
     return (
-      <div ref={this.refContent} className={styles.tooltipContent(this.theme)}>
+      <div ref={this.refContent} className={styles.tooltipContent(this.theme)} data-tid={TooltipDataTids.content}>
         {content}
         {this.renderCloseButton()}
       </div>

--- a/packages/react-ui/components/Tooltip/__tests__/Tooltip-test.tsx
+++ b/packages/react-ui/components/Tooltip/__tests__/Tooltip-test.tsx
@@ -1,11 +1,13 @@
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 import { findDOMNode } from 'react-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Button } from '../../Button';
-import { Tooltip, TooltipProps, TooltipState } from '../Tooltip';
+import { Tooltip, TooltipProps, TooltipState, TooltipDataTids } from '../Tooltip';
 import { Popup } from '../../../internal/Popup';
+import { delay } from '../../../lib/utils';
 
 function clickOutside() {
   const event = document.createEvent('HTMLEvents');
@@ -16,8 +18,306 @@ function clickOutside() {
 
 const selectorCross = 'svg[viewBox="0 0 10 10"]';
 
+/** Wraps test and runs it twice with external and child anchor */
+const withVariousAnchors = (testFn: (render: (props: Partial<TooltipProps>) => { anchor: HTMLElement }) => void) => {
+  const childAnchorRef = React.createRef<HTMLButtonElement>();
+  const externalAnchor = document.createElement('button');
+
+  const getExternalAnchor = () => externalAnchor;
+  const getChildAnchor = () => {
+    const anchor = childAnchorRef.current;
+    if (anchor === null) {
+      // eliminate null from anchor type
+      throw new Error('childAnchor is null');
+    }
+    return anchor;
+  };
+
+  describe.each([
+    ['external anchor', getExternalAnchor, { anchorElement: externalAnchor }],
+    ['child anchor', getChildAnchor, { children: <button ref={childAnchorRef} /> }],
+  ])('%s', (_, getAnchor, tooltipProps) => {
+    const renderTooltip = (props: Partial<TooltipProps>) => {
+      render(<Tooltip render={() => <div />} {...tooltipProps} {...props} />);
+      return { anchor: getAnchor() };
+    };
+
+    beforeEach(() => {
+      document.body.appendChild(externalAnchor);
+    });
+
+    afterEach(() => {
+      externalAnchor?.parentNode?.removeChild(externalAnchor);
+    });
+
+    testFn(renderTooltip);
+  });
+};
+
 describe('Tooltip', () => {
   const renderTooltip = () => '';
+
+  describe('triggers', () => {
+    describe('click', () => {
+      withVariousAnchors((renderTooltip) => {
+        it('opens after click by anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'click' });
+
+          userEvent.click(anchor);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('opens after click by anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'click' });
+
+          userEvent.click(anchor);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after second click by anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'click' });
+
+          userEvent.click(anchor);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          userEvent.click(anchor);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click by content', async () => {
+          const { anchor } = renderTooltip({ trigger: 'click' });
+
+          userEvent.click(anchor);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          userEvent.click(content);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('closes after click outside', async () => {
+          const { anchor } = renderTooltip({ trigger: 'click' });
+
+          userEvent.click(anchor);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(document.body);
+          expect(content).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('focus', () => {
+      withVariousAnchors((renderTooltip) => {
+        it('opens by focus on anchor', () => {
+          const { anchor } = renderTooltip({ trigger: 'focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click on anchor', () => {
+          const { anchor } = renderTooltip({ trigger: 'focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          userEvent.click(anchor);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('closes after click on content', () => {
+          const { anchor } = renderTooltip({ trigger: 'focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(content);
+          expect(content).not.toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('closes after click outside', () => {
+          const { anchor } = renderTooltip({ trigger: 'focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(document.body);
+          expect(content).not.toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('closes after blur', () => {
+          const { anchor } = renderTooltip({ trigger: 'focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          anchor.blur();
+          expect(content).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('hover&focus', () => {
+      withVariousAnchors((renderTooltip) => {
+        it('opens by hover on anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          userEvent.hover(anchor);
+          await delay(Tooltip.delay);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('opens by focus on anchor', () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click on anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          userEvent.hover(anchor);
+          await delay(Tooltip.delay);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(anchor);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click on content', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          userEvent.hover(anchor);
+          await delay(Tooltip.delay);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(content);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('closes after click outside', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          userEvent.hover(anchor);
+          await delay(Tooltip.delay);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(document.body);
+          expect(content).not.toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('closes after blur', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          anchor.focus();
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          anchor.blur();
+          expect(content).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('opened', () => {
+      withVariousAnchors((renderTooltip) => {
+        it('opened by default', async () => {
+          renderTooltip({ trigger: 'opened' });
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click on anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'opened' });
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(anchor);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click on content', async () => {
+          renderTooltip({ trigger: 'opened' });
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(content);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('keeps open after click outside', async () => {
+          renderTooltip({ trigger: 'opened' });
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(document.body);
+          expect(content).toBeInTheDocument();
+        });
+      });
+    });
+  });
 
   it('keeps child ref', () => {
     interface CompProps {


### PR DESCRIPTION
Исправил баг в работе Tooltip с триггером `hover&focus`. Tooltip появлялся по ховеру на anchor, но при клике по нему сразу скрывался. А если anchor от клика получал фокус, то Tooltip появлялся снова. 

Также, с триггером `click` Tooltip скрывался по второму клику на `anchor`, хотя не должен.

## Проблема

В #2873 поменялось видение того, что является корневым элементом у `Popup`. Раньше им было то, что попадало в `children` (это мог быть anchor или контент)*, а в последствии стал конкретно его контент. Это повлияло на работу `Popup` внутри `RenderLayer` (который детектит клики вне корневого элемента того, что в него положили). А именно, `RenderLayer` стал детектить клики вне контента `Popup`, а не вне его `anchor`, как раньше. Эта поведение законно, но оно не было учтено в #2873, т.к. на триггеры тултипа не было тестов.


<!-- Подробно опиши решаемую проблему. -->

## Решение

Подправил логику в обработчике клика снаружи тултипа, чтобы вернуть прежнее поведение. Можно потестить в [кодсандбоксе](https://codesandbox.io/s/frosty-moser-b1qfr0?file=/src/CashboxEditableTitle.tsx) из чата на тестовой версии `@skbkontur/react-ui@0.0.0-7b63c63db3`, выпущенной из этого ПРа.

Забавный факт. До избавления от findDOMNode (3.10.0) и правок в #2873 поведение тултипа могло разниться в зависимости от способа передачи anchor (через проп anchorElement или через children)**. Это можно увидеть, если запустить тесты, добавленные в этом ПРе на старых версиях:

<details>
<summary>3.9.0</summary>

```

    triggers
      click
        external anchor
          ✓ opens after click by anchor (37 ms)
          ✓ opens after click by anchor (6 ms)
          ✕ keeps open after second click by anchor (13 ms)
          ✓ keeps open after click by content (8 ms)
          ✓ closes after click outside (8 ms)
        child anchor
          ✓ opens after click by anchor (11 ms)
          ✓ opens after click by anchor (9 ms)
          ✓ keeps open after second click by anchor (8 ms)
          ✓ keeps open after click by content (11 ms)
          ✓ closes after click outside (7 ms)
      focus
        external anchor
          ✓ opens by focus on anchor (2 ms)
          ✓ keeps open after click on anchor (4 ms)
          ✓ closes after click on content (7 ms)
          ✓ closes after click outside (5 ms)
          ✓ closes after blur (4 ms)
        child anchor
          ✓ opens by focus on anchor (2 ms)
          ✓ keeps open after click on anchor (4 ms)
          ✓ closes after click on content (9 ms)
          ✓ closes after click outside (5 ms)
          ✓ closes after blur (3 ms)
      hover&focus
        external anchor
          ✓ opens by hover on anchor (106 ms)
          ✓ opens by focus on anchor (4 ms)
          ✕ keeps open after click on anchor (111 ms)
          ✓ keeps open after click on content (118 ms)
          ✓ closes after click outside (120 ms)
          ✓ closes after blur (8 ms)
        child anchor
          ✓ opens by hover on anchor (107 ms)
          ✓ opens by focus on anchor (6 ms)
          ✓ keeps open after click on anchor (113 ms)
          ✓ keeps open after click on content (123 ms)
          ✓ closes after click outside (121 ms)
          ✓ closes after blur (9 ms)
      opened
        external anchor
          ✓ opened by default (6 ms)
          ✓ keeps open after click on anchor (6 ms)
          ✓ keeps open after click on content (8 ms)
          ✓ keeps open after click outside (4 ms)
        child anchor
          ✓ opened by default (6 ms)
          ✓ keeps open after click on anchor (6 ms)
          ✓ keeps open after click on content (10 ms)
          ✓ keeps open after click outside (3 ms)

```
</details>

Добавил тесты на затронутые триггеры. Сделал через обертку, которая позволяет тестировать один и тот же сценарий Tooltip с разными anchor: внешним (переданным через проп `anchorElement`) и внутренним (переданным как `children`). Поскольку, как выяснилось, это имеет значение.

Также, добавил недостающий `data-tid` на контент тултипа.
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

PS: * и ** связаны с одной и той же особенностью работы findDOMNode. Если в него попадает фрагмент, то он возвращает лишь первый его элемент. И, в зависимости от того, передавался anchor в children тултипа или нет, RenderLayer внутри смотрел на разные вещи (см. Tooltip -> RenderLayer -> Popup -> RenderContainer). 

## Ссылки

[IF-580](https://yt.skbkontur.ru/agiles/101-1467/current?issue=IF-580), [slack](https://kontur.slack.com/archives/C013HTCE18Q/p1656915253833229), [кодсандбокс](https://codesandbox.io/s/morning-thunder-m1u5nd?file=/src/CashboxEditableTitle.tsx) с проблемой

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их в чекбоксах. Если с каким-то из них возникли сложности — укажи это. -->

- [ ] Добавлены тесты на все изменения
  - [x] unit-тесты для логики ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#unit-тесты))
  - [ ] скриншоты для верстки и кросс-браузерности ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#скриншотные-тесты))
  - [ ] тесты не требуются
- [ ] Добавлена (обновлена) документация
  - [ ] styleguidist для пропов и примеров использования компонентов ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#styleguidist))
  - [x] jsdoc для утилит и хелперов ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#jsdoc))
  - [ ] комментарии для неочевидных мест в коде ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#комментарии-в-коде))
  - [ ] гайд для контрибьютеров ([contributing.md](https://github.com/skbkontur/retail-ui/blob/master/contributing.md))
  - [ ] документация не требуется
- [x] Все тесты и линтеры на CI проходят
- [x] В коде нет лишних изменений
- [x] Заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
