### PR TITLE
build(validations): don't use createPropsGetter from react-ui

### DIFF
--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -9,7 +9,7 @@
     "build:retail-ui": "rollup --config rollup.retail-ui.config.js",
     "build:react-ui": "rollup --config rollup.react-ui.config.js",
     "build:docs": "cross-env NODE_ENV=production webpack --config webpack.docs.config.js",
-    "predeploy": "yarn bundle-dts && yarn prepare-packages",
+    "predeploy": "yarn bundle-dts && yarn prepare-packages && yarn test:pack",
     "bundle-dts": "node scripts/bundle-dts.js",
     "prepare-packages": "node scripts/prepare-packages.js",
     "deploy": "npm-run-all --continue-on-error deploy:*",
@@ -26,7 +26,8 @@
     "fix:eslint": "yarn lint:eslint --fix",
     "fix:prettier": "yarn prettier --write .",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:pack": "jest --testMatch ** --testPathPattern=\"scripts/check-pack-files.js\""
   },
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/react-ui-validations/scripts/check-pack-files.js
+++ b/packages/react-ui-validations/scripts/check-pack-files.js
@@ -1,0 +1,15 @@
+const { readdirSync } = require('fs');
+
+// these files must exist in the final pack
+const FILES = ['CHANGELOG.md', 'index.d.ts', 'index.js', 'index.js.map', 'package.json', 'README.md'];
+const REACT_UI_DIST = 'build/react-ui-dist';
+const RETAIL_UI_DIST = 'build/retail-ui-dist';
+
+describe('Publishing packs must contain the required files', () => {
+  it('@skbkontur/react-ui', () => {
+    expect(readdirSync(REACT_UI_DIST)).toEqual(FILES);
+  });
+  it('retail-ui', () => {
+    expect(readdirSync(RETAIL_UI_DIST)).toEqual(FILES);
+  });
+});

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { createPropsGetter } from '@skbkontur/react-ui/lib/createPropsGetter';
 
 import { Nullable } from '../typings/Types';
 
+import { createPropsGetter } from './utils/createPropsGetter';
 import { isTestEnv } from './utils/utils';
 import { ValidationContextWrapper } from './ValidationContextWrapper';
 

--- a/packages/react-ui-validations/src/utils/createPropsGetter.ts
+++ b/packages/react-ui-validations/src/utils/createPropsGetter.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export type DefaultizedProps<P, DP> = P & DP;
+
+export function createPropsGetter<DP extends {}>(defaultProps: DP) {
+  return function <P, T extends React.Component<P>>(this: T) {
+    return this.props as DefaultizedProps<T['props'], DP>;
+  };
+}


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Валидации `1.9.0` потеряли типы. В итоговой сборке пакета отсутствует файл `index.d.ts`:

| ![image](https://user-images.githubusercontent.com/2708211/182213910-8c85cc6e-6cdc-47f5-8d67-c1328a18c351.png) |
| --- |


Причина в [ПРе](https://github.com/skbkontur/retail-ui/pull/2915) по исправлению проблем с типами в `defaultProps`, где заимпортили хелпер `createPropsGetter` [из контролов](https://github.com/skbkontur/retail-ui/commit/72d02d511a6ca0ea1a3569942f8cbde2f4c07d25#diff-ef28c82ff8cef217bba35323d8826f9f5bc8cc0f9797288f8bfb9831d37ecf67R2):

```js
// ValidationContainer.tsx

import { createPropsGetter } from '@skbkontur/react-ui/lib/createPropsGetter';
```

Из-за этого сборщик `rollup` стал разделять типы для пакета валидаций и для пакета контролов:

| Было | Стало |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2708211/182220885-82ff9727-f270-4fc8-9159-2eb09febb339.png) | ![image](https://user-images.githubusercontent.com/2708211/182218966-7a7faeb6-b97a-46bb-8516-34bf2657e6e3.png) |


Из-за чего сборщик типов в один файл `dts-bundle` не мог собрать типы по старым путям. Он выводил предупреждение в консоль, но не выкидывал ошибку и следующие за ним скрипты работали дальше:

| ![image](https://user-images.githubusercontent.com/2708211/182219557-0e3c2fb2-21a2-4b47-81d2-d4a6c7b2eb49.png) |
| --- |


## Решение

- Скопировал хэлпер `createPropsGetter` в валидации.
- Добавил тест наличия необходимых файлов.
- Вызываю этот тест в скрипте `predeploy`. 

Хотел сначала добавить новый `build step` на тимсити. Но новые конфиги стали пушиться в мастер в папку `.teamcity`, хотя текущих конфигов там нет. Откатил изменения, и пришлось ограничиться проверкой уже непосредственно перед диплоем.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
  (**Надо будет засквошить с коммитом build**)
