### PR TITLE
chore: fixed `tabbable` version

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -63,7 +63,7 @@
     "react-transition-group": "^4.4.2",
     "shallowequal": "^1.1.0",
     "stylis-plugin-extra-scope": "^0.3.0",
-    "tabbable": "^5.2.1",
+    "tabbable": "5.3.1",
     "warning": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -63,7 +63,7 @@
     "react-transition-group": "^4.4.2",
     "shallowequal": "^1.1.0",
     "stylis-plugin-extra-scope": "^0.3.0",
-    "tabbable": "5.3.1",
+    "tabbable": "5.2.1",
     "warning": "^4.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22175,10 +22175,10 @@ symbol.prototype.description@^1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.2"
 
-tabbable@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
+tabbable@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.npmjs.org/tabbable/-/tabbable-5.3.1.tgz#059f2a19b829efce2a0ec05785a47dd3bcd0a25b"
+  integrity sha512-NtO7I7eoAHR+JwwcNsi/PipamtAEebYDnur/k9wM6n238HHy/+1O4+7Zx7e/JaDAbKJPlIFYsfsV/6tPqTOQvg==
 
 table@^6.0.4:
   version "6.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22175,10 +22175,10 @@ symbol.prototype.description@^1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.2"
 
-tabbable@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.npmjs.org/tabbable/-/tabbable-5.3.1.tgz#059f2a19b829efce2a0ec05785a47dd3bcd0a25b"
-  integrity sha512-NtO7I7eoAHR+JwwcNsi/PipamtAEebYDnur/k9wM6n238HHy/+1O4+7Zx7e/JaDAbKJPlIFYsfsV/6tPqTOQvg==
+tabbable@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
+  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
 
 table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
## Проблема
В пакете `tabbable` с [версии 5.3.2](https://github.com/focus-trap/tabbable/commit/aa2a699d7e9d37628a7b1208ba700eb85b42a31e) используется метод дом элемента `Node.contains()`. Но в IE11 этот метод [поддерживается частично](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains).

Мы используем этот пакет, например, в контроле `Loader`. Эта может развалить всё приложение.

## Решение
На нашей стороне можно исправить зафиксировав версию `tabbable` на `5.3.1`