### PR TITLE
fix(TooltipMenu): set box-sizing

### DIFF
--- a/packages/react-ui/internal/InternalMenu/InternalMenu.styles.ts
+++ b/packages/react-ui/internal/InternalMenu/InternalMenu.styles.ts
@@ -7,6 +7,7 @@ export const styles = memoizeStyle({
       overflow: auto;
       padding: 5px ${t.menuPaddingX};
       outline: none;
+      box-sizing: content-box;
       background: ${t.bgSecondary};
     `;
   },


### PR DESCRIPTION
Явно указал у элемента `box-sizing`, чтобы глобальные стили не портили отображение.
Fixes #2935 