### PR TITLE
fix(Radio): указать нужный border-collapse у корневого элемента

### DIFF
--- a/packages/react-ui/components/Radio/Radio.styles.ts
+++ b/packages/react-ui/components/Radio/Radio.styles.ts
@@ -34,7 +34,6 @@ export const styles = memoizeStyle({
       padding-bottom: ${t.radioPaddingY};
       display: inline-flex;
       align-items: baseline;
-      border-collapse: separate;
       line-height: ${t.radioLineHeight};
       font-size: ${t.radioFontSize};
 

--- a/packages/react-ui/components/Radio/Radio.styles.ts
+++ b/packages/react-ui/components/Radio/Radio.styles.ts
@@ -34,6 +34,7 @@ export const styles = memoizeStyle({
       padding-bottom: ${t.radioPaddingY};
       display: inline-flex;
       align-items: baseline;
+      border-collapse: separate;
       line-height: ${t.radioLineHeight};
       font-size: ${t.radioFontSize};
 

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1422,7 +1422,7 @@ export class DefaultTheme {
   public static get radioDisabledShadow() {
     return `0 0 0 ${this.radioBorderWidth} ${this.borderColorDisabled}`;
   }
-  public static radioCaptionDisplay = 'inline-table';
+  public static radioCaptionDisplay = 'inline-flex';
   public static radioBorderWidthCompensation = '0px';
   public static radioCircleOffsetY = '1px';
   //#endregion


### PR DESCRIPTION
## Проблема

У текста в компоненте Radio пропадает отступ, если у контейнера указан `border-collapse: collapse`.

## Решение

Указал нужный border-collapse у корневого элемента.

## Ссылки

fix #2980 
