### PR TITLE
[Tooltip]: добавить event в onCloseRequest - LTS

### DIFF
--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -92,7 +92,7 @@ export interface TooltipProps extends CommonProps {
    * Хэндлер, вызываемый при клике по крестику или
    * снаружи тултипа
    */
-  onCloseRequest?: () => void;
+  onCloseRequest?: (event?: Event | React.MouseEvent) => void;
 
   /**
    * Хэндлер, вызываемый при закрытии тултипа
@@ -482,7 +482,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     this.clickedOutside = this.isClickOutsideContent(event);
     if (this.clickedOutside) {
       if (this.props.onCloseRequest) {
-        this.props.onCloseRequest();
+        this.props.onCloseRequest(event);
       }
       this.close();
     }
@@ -526,7 +526,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     }
 
     if (this.props.onCloseRequest) {
-      this.props.onCloseRequest();
+      this.props.onCloseRequest(event);
     }
 
     this.close();

--- a/packages/react-ui/components/Tooltip/__tests__/Tooltip-test.tsx
+++ b/packages/react-ui/components/Tooltip/__tests__/Tooltip-test.tsx
@@ -267,6 +267,18 @@ describe('Tooltip', () => {
 
       expect(onCloseRequest).toHaveBeenCalledTimes(1);
     });
+
+    it('should be called with event', () => {
+      wrapper.setProps({ trigger: 'click' });
+      wrapper.setState({ opened: true });
+      wrapper.update();
+      expect(wrapper.find(Content).length).toBe(1);
+
+      clickOutside();
+
+      const event = document.createEvent('HTMLEvents');
+      expect(onCloseRequest).toHaveBeenCalledWith(event);
+    });
   });
 
   it('clears hoverTimeout timer after unmount', () => {


### PR DESCRIPTION
## Проблема

В `onCloseRequest` не прокидывается `event`. Для некоторых команд это оказалось нужно, чтобы не закрывать Tooltip при клике на определенные элементы

## Решение

Прокинула `event`  в `onCloseRequest`. Сделала его необязательным, чтобы не нарушать обратную совместимость. Также добавила ему два типа: `Event` и `React.MouseEvent<HTMLElement> `чтобы не менять типы в других местах

## Ссылки

Дублирует правки из #2966 
fix IF-652

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
