### PR TITLE
fix(Modal): useEffect -> useLayoutEffect

### DIFF
--- a/packages/react-ui/components/Modal/ModalFooter.tsx
+++ b/packages/react-ui/components/Modal/ModalFooter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useEffect } from 'react';
+import React, { ReactNode, useContext, useLayoutEffect } from 'react';
 
 import { getScrollWidth } from '../../lib/dom/getScrollWidth';
 import { Sticky } from '../Sticky';
@@ -36,7 +36,7 @@ function ModalFooter(props: ModalFooterProps) {
 
   const { sticky = !layout.isMobile, panel, children } = props;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     modal.setHasFooter?.();
     modal.setHasPanel?.(panel);
 

--- a/packages/react-ui/components/Modal/ModalHeader.tsx
+++ b/packages/react-ui/components/Modal/ModalHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useEffect } from 'react';
+import React, { ReactNode, useContext, useLayoutEffect } from 'react';
 
 import { Sticky } from '../Sticky';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -32,7 +32,7 @@ function ModalHeader(props: ModalHeaderProps) {
 
   const { sticky = !layout.isMobile, children } = props;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     modal.setHasHeader?.();
 
     return () => modal.setHasHeader?.(false);


### PR DESCRIPTION
Fixes #2947 

Состояния `hasHeader` и `hasFooter` устанавливались только в `useEffect` через некоторое время, а не сразу после маунта, из-за чего иногда появлялось дёргание. С использованием `useLayoutEffect` дёргания нет.