### PR TITLE
fix(ValidationContainer): level warning is valid

### DIFF
--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 
-import { Nullable } from '../typings/Types';
-
-import { Validation, ValidationWrapperInternal } from './ValidationWrapperInternal';
+import { ValidationWrapperInternal } from './ValidationWrapperInternal';
 import { ScrollOffset } from './ValidationContainer';
 import { isNullable } from './utils/isNullable';
-import { isEqual } from './ValidationHelper';
 
 export interface ValidationContextSettings {
   scrollOffset: ScrollOffset;
@@ -44,7 +41,6 @@ ValidationContext.displayName = 'ValidationContext';
 
 export class ValidationContextWrapper extends React.Component<ValidationContextWrapperProps> {
   public childWrappers: ValidationWrapperInternal[] = [];
-  private previousValidation: Array<Nullable<Validation>> = [];
 
   public getSettings(): ValidationContextSettings {
     let scrollOffset: ScrollOffset = {};
@@ -132,19 +128,9 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
   }
 
   public async validate(withoutFocus: boolean): Promise<boolean> {
-    const currentValidation = this.childWrappers.map((x) => x.props.validation);
-    const validationHasNotChanged = this.validationsArraysEqual(this.previousValidation, currentValidation);
-
     await Promise.all(this.childWrappers.map((x) => x.processSubmit()));
 
-    const firstInvalid = this.getChildWrappersSortedByPosition().find((x) => {
-      const hasWarning = x.hasWarning();
-      const hasError = x.hasError();
-      if (validationHasNotChanged && hasWarning && !hasError) {
-        return false;
-      }
-      return hasError || hasWarning;
-    });
+    const firstInvalid = this.getChildWrappersSortedByPosition().find((x) => x.hasError());
     if (firstInvalid) {
       if (!withoutFocus) {
         firstInvalid.focus();
@@ -154,8 +140,6 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
     if (this.props.onValidationUpdated) {
       this.props.onValidationUpdated(!firstInvalid);
     }
-
-    this.previousValidation = currentValidation;
     return !firstInvalid;
   }
 
@@ -166,7 +150,4 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
       </ValidationContext.Provider>
     );
   }
-
-  private validationsArraysEqual = (a1: Array<Nullable<Validation>>, a2: Array<Nullable<Validation>>): boolean =>
-    a1.length === a2.length && a1.every((o, idx) => isEqual(o, a2[idx]));
 }

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -130,22 +130,18 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
   public async validate(withoutFocus: boolean): Promise<boolean> {
     await Promise.all(this.childWrappers.map((x) => x.processSubmit()));
 
-    const firstInvalid = this.getChildWrappersSortedByPosition().find((x) => x.hasError());
-    const firstWarning = this.getChildWrappersSortedByPosition().find((x) => x.hasWarning());
+    const childrenWrappersSortedByPosition = this.getChildWrappersSortedByPosition();
+    const firstInvalid = childrenWrappersSortedByPosition.find((x) => x.hasError() || x.hasWarning());
+    const invalid = childrenWrappersSortedByPosition.some((x) => x.hasError());
     if (firstInvalid) {
       if (!withoutFocus) {
         firstInvalid.focus();
       }
     }
-    if (firstWarning) {
-      if (!withoutFocus) {
-        firstWarning.focus();
-      }
-    }
     if (this.props.onValidationUpdated) {
       this.props.onValidationUpdated(!firstInvalid);
     }
-    return !firstInvalid;
+    return !invalid;
   }
 
   public render() {

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -131,12 +131,17 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
     await Promise.all(this.childWrappers.map((x) => x.processSubmit()));
 
     const firstInvalid = this.getChildWrappersSortedByPosition().find((x) => x.hasError());
+    const firstWarning = this.getChildWrappersSortedByPosition().find((x) => x.hasWarning());
     if (firstInvalid) {
       if (!withoutFocus) {
         firstInvalid.focus();
       }
     }
-
+    if (firstWarning) {
+      if (!withoutFocus) {
+        firstWarning.focus();
+      }
+    }
     if (this.props.onValidationUpdated) {
       this.props.onValidationUpdated(!firstInvalid);
     }

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -11,8 +11,12 @@ import {
   TokenInputType,
 } from '@skbkontur/react-ui';
 
-import { ValidationContainer, ValidationContainerProps, ValidationWrapper } from '../src';
+import { ValidationContainer, ValidationContainerProps, ValidationInfo, ValidationWrapper } from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
+
+const validate = (v: string): ValidationInfo | null => {
+  return !/^\d*$/.test(v) ? { message: 'Только цифры', level: 'warning' } : null;
+};
 
 describe('ValidationContainer', () => {
   it('renders passed children', () => {
@@ -67,6 +71,29 @@ describe('ValidationContainer', () => {
 
         expect(smoothScrollIntoView).toBeCalled();
       });
+    });
+  });
+
+  describe('on warning level', () => {
+    const renderValidationContainer = (
+      input: React.ReactElement,
+      props?: ValidationContainerProps,
+    ): React.RefObject<ValidationContainer> => {
+      const containerRef = React.createRef<ValidationContainer>();
+      render(
+        <ValidationContainer ref={containerRef} {...props}>
+          <ValidationWrapper validationInfo={validate('text')}>{input}</ValidationWrapper>
+        </ValidationContainer>,
+      );
+      return containerRef;
+    };
+
+    it('validate form', async () => {
+      const containerRef = renderValidationContainer(<Input />);
+
+      const result = await containerRef.current?.validate();
+
+      expect(result).toEqual(true);
     });
   });
 });

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -11,12 +11,8 @@ import {
   TokenInputType,
 } from '@skbkontur/react-ui';
 
-import { ValidationContainer, ValidationContainerProps, ValidationInfo, ValidationWrapper } from '../src';
+import { ValidationContainer, ValidationContainerProps, ValidationWrapper } from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
-
-const validate = (v: string): ValidationInfo | null => {
-  return !/^\d*$/.test(v) ? { message: 'Только цифры', level: 'warning' } : null;
-};
 
 describe('ValidationContainer', () => {
   it('renders passed children', () => {
@@ -82,7 +78,9 @@ describe('ValidationContainer', () => {
       const containerRef = React.createRef<ValidationContainer>();
       render(
         <ValidationContainer ref={containerRef} {...props}>
-          <ValidationWrapper validationInfo={validate('text')}>{input}</ValidationWrapper>
+          <ValidationWrapper validationInfo={{ message: 'warning message', level: 'warning' }}>
+            {input}
+          </ValidationWrapper>
         </ValidationContainer>,
       );
       return containerRef;


### PR DESCRIPTION
## Проблема

В #2977 реализовали поведение, когда при типе валидаций `warning` `ValidationContainer` дает засабмитить форму только со второго раза. Но это поломало пользовательские сценарии и было решено разрешить сабмитить форму с первого раза

## Решение

Просто откатить #2977 не помогло бы, так как до этого в #2804 при типе валидаций `warning` `ValidationContainer`  не давал в принципе засабмитить форму. Поэтому пришлось вручную удалять логику валидирования со второго раза и изменять условие валидации

## Ссылки

fix IF-817

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
