### PR TITLE
fix(Tooltip): correct focus&hover trigger behavior

### DIFF
--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -393,7 +393,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
         return {
           layerProps: {
             active: true,
-            onClickOutside: this.handleClickOutside,
+            onClickOutside: this.handleClickOutsideAnchor,
           },
           popupProps: {
             opened: true,
@@ -428,7 +428,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
         return {
           layerProps: {
             active: this.state.opened,
-            onClickOutside: this.handleClickOutside,
+            onClickOutside: this.handleClickOutsideAnchor,
           },
           popupProps: {
             onClick: this.handleClick,
@@ -449,7 +449,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
         return {
           layerProps: {
             active: this.state.opened,
-            onClickOutside: this.handleClickOutside,
+            onClickOutside: this.handleClickOutsideAnchor,
           },
           popupProps: {
             onFocus: this.handleFocus,
@@ -512,8 +512,8 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
     this.open();
   };
 
-  private handleClickOutside = (event: Event) => {
-    this.clickedOutside = this.isClickOutsideContent(event) && this.isClickOutsideAnchor(event);
+  private handleClickOutsideAnchor = (event: Event) => {
+    this.clickedOutside = this.isClickOutsideContent(event);
     if (this.clickedOutside) {
       if (this.props.onCloseRequest) {
         this.props.onCloseRequest();
@@ -523,16 +523,8 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
   };
 
   private isClickOutsideContent(event: Event) {
-    return this.isClickOutside(event, this.contentElement);
-  }
-
-  private isClickOutsideAnchor(event: Event) {
-    return this.isClickOutside(event, this.getAnchorElement());
-  }
-
-  private isClickOutside(event: Event, target: Nullable<HTMLElement>) {
-    if (target && event.target instanceof Element) {
-      return !containsTargetOrRenderContainer(event.target)(target);
+    if (this.contentElement && event.target instanceof Element) {
+      return !containsTargetOrRenderContainer(event.target)(this.contentElement);
     }
 
     return true;

--- a/packages/react-ui/components/Tooltip/__tests__/Tooltip-test.tsx
+++ b/packages/react-ui/components/Tooltip/__tests__/Tooltip-test.tsx
@@ -212,7 +212,7 @@ describe('Tooltip', () => {
       });
 
       withVariousAnchors((renderTooltip) => {
-        it('keeps open after click on anchor', async () => {
+        it('openes by hover and keeps open after click on anchor', async () => {
           const { anchor } = renderTooltip({ trigger: 'hover&focus' });
 
           userEvent.hover(anchor);
@@ -227,10 +227,40 @@ describe('Tooltip', () => {
       });
 
       withVariousAnchors((renderTooltip) => {
-        it('keeps open after click on content', async () => {
+        it('openes by hover and keeps open after click on content', async () => {
           const { anchor } = renderTooltip({ trigger: 'hover&focus' });
 
           userEvent.hover(anchor);
+          await delay(Tooltip.delay);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(content);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('openes by focus and keeps open after click on anchor', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          anchor.focus();
+          await delay(Tooltip.delay);
+          const content = screen.getByTestId(TooltipDataTids.content);
+
+          expect(content).toBeInTheDocument();
+
+          userEvent.click(anchor);
+          expect(content).toBeInTheDocument();
+        });
+      });
+
+      withVariousAnchors((renderTooltip) => {
+        it('openes by focus and keeps open after click on content', async () => {
+          const { anchor } = renderTooltip({ trigger: 'hover&focus' });
+
+          anchor.focus();
           await delay(Tooltip.delay);
           const content = screen.getByTestId(TooltipDataTids.content);
 

--- a/packages/react-ui/internal/RenderLayer/RenderLayer.tsx
+++ b/packages/react-ui/internal/RenderLayer/RenderLayer.tsx
@@ -66,13 +66,18 @@ export class RenderLayer extends React.Component<RenderLayerProps> {
     );
   }
 
+  private getAnchorNode(): Nullable<HTMLElement> {
+    const { getAnchorElement } = this.props;
+    return getAnchorElement ? getAnchorElement() : getRootNode(this);
+  }
+
   private attachListeners() {
-    const rootNode = getRootNode(this) || this.props.getAnchorElement?.();
-    if (!rootNode) {
+    const node = this.getAnchorNode();
+    if (!node) {
       return;
     }
 
-    this.focusOutsideListenerToken = listenFocusOutside(() => [rootNode], this.handleFocusOutside);
+    this.focusOutsideListenerToken = listenFocusOutside(() => [node], this.handleFocusOutside);
     window.addEventListener('blur', this.handleFocusOutside);
     document.addEventListener(
       'ontouchstart' in document.documentElement ? 'touchstart' : 'mousedown',
@@ -101,7 +106,7 @@ export class RenderLayer extends React.Component<RenderLayerProps> {
 
   private handleNativeDocClick = (event: Event) => {
     const target = event.target || event.srcElement;
-    const node = getRootNode(this) || getRootNode(this.props.getAnchorElement?.());
+    const node = this.getAnchorNode();
 
     if (!node || (target instanceof Element && containsTargetOrRenderContainer(target)(node))) {
       return;


### PR DESCRIPTION
<!--

Привет! Спасибо, за твой вклад проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md).

-->

Пофиксил проблему закрытия тултипа с триггером `hover&focus` в сценарии, когда он открывался по ховеру (или фокусу без клика), а затем получал клик в контент. 

[Пример](https://codesandbox.io/s/staging-wind-vc5g2u) с проблемой, [пример](https://codesandbox.io/s/mystifying-pond-jkf7x8) с фиксом. Сначала кликнуть на `Ok`, затем в тултип. Тултип не должен закрываться.

## Проблема

Источник проблемы тянется из предыдущих правок (см. #2873), после которых корневой элемент Popup поменялся с его anchor на его контент. Это поменяло события, при которых вызывается обработчик `handleClickOutside` внутри `Tooltip`. Раньше он вызывался при кликах вне anchor,  после #2873 стал вызываться при кликах вне контента тултипа. В итоге, внутренний флаг `isClickedOutside` при клике в контент тултипа не проставлялся в `false` и тултип закрывался обработчиком `handleBlur`. 


<!-- Подробно опиши решаемую проблему. -->

## Решение

По сути, тултипу для реализации его триггеров нужно слушать клики именно вне его anchor. Для этого используется `RenderLayer`. Но `RenderLayer` сам решает внутри себя что ему слушать и это не очень очевидно. На этом моменте и была поломка. В новой логике (#2873) `RenderLayer` слушает клики вне контента тултипа. Для решения предыдущей похожей проблемы (#2941) мы добавили дополнительную проверку на `target` клика, чтобы вернуть старое поведение. Однако, как видно в текущем ПР, это не решило проблему полностью. Поэтому здесь я предлагаю напрямую указать `RenderLayer`, что нужно слушать anchor, полностью вернув поведение до #2873, также откатив правки и из #2941.

Для решения подходит уже существующий проп `getAnchorElement` в `RenderLayer`. Он был добавлен во время избавления от `findDOMNode` (#2518) как фикс локальной проблемы. Она больше не воспроизводится, если удалить проп - тесты проходят. Вероятно, была на корню устранена в #2873. Подправил логику пропа, чтобы он имел приоритет над основной логикой определения anchor внутри `RenderLayer`.


<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-619

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их в чекбоксах. Если с каким-то из них возникли сложности — укажи это. -->

- [ ] Добавлены тесты на все изменения
  - [x] unit-тесты для логики ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#unit-тесты))
  - [ ] скриншоты для верстки и кросс-браузерности ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#скриншотные-тесты))
  - [ ] нерелевантно
- [ ] Добавлена (обновлена) документация
  - [ ] styleguidist для пропов и примеров использования компонентов ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#styleguidist))
  - [ ] jsdoc для утилит и хелперов ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#jsdoc))
  - [ ] комментарии для неочевидных мест в коде ([гайд](https://github.com/skbkontur/retail-ui/blob/pr-template/contributing.md#комментарии-в-коде))
  - [ ] прочие инструкции ([README.md](https://github.com/skbkontur/retail-ui/blob/master/README.md)), ([contributing.md](https://github.com/skbkontur/retail-ui/blob/master/contributing.md))
  - [x] нерелевантно
- [ ] Изменения корректно типизированы
  - [x] без использования `any` ([#2856](https://github.com/skbkontur/retail-ui/pull/2856))
  - [ ] нерелевантно
- [x] Все тесты и линтеры на CI проходят
- [x] В коде нет лишних изменений
- [x] Заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
