### PR TITLE
build(tc): pick 3.15 version of NUnit due to .NET 7.0

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -623,7 +623,7 @@ object Validations_LintTest : BuildType({
         nunit {
             name = "Run tests"
             id = "RUNNER_7"
-            nunitPath = "%teamcity.tool.NUnit.Console.3.10.0%"
+            nunitPath = "%teamcity.tool.NUnit.Console.3.15.2%"
             includeTests = """packages\react-ui-validations\selenium-tests\ValidationTests\bin\Debug\ValidationTests.dll"""
         }
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -623,7 +623,7 @@ object Validations_LintTest : BuildType({
         nunit {
             name = "Run tests"
             id = "RUNNER_7"
-            nunitPath = "%teamcity.tool.NUnit.Console.DEFAULT%"
+            nunitPath = "%teamcity.tool.NUnit.Console.3.10.0%"
             includeTests = """packages\react-ui-validations\selenium-tests\ValidationTests\bin\Debug\ValidationTests.dll"""
         }
     }

--- a/packages/react-ui-validations/selenium-tests/ValidationTests/packages.config
+++ b/packages/react-ui-validations/selenium-tests/ValidationTests/packages.config
@@ -5,8 +5,8 @@
   <package id="Kontur.RetryableAssertions" version="0.0.2-alpha" targetFramework="net45" />
   <package id="Kontur.Selone" version="0.0.6-alpha" targetFramework="net45" />
   <package id="Microsoft.Windows.Compatibility" version="2.0.1" targetFramework="net45" />
-  <package id="NUnit" version="3.12.0" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.15.1" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.13.1" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/packages/react-ui-validations/selenium-tests/ValidationTests/packages.config
+++ b/packages/react-ui-validations/selenium-tests/ValidationTests/packages.config
@@ -5,8 +5,8 @@
   <package id="Kontur.RetryableAssertions" version="0.0.2-alpha" targetFramework="net45" />
   <package id="Kontur.Selone" version="0.0.6-alpha" targetFramework="net45" />
   <package id="Microsoft.Windows.Compatibility" version="2.0.1" targetFramework="net45" />
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
-  <package id="NUnit3TestAdapter" version="3.15.1" targetFramework="net45" />
+  <package id="NUnit" version="3.12.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.13.1" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Начали падать шарповые тесты на некоторых агентах. Ранер тестов NUnit валился с такой ошибкой:
```diff
-Process exited with code -100 (Step: Run tests (NUnit))
-Step Run tests (NUnit) failed
```

Дело оказалось в обновлении dotnet до `7.0` на половине агентах. У нас в конфиг этого билда указана дефолтная версия NUnit. Тимсити назначил дефолтной версию `3.12.2`, и в ней оказался [баг](https://github.com/nunit/nunit3-vs-adapter/issues/987).


## Решение

Указал другую версию NUnit, которая нормально работает и с `6.0` и с `7.0` версиями dotnet.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
