### PR TITLE
docs(FileUploader): fix incorrect example

### DIFF
--- a/packages/react-ui/components/FileUploader/FileUploader.md
+++ b/packages/react-ui/components/FileUploader/FileUploader.md
@@ -38,7 +38,12 @@ import { FileUploader } from '@skbkontur/react-ui';
 ```jsx harmony
 import { FileUploader } from '@skbkontur/react-ui';
 
-<FileUploader multiple validateBeforeUpload={({originalFile}) => `У файла ${originalFile.name} неверный формат`} />
+<FileUploader
+  multiple
+  validateBeforeUpload={({ originalFile }) => {
+    return Promise.resolve(`У файла ${originalFile.name} неверный формат`);
+  }}
+/>;
 ```
 
 Валидация контрола


### PR DESCRIPTION
## Проблема

Пример "Валидация файла в списке" в доке `FileUploader`'а некорректен, в нём возвращаемое значение в функции передаваемой в `validateBeforeUpload` не оборачивается в `Promise`, хотя согласно типам это происходить должно. Из-за чего, пользователи, которые копируют пример с доки, сталкиваются с `TypeScript`'овыми ошибками 

## Решение

Обернул в `Promise.resolve` возвращаемое значение в функции передаваемой в `validateBeforeUpload`

## Ссылки

IF-744

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
