### PR TITLE
build: move jest configs to separate files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  projects: ['<rootDir>/packages/*'],
+  roots: ['<rootDir>/packages/*'],
+};

--- a/package.json
+++ b/package.json
@@ -22,14 +22,6 @@
     "preinstall": "node scripts/update-package-registry",
     "postinstall": "node scripts/update-package-registry back"
   },
-  "jest": {
-    "projects": [
-      "<rootDir>/packages/*"
-    ],
-    "roots": [
-      "<rootDir>/packages/*"
-    ]
-  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/packages/react-ui-smoke-test/jest.config.js
+++ b/packages/react-ui-smoke-test/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testResultsProcessor: "jest-teamcity-reporter"
+};

--- a/packages/react-ui-smoke-test/package.json
+++ b/packages/react-ui-smoke-test/package.json
@@ -18,8 +18,5 @@
     "rimraf": "^3.0.2",
     "serve": "^11.3.0",
     "wait-on": "^4.0.0"
-  },
-  "jest": {
-    "testResultsProcessor": "jest-teamcity-reporter"
   }
 }

--- a/packages/react-ui-validations/jest.config.js
+++ b/packages/react-ui-validations/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testResultsProcessor: 'jest-teamcity-reporter',
+  moduleNameMapper: {
+    '\\.(css|less)$': 'identity-obj-proxy',
+  },
+  testMatch: ['<rootDir>/tests/**/*test.(ts|tsx)'],
+  testPathIgnorePatterns: ['/node_modules/', '/__fixtures__/'],
+  setupFilesAfterEnv: ['<rootDir>/tests/test-setup.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -114,30 +114,5 @@
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "3.9.0"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "testResultsProcessor": "jest-teamcity-reporter",
-    "moduleNameMapper": {
-      "\\.(css|less)$": "identity-obj-proxy"
-    },
-    "testMatch": [
-      "<rootDir>/tests/**/*test.(ts|tsx)"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/__fixtures__/"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/tests/test-setup.js"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ]
   }
 }

--- a/packages/react-ui/jest.config.js
+++ b/packages/react-ui/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testResultsProcessor: 'jest-teamcity-reporter',
+  moduleNameMapper: {
+    '\\.(css|less)$': 'identity-obj-proxy',
+  },
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest',
+  },
+  testRegex: '__tests__(\\\\|/).*(\\.|-)test\\.(j|t)sx?$',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/test-setup.js'],
+  transformIgnorePatterns: ['<rootDir>/node_modules/'],
+};

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -150,22 +150,5 @@
   "peerDependencies": {
     "react": ">=16.9",
     "react-dom": ">=16.9"
-  },
-  "jest": {
-    "testResultsProcessor": "jest-teamcity-reporter",
-    "moduleNameMapper": {
-      "\\.(css|less)$": "identity-obj-proxy"
-    },
-    "transform": {
-      "\\.[jt]sx?$": "babel-jest"
-    },
-    "testRegex": "__tests__(\\\\|/).*(\\.|-)test\\.(j|t)sx?$",
-    "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": [
-      "<rootDir>/test-setup.js"
-    ],
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/"
-    ]
   }
 }


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Конфиги jest загромождают package.json-ы и не очень удобно версионируются.

## Решение

Вынести конфиги в отдельные файлы.

## Ссылки

close #1178 

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
