### PR TITLE
feat(react-ui): add inputFocusedBg and inputFocusedIconColor variables

### DIFF
--- a/packages/react-ui/components/Input/Input.styles.ts
+++ b/packages/react-ui/components/Input/Input.styles.ts
@@ -66,6 +66,7 @@ export const styles = memoizeStyle({
 
   focus(t: Theme) {
     return css`
+      background: ${t.inputFocusedBg};
       border-color: ${t.inputBorderColorFocus};
       box-shadow: ${t.inputFocusShadow};
       outline: none;
@@ -374,6 +375,12 @@ export const styles = memoizeStyle({
       z-index: 2;
       text-align: center;
       box-sizing: content-box !important; // fix possible "reset.css" problem
+    `;
+  },
+
+  iconFocus(t: Theme) {
+    return css`
+      color: ${t.inputFocusedIconColor};
     `;
   },
 

--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -404,6 +404,7 @@ export class Input extends React.Component<InputProps, InputState> {
     return (
       <span
         className={cx(styles.icon(), sizeClassName, styles.useDefaultColor(this.theme), {
+          [styles.iconFocus(this.theme)]: this.state.focused,
           [styles.iconDisabled()]: disabled,
         })}
       >

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1085,6 +1085,9 @@ export class DefaultTheme {
   public static inputShadow = 'none';
   public static inputBg = 'white';
   public static inputIconColor = '#a9a9a9';
+  public static get inputFocusedIconColor() {
+    return this.inputIconColor;
+  }
   public static inputColor = 'inherit';
   public static inputWidth = '200px';
   public static get inputTextColorDisabled() {
@@ -1146,6 +1149,9 @@ export class DefaultTheme {
   public static inputIconSizeLarge = '20px';
   public static get inputFocusShadow() {
     return `0 0 0 ${this.inputOutlineWidth} ${this.borderColorFocus}`;
+  }
+  public static get inputFocusedBg() {
+    return this.inputBg;
   }
   public static get inputDisabledBg() {
     return this.bgDisabled;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Поступил запрос на добавление переменных `inputFocusedIconColor` и `inputFocusedBg`

## Решение

Добавил переменные. Не стал добавлять дополнительные переменные для глаза из `PasswordInput` и настраивать переменные для работы с `TokenInput`, так как запрос поступил именно на добавление переменных для обычного инпута

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-625

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
