### PR TITLE
fix(CurrencyInput): add support comma aliases

### DIFF
--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -302,6 +302,10 @@ export class CurrencyInput extends React.PureComponent<CurrencyInputProps, Curre
         });
         return;
       }
+      case CURRENCY_INPUT_ACTIONS.Comma: {
+        this.inputValue(selection.start, selection.end, ',');
+        return;
+      }
     }
   };
 

--- a/packages/react-ui/components/CurrencyInput/CurrencyInputKeyboardActions.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInputKeyboardActions.tsx
@@ -1,6 +1,15 @@
 import * as Keyboard from '../../lib/events/keyboard/identifiers';
 import { KeyboardActionExctracterBuilder } from '../../lib/extractKeyboardAction';
 
+export const commaAliases = [
+  Keyboard.isCodeComma,
+  Keyboard.isCodePeriod,
+  Keyboard.isCodeSlash,
+  Keyboard.isCodeBackslash,
+  Keyboard.isCodeIntlBackslash,
+  Keyboard.isCodeNumpadDivide,
+];
+
 export const CURRENCY_INPUT_ACTIONS = {
   Unknown: 0,
   Ignore: 1,
@@ -19,6 +28,8 @@ export const CURRENCY_INPUT_ACTIONS = {
   Backspace: 31,
   Delete: 32,
   Submit: 33,
+
+  Comma: 34,
 };
 
 export const extractAction = new KeyboardActionExctracterBuilder()
@@ -35,4 +46,5 @@ export const extractAction = new KeyboardActionExctracterBuilder()
   .add(CURRENCY_INPUT_ACTIONS.Backspace, Keyboard.isKeyBackspace)
   .add(CURRENCY_INPUT_ACTIONS.Delete, Keyboard.isKeyDelete)
   .add(CURRENCY_INPUT_ACTIONS.Ignore, (e) => Keyboard.isModified()(e) || Keyboard.isKeyTab(e))
+  .add(CURRENCY_INPUT_ACTIONS.Comma, Keyboard.someKeys(...commaAliases))
   .build(CURRENCY_INPUT_ACTIONS.Unknown);

--- a/packages/react-ui/components/CurrencyInput/__tests__/CurrencyInput-test.tsx
+++ b/packages/react-ui/components/CurrencyInput/__tests__/CurrencyInput-test.tsx
@@ -108,4 +108,22 @@ describe('CurrencyInput', () => {
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('12,00');
   });
+
+  describe.each([
+    ['Comma', '1,23'],
+    ['Period', '1,23'],
+    ['Slash', '1,23'],
+    ['Backslash', '1,23'],
+    ['IntlBackslash', '1,23'],
+    ['NumpadDivide', '1,23'],
+  ])('should applied [%s] as comma', (delimiter, expected) => {
+    test(`return: ${expected}`, async () => {
+      render(<CurrencyInputWithState />);
+      const input = screen.getByRole('textbox');
+      await userEvent.clear(input);
+      await userEvent.keyboard(`1[${delimiter}]23`, {});
+      await input.blur();
+      expect(input).toHaveValue(expected);
+    });
+  });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема


> Точка, слеш (/), буква б или ю на лету заменяются на запятую. Слеш, б и ю находятся на тех же клавишах, что точка и запятая, и пользователь может ввести их, забыв сменить раскладку.
>
> _© [guides.kontur.ru](https://guides.kontur.ru/components/currency/#11)_

Недостаточно ожидать значения `б` или `ю` в свойстве события `key`. На разных раскладках клавиатуры и зажатым капсом кол-во значений сильно возрастает.


## Решение

Надёжней всего использовать свойство события `code`. Они не зависят от регистра или раскладки.
Для подобных целей был реализован набор хэлперов по идентификации клавиш.

## Ссылки

Подробнее про идентификацию клавиш здесь https://github.com/skbkontur/retail-ui/pull/1639.


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
