### PR TITLE
fix(ResponsiveLayout): fix memory leak

### DIFF
--- a/packages/react-ui/components/ResponsiveLayout/__tests__/useResponsiveLayout-test.tsx
+++ b/packages/react-ui/components/ResponsiveLayout/__tests__/useResponsiveLayout-test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { eventListenersMap } from '../ResponsiveLayoutEvents';
+import { useResponsiveLayout } from '../useResponsiveLayout';
+
+describe('useResponsiveLayout', () => {
+  it('removes listeners after unmount', () => {
+    const WithResponsiveLayoutListener = () => {
+      const { isMobile } = useResponsiveLayout();
+      return <i>{isMobile}</i>;
+    };
+    eventListenersMap.clear();
+
+    const { unmount } = render(<WithResponsiveLayoutListener />);
+    expect(eventListenersMap.size).toBe(1);
+
+    unmount();
+    expect(eventListenersMap.size).toBe(0);
+  });
+});

--- a/packages/react-ui/components/ResponsiveLayout/useResponsiveLayout.ts
+++ b/packages/react-ui/components/ResponsiveLayout/useResponsiveLayout.ts
@@ -53,7 +53,7 @@ export function useResponsiveLayout() {
     prepareMediaQueries();
 
     return () => {
-      mobileListener.current?.remove;
+      mobileListener.current?.remove();
     };
   }, []);
 


### PR DESCRIPTION
<!--

Привет! Спасибо, за твой вклад проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md).

-->

По обращению пользователя пофиксил утечку памяти из `ResponsveLayout`.

## Проблема

Все компоненты с адаптивностью (напрямую или через декоратор и `<ResponsiveLayout />`) используют хук `useResponsveLayout` для определения текущего режима (мобильный или нет). Внутри для каждого компонента добавляются отдельные слушатели глобального `MediaQueryListEvent`, которые должны удаляться на `unmout`. Но из-за опечатки в коде они оставались и занимали память.

![telegram-cloud-photo-size-2-5371084769946877388-y](https://user-images.githubusercontent.com/4607770/179213565-46892a86-3e13-4240-88b7-ad5477f81050.jpg)


<!-- Подробно опиши решаемую проблему. -->

## Решение

Исправил опечатку наладив удаление слушателей. Добавил тест.

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-615, тестовая версия `@skbkontur/react-ui@0.0.0-8824ede9eb`

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их в чекбоксах. Если с каким-то из них возникли сложности — укажи это. -->

- [ ] Добавлены тесты на все изменения
  - [x] unit-тесты для логики ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#unit-тесты))
  - [ ] скриншоты для верстки и кросс-браузерности ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#скриншотные-тесты))
  - [ ] нерелевантно
- [ ] Добавлена (обновлена) документация
  - [ ] styleguidist для пропов и примеров использования компонентов ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#styleguidist))
  - [ ] jsdoc для утилит и хелперов ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#jsdoc))
  - [ ] комментарии для неочевидных мест в коде ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#комментарии-в-коде))
  - [ ] прочие инструкции ([README.md](https://github.com/skbkontur/retail-ui/blob/master/README.md)), ([contributing.md](https://github.com/skbkontur/retail-ui/blob/master/contributing.md))
  - [x] нерелевантно
- [ ] Изменения корректно типизированы
  - [ ] без использования `any` ([#2856](https://github.com/skbkontur/retail-ui/pull/2856))
  - [x] нерелевантно
- [x] Все тесты и линтеры на CI проходят
- [x] В коде нет лишних изменений
- [x] Заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)