### PR TITLE
fix(CurrencyInput): clearing value (master)

### DIFF
--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.md
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.md
@@ -4,6 +4,19 @@ const [value, setValue] = React.useState();
 <CurrencyInput value={value} fractionDigits={3} onValueChange={setValue} />
 ```
 
+Очистить значение в `CurrencyInput` можно с помощью `null` или `undefined`
+```jsx harmony
+import { Button, Group } from '@skbkontur/react-ui';
+
+const [value, setValue] = React.useState();
+
+<Group>
+  <CurrencyInput value={value} onValueChange={setValue} />
+  <Button onClick={() => setValue(null)}>Null</Button>
+  <Button onClick={() => setValue(undefined)}>Undefined</Button>
+</Group>
+```
+
 `fractionDigits={15}`
 
 ```jsx harmony

--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -83,7 +83,7 @@ export class CurrencyInput extends React.PureComponent<CurrencyInputProps, Curre
     signed: PropTypes.bool,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     value: (props: CurrencyInputProps) => {
-      warning(isValidNumber(props.value), `[CurrencyInput]: Prop value is not a valid number`);
+      warning(isValidNumber(props.value), '[CurrencyInput]: Prop `value` is not a valid number');
     },
     warning: PropTypes.bool,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -136,6 +136,9 @@ export class CurrencyInput extends React.PureComponent<CurrencyInputProps, Curre
       prevProps.fractionDigits !== fractionDigits
     ) {
       this.setState(this.getState(value, fractionDigits, hideTrailingZeros));
+    }
+    if (prevProps.value !== null && value === null) {
+      this.setState({ formatted: '' });
     }
     if (this.state.focused && this.input) {
       const { start, end } = this.state.selection;

--- a/packages/react-ui/components/CurrencyInput/__tests__/CurrencyInput-test.tsx
+++ b/packages/react-ui/components/CurrencyInput/__tests__/CurrencyInput-test.tsx
@@ -30,62 +30,62 @@ const CurrencyInputAndButton = (props: { value: unknown }): JSX.Element => {
 };
 
 describe('CurrencyInput', () => {
-  it('should mount with a number value', async () => {
+  it('should mount with a number value', () => {
     render(<CurrencyInputWithValueProp value={12} />);
     expect(screen.getByRole('textbox')).toHaveValue('12,00');
   });
 
-  it('should mount with a correct string value', async () => {
+  it('should mount with a correct string value', () => {
     render(<CurrencyInputWithValueProp value={'12'} />);
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('12,00');
   });
 
-  it('should mount with incorrect string value', async () => {
+  it('should mount with incorrect string value', () => {
     render(<CurrencyInputWithValueProp value={'str'} />);
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue(',00');
   });
 
-  it('should mount with NaN value', async () => {
+  it('should mount with NaN value', () => {
     render(<CurrencyInputWithValueProp value={parseInt('str')} />);
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue(',00');
   });
 
-  it('should mount with null value', async () => {
+  it('should mount with null value', () => {
     render(<CurrencyInputWithValueProp value={null} />);
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('');
   });
 
-  it('should set a correct number value', async () => {
+  it('should set a correct number value', () => {
     render(<CurrencyInputWithState />);
     const input = screen.getByRole('textbox');
-    await userEvent.clear(input);
-    await userEvent.type(input, '123');
-    await input.blur();
+    userEvent.clear(input);
+    userEvent.type(input, '123');
+    input.blur();
     expect(input).toHaveValue('123,00');
   });
 
-  it('should not set a string value', async () => {
+  it('should not set a string value', () => {
     render(<CurrencyInputWithState />);
     const input = screen.getByRole('textbox');
-    await userEvent.clear(input);
-    await userEvent.type(input, 'str');
-    await input.blur();
+    userEvent.clear(input);
+    userEvent.type(input, 'str');
+    input.blur();
     expect(input).toHaveValue('');
   });
 
-  it('should change value with a valid number', async () => {
+  it('should change value with a valid number', () => {
     render(<CurrencyInputAndButton value={123} />);
     const button = screen.getByRole('button');
-    await userEvent.click(button);
+    userEvent.click(button);
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('123,00');
   });
 
-  it('should change value and not throw an error with a valid string', async () => {
+  it('should change value and not throw an error with a valid string', () => {
     render(<CurrencyInputAndButton value={'123'} />);
     const button = screen.getByRole('button');
     expect(() => userEvent.click(button)).not.toThrow();
@@ -93,7 +93,7 @@ describe('CurrencyInput', () => {
     expect(input).toHaveValue('123,00');
   });
 
-  it('should not change value and not throw an error with an invalid string', async () => {
+  it('should not change value and not throw an error with an invalid string', () => {
     render(<CurrencyInputAndButton value={'str'} />);
     const button = screen.getByRole('button');
     expect(() => userEvent.click(button)).not.toThrow();
@@ -101,12 +101,44 @@ describe('CurrencyInput', () => {
     expect(input).toHaveValue('12,00');
   });
 
-  it('should not change value and should not throw an error with NaN', async () => {
+  it('should not change value and should not throw an error with NaN', () => {
     render(<CurrencyInputAndButton value={parseInt('str')} />);
     const button = screen.getByRole('button');
     expect(() => userEvent.click(button)).not.toThrow();
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('12,00');
+  });
+
+  it('should clear `value` in input when undefined passed', () => {
+    const Comp = () => {
+      const [value, setValue] = useState<Nullable<number>>(12345);
+      return (
+        <>
+          <button onClick={() => setValue(undefined)}>clear</button>
+          <CurrencyInput value={value} onValueChange={setValue} />
+        </>
+      );
+    };
+    render(<Comp />);
+
+    userEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('should clear `value` in input when null passed', () => {
+    const Comp = () => {
+      const [value, setValue] = useState<Nullable<number>>(12345);
+      return (
+        <>
+          <button onClick={() => setValue(null)}>clear</button>
+          <CurrencyInput value={value} onValueChange={setValue} />
+        </>
+      );
+    };
+    render(<Comp />);
+
+    userEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   describe.each([
@@ -117,12 +149,12 @@ describe('CurrencyInput', () => {
     ['IntlBackslash', '1,23'],
     ['NumpadDivide', '1,23'],
   ])('should applied [%s] as comma', (delimiter, expected) => {
-    test(`return: ${expected}`, async () => {
+    test(`return: ${expected}`, () => {
       render(<CurrencyInputWithState />);
       const input = screen.getByRole('textbox');
-      await userEvent.clear(input);
-      await userEvent.keyboard(`1[${delimiter}]23`, {});
-      await input.blur();
+      userEvent.clear(input);
+      userEvent.keyboard(`1[${delimiter}]23`, {});
+      input.blur();
       expect(input).toHaveValue(expected);
     });
   });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

- После #2885 стала невозможной очистка значения в `CurrencyInput`
- В #2987 не получилось задокументировать очистку значений в `CurrencyInput`

## Решение

- Вернул возможность очищать `value` в `CurrencyInput` с помощью `null` и `undefined`, как это работало раньше
- Дополнил документацию в `CurrencyInput` по мотивам #2987
- Произвёл незначительный рефакторинг тестов `CurrencyInput`'а
- Немного подправил сообщение об ошибке в `PropTypes`

## Ссылки

IF-729

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
