### PR TITLE
chore: correct some ts interfaces

### DIFF
--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -15,7 +15,7 @@ import { styles } from './MenuItem.styles';
 
 export type MenuItemState = null | 'hover' | 'selected' | void;
 
-export interface MenuItemProps extends CommonProps {
+export interface MenuItemProps extends Omit<CommonProps, 'children'> {
   /**
    * @ignore
    */

--- a/packages/react-ui/components/SidePage/SidePageFooter.tsx
+++ b/packages/react-ui/components/SidePage/SidePageFooter.tsx
@@ -14,7 +14,7 @@ import { isNonNullable } from '../../lib/utils';
 import { styles } from './SidePage.styles';
 import { SidePageContext, SidePageContextType } from './SidePageContext';
 
-export interface SidePageFooterProps extends CommonProps {
+export interface SidePageFooterProps extends Omit<CommonProps, 'children'> {
   children?: React.ReactNode | ((fixed: boolean) => React.ReactNode);
   /**
    * Включает серый цвет в футере

--- a/packages/react-ui/components/SidePage/SidePageHeader.tsx
+++ b/packages/react-ui/components/SidePage/SidePageHeader.tsx
@@ -15,7 +15,7 @@ import { getDOMRect } from '../../lib/dom/getDOMRect';
 import { styles } from './SidePage.styles';
 import { SidePageContext, SidePageContextType } from './SidePageContext';
 
-export interface SidePageHeaderProps extends CommonProps {
+export interface SidePageHeaderProps extends Omit<CommonProps, 'children'> {
   children?: React.ReactNode | ((fixed: boolean) => React.ReactNode);
   sticky?: boolean;
 }

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -16,7 +16,7 @@ import { styles } from './Sticky.styles';
 
 const MAX_REFLOW_RETRIES = 5;
 
-export interface StickyProps extends CommonProps {
+export interface StickyProps extends Omit<CommonProps, 'children'> {
   side: 'top' | 'bottom';
   /**
    * Отступ в пикселях от края экрана, на сколько сдвигается элемент в залипшем состоянии

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -68,7 +68,7 @@ export interface PopupHandlerProps {
   onClose?: () => void;
 }
 
-export interface PopupProps extends CommonProps, PopupHandlerProps {
+export interface PopupProps extends Omit<CommonProps, 'children'>, PopupHandlerProps {
   anchorElement: React.ReactNode | HTMLElement;
   backgroundColor?: React.CSSProperties['backgroundColor'];
   borderColor?: React.CSSProperties['borderColor'];


### PR DESCRIPTION
## Проблема

Собирал библиотеку собственных контроллов поверх ваших и столкнулся с проблемой в тайпингах в связке со свежим реактом
```
Interface 'PopupProps' incorrectly extends interface 'CommonProps'.
  Types of property 'children' are incompatible.
    Type 'ReactNode | (() => ReactNode)' is not assignable to type 'ReactNode'.
      Type '() => ReactNode' is not assignable to type 'ReactNode'.
```
## Решение

Наследуюсь `Omit<CommonProps, 'children'>` вместо просто `CommonProps`, если есть несовместимое переопределение в описываемом интерфейсе  

Список измененных интерейфесов:
```
MenuItemProps
SidePageHeaderProps
SidePageFooterProps
StickyProps
PopupProps
```
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
