### PR TITLE
fix(Input): restore background-clip in focus state

### DIFF
--- a/packages/react-ui/components/Input/Input.styles.ts
+++ b/packages/react-ui/components/Input/Input.styles.ts
@@ -66,7 +66,7 @@ export const styles = memoizeStyle({
 
   focus(t: Theme) {
     return css`
-      background: ${t.inputFocusedBg};
+      background-color: ${t.inputFocusedBg};
       border-color: ${t.inputBorderColorFocus};
       box-shadow: ${t.inputFocusShadow};
       outline: none;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В #2981 добавили переменную для цвета фона в состоянии фокуса. Но использование сокращенной формы `background: ${color};` устанавливает все другие неупомянутые явно свойства `background-*` в [дефолтные значения](https://developer.mozilla.org/en-US/docs/Web/CSS/background#formal_definition). Из-за этого, `background-clip` на элементе `root` сбросился с `padding-box` на `border-box`. 

Это вызвало дифф на скриншоте. Воспроизводится только в теме `THEME_2022`, т.к. там поменялся border-radius. Наши тесты не поймали, потому что новая тема еще не тестируется скриншотами. Найдено тестами экстерна.

_Добавить тест на это к нам, кажется, пока представляется не целесообразным._

## Решение

Вернуть старое значение `background-clip`, указав цвет фона через специальное свойство `background-color`.

## Ссылки

IF-720, IF-722

![image](https://user-images.githubusercontent.com/4607770/186147492-ee8e757a-1920-4868-855c-0a86e886e557.png)


<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
