### PR TITLE
fix(Paging): visual appearance of disabled state

### DIFF
--- a/packages/react-ui/.creevey/images/Paging/Disabled Paging/chrome.png
+++ b/packages/react-ui/.creevey/images/Paging/Disabled Paging/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ea019c41cb050541cc09dba24a6b017f9bf369bdf7d4d692e6610ea9d464e3
+size 2952

--- a/packages/react-ui/.creevey/images/Paging/Disabled Paging/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Paging/Disabled Paging/chromeDark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ecbad57876272887aa8a24a52d9f2c8f7162a59c327e52c1002261456b77e513
-size 2714
+oid sha256:bc5b56c6c2a931b2cc81c1b8f027edd65450934530151b0f97b7a71c6792d5a7
+size 2979

--- a/packages/react-ui/.creevey/images/Paging/Disabled Paging/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Paging/Disabled Paging/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecbad57876272887aa8a24a52d9f2c8f7162a59c327e52c1002261456b77e513
+size 2714

--- a/packages/react-ui/components/Paging/Paging.md
+++ b/packages/react-ui/components/Paging/Paging.md
@@ -26,6 +26,19 @@ class Paginator3000 extends React.Component {
 <Paginator3000 />;
 ```
 
+Пейджинг в отключенном состоянии
+
+```jsx
+const [activePage, setActivePage] = React.useState(3);
+
+<Paging
+  disabled
+  onPageChange={(activePage) => setActivePage(activePage)}
+  activePage={activePage}
+  pagesCount={8}
+/>
+```
+
 #### Локали по умолчанию
 
 ```typescript static

--- a/packages/react-ui/components/Paging/Paging.styles.ts
+++ b/packages/react-ui/components/Paging/Paging.styles.ts
@@ -26,9 +26,9 @@ export const styles = memoizeStyle({
     `;
   },
 
-  dotsDisabled() {
+  dotsDisabled(t: Theme) {
     return css`
-      color: #adadad;
+      color: ${t.textColorDisabled};
     `;
   },
 

--- a/packages/react-ui/components/Paging/Paging.styles.ts
+++ b/packages/react-ui/components/Paging/Paging.styles.ts
@@ -114,7 +114,7 @@ export const styles = memoizeStyle({
 
   pageLinkCurrentDisabled(t: Theme) {
     return css`
-      background: rgba(0, 0, 0, 0.04) !important;
+      background: ${t.pagingPageLinkDisabledActiveBg} !important;
       color: ${t.linkDisabledColor};
     `;
   },

--- a/packages/react-ui/components/Paging/Paging.styles.ts
+++ b/packages/react-ui/components/Paging/Paging.styles.ts
@@ -12,11 +12,23 @@ export const styles = memoizeStyle({
     `;
   },
 
+  pagingDisabled() {
+    return css`
+      pointer-events: none;
+    `;
+  },
+
   dots(t: Theme) {
     return css`
       color: ${t.pagingDotsColor};
       display: inline-block;
       padding: ${t.pagingDotsPadding};
+    `;
+  },
+
+  dotsDisabled() {
+    return css`
+      color: #adadad;
     `;
   },
 
@@ -51,7 +63,7 @@ export const styles = memoizeStyle({
     `;
   },
 
-  disabled(t: Theme) {
+  forwardLinkDisabled(t: Theme) {
     return css`
       color: ${t.pagingForwardLinkDisabledColor};
       cursor: default;
@@ -86,11 +98,24 @@ export const styles = memoizeStyle({
     `;
   },
 
-  active(t: Theme) {
+  pageLinkDisabled(t: Theme) {
+    return css`
+      color: ${t.linkDisabledColor};
+    `;
+  },
+
+  pageLinkCurrent(t: Theme) {
     return css`
       cursor: default;
       background: ${t.pagingPageLinkActiveBg} !important; // override hover styles
       color: ${t.pagingPageLinkActiveColor};
+    `;
+  },
+
+  pageLinkCurrentDisabled(t: Theme) {
+    return css`
+      background: rgba(0, 0, 0, 0.04) !important;
+      color: ${t.linkDisabledColor};
     `;
   },
 

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -169,7 +169,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
         <span
           tabIndex={0}
           data-tid={dataTid}
-          className={styles.paging(this.theme)}
+          className={cx({ [styles.paging(this.theme)]: true, [styles.pagingDisabled()]: this.props.disabled })}
           onKeyDown={useGlobalListener ? undefined : this.handleKeyDown}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
@@ -202,7 +202,11 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
 
   private renderDots = (key: string) => {
     return (
-      <span data-tid={PagingDataTids.dots} key={key} className={styles.dots(this.theme)}>
+      <span
+        data-tid={PagingDataTids.dots}
+        key={key}
+        className={cx({ [styles.dots(this.theme)]: true, [styles.dotsDisabled()]: this.props.disabled })}
+      >
         {'...'}
       </span>
     );
@@ -212,9 +216,8 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
     const classes = cx({
       [styles.forwardLink(this.theme)]: true,
       [styles.forwardLinkFocused()]: focused,
-      [styles.disabled(this.theme)]: disabled,
+      [styles.forwardLinkDisabled(this.theme)]: disabled || this.props.disabled,
     });
-    const { caption } = this.props;
     const Component = this.getProps().component;
     const { forward } = this.locale;
 
@@ -228,7 +231,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
         tabIndex={-1}
         pageNumber={'forward' as const}
       >
-        {caption || forward}
+        {this.props.caption || forward}
         <span className={styles.forwardIcon(this.theme)}>
           <ArrowChevronRightIcon size={this.theme.pagingForwardIconSize} />
         </span>
@@ -240,7 +243,9 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
     const classes = cx({
       [styles.pageLink(this.theme)]: true,
       [styles.pageLinkFocused(this.theme)]: focused,
-      [styles.active(this.theme)]: active,
+      [styles.pageLinkDisabled(this.theme)]: this.props.disabled,
+      [styles.pageLinkCurrent(this.theme)]: active,
+      [styles.pageLinkCurrentDisabled(this.theme)]: active && this.props.disabled,
     });
     const Component = this.getProps().component;
     const handleClick = () => this.goToPage(pageNumber);

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -205,7 +205,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
       <span
         data-tid={PagingDataTids.dots}
         key={key}
-        className={cx({ [styles.dots(this.theme)]: true, [styles.dotsDisabled()]: this.props.disabled })}
+        className={cx({ [styles.dots(this.theme)]: true, [styles.dotsDisabled(this.theme)]: this.props.disabled })}
       >
         {'...'}
       </span>

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -167,7 +167,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <span
-          tabIndex={0}
+          tabIndex={this.props.disabled ? -1 : 0}
           data-tid={dataTid}
           className={cx({ [styles.paging(this.theme)]: true, [styles.pagingDisabled()]: this.props.disabled })}
           onKeyDown={useGlobalListener ? undefined : this.handleKeyDown}

--- a/packages/react-ui/components/Paging/__stories__/Paging.stories.tsx
+++ b/packages/react-ui/components/Paging/__stories__/Paging.stories.tsx
@@ -256,6 +256,15 @@ WithLongItems.args = {
   pagesCount: 7530050,
 };
 
+export const DisabledPaging = () => {
+  return <Paging onPageChange={() => false} disabled activePage={1} pagesCount={8} />;
+};
+DisabledPaging.parameters = {
+  creevey: {
+    skip: { in: /^(?!\bchrome\b)/ },
+  },
+};
+
 export const PlaygroundStory = () => <Playground />;
 PlaygroundStory.storyName = 'Playground';
 PlaygroundStory.parameters = { creevey: { skip: [true] } };

--- a/packages/react-ui/components/Paging/__stories__/Paging.stories.tsx
+++ b/packages/react-ui/components/Paging/__stories__/Paging.stories.tsx
@@ -261,7 +261,7 @@ export const DisabledPaging = () => {
 };
 DisabledPaging.parameters = {
   creevey: {
-    skip: { in: /^(?!\bchrome\b)/ },
+    skip: { in: /^(?!\b(chrome|chromeDark)\b)/ },
   },
 };
 

--- a/packages/react-ui/components/Paging/__stories__/Paging.stories.tsx
+++ b/packages/react-ui/components/Paging/__stories__/Paging.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentStory } from '@storybook/react';
 
 import { Meta, Story } from '../../../typings/stories';
 import { ItemComponentProps, Paging } from '../Paging';
-import { delay } from '../../../lib/utils';
+import { delay, emptyHandler } from '../../../lib/utils';
 import { PagingProps } from '..';
 
 const lorem = `Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores
@@ -257,7 +257,7 @@ WithLongItems.args = {
 };
 
 export const DisabledPaging = () => {
-  return <Paging onPageChange={() => false} disabled activePage={1} pagesCount={8} />;
+  return <Paging onPageChange={emptyHandler} disabled activePage={1} pagesCount={8} />;
 };
 DisabledPaging.parameters = {
   creevey: {

--- a/packages/react-ui/components/Paging/__tests__/Paging-test.tsx
+++ b/packages/react-ui/components/Paging/__tests__/Paging-test.tsx
@@ -9,6 +9,14 @@ import { PagingLocaleHelper } from '../locale';
 import { Paging } from '../Paging';
 
 describe('Paging', () => {
+  it('should keep focus on body when the component is disabled', () => {
+    render(<Paging disabled pagesCount={3} activePage={1} onPageChange={emptyHandler} />);
+
+    userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
   it('should render correct number of links', () => {
     render(<Paging pagesCount={5} activePage={1} onPageChange={emptyHandler} />);
 

--- a/packages/react-ui/internal/themes/DarkTheme.ts
+++ b/packages/react-ui/internal/themes/DarkTheme.ts
@@ -130,6 +130,7 @@ export class DarkTheme extends (class {} as typeof DefaultThemeInternal) {
   //#region Paging
   public static pagingPageLinkHoverBg = 'rgba(255, 255, 255, 0.8)';
   public static pagingPageLinkActiveBg = 'rgba(255, 255, 255, 0.16)';
+  public static pagingPageLinkDisabledActiveBg = 'rgba(255, 255, 255, 0.08)';
   //#endregion
   //#region Toast
   public static toastLinkColor = '#51adff';

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -843,6 +843,7 @@ export class DefaultTheme {
   public static pagingDotsColor = 'gray';
   public static pagingDotsPadding = '0.375em 0.625em 0';
   public static pagingPageLinkActiveBg = 'rgba(0, 0, 0, 0.09)';
+  public static pagingPageLinkDisabledActiveBg = 'rgba(0, 0, 0, 0.04)';
   public static get pagingPageLinkActiveColor() {
     return this.textColorDefault;
   }


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

У `Paging`'а в отключенном состоянии пропадала только возможность сфокусироваться на нём, но никак не менялся внешний вид

## Решение

1. Изменил дизайн отключенного состояния в соотвествии с макетами (макеты можно найти в комментариях к задаче)
2. Новых переменных в тему не добавлял, так как пока не ясно есть ли в них необходимость
3. Оставил скриншоты только в `Chrome`, так как в отключенном состоянии меняются только цвета контрола


## Ссылки

#3018, IF-806

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
