### PR TITLE
feat(Validation): add an option to disable focus on warning

### DIFF
--- a/packages/react-ui-validations/docs/Pages/Api.md
+++ b/packages/react-ui-validations/docs/Pages/Api.md
@@ -4,17 +4,23 @@
 
 Контейнер, внутри которого находятся валидируемые контролы.
 
-### `submit(): Promise<void>`
+### `submit(withoutFocus?: boolean | 'warningsWithoutFocus'): Promise<void>`
 
 При вызове этой функции загораются все невалидные контролы. Необходимо для реализации
 сценария [валидации при отправке формы](https://guides.kontur.ru/principles/validation/#07).
+
 
     <ValidationContainer ref='container'>
         // ...
         <Button onClick={() => this.refs.container.submit()}>Сохранить</Button>
     </ValidationContainer>
 
-### `validate(): Promise<boolean>`
+Аргументы:
+
+- `withoutFocus`: `true` отключает автофокус невалидных контролов. `'warningsWithoutFocus'` отключает автофокус к валидациям с уровнем варнинг (`level = 'warning'`). Дефолтное значение `false`.
+
+
+### `validate(withoutFocus?: boolean | 'warningsWithoutFocus'): Promise<boolean>`
 
 При вызове этой функции загораются все невалидные контролы так же как и при вызове
 функции `submit()`. Кроме того функция возвращает признак валидности формы.
@@ -34,6 +40,11 @@
             </ValidationContainer>
         );
     }
+
+Аргументы:
+
+- `withoutFocus`: `true` отключает автофокус невалидных контролов. `'warningsWithoutFocus'` отключает автофокус к валидациям с уровнем варнинг (`level = 'warning'`). Дефолтное значение `false`.
+
 
 ### `children`
 

--- a/packages/react-ui-validations/docs/Pages/Api.md
+++ b/packages/react-ui-validations/docs/Pages/Api.md
@@ -4,7 +4,9 @@
 
 Контейнер, внутри которого находятся валидируемые контролы.
 
-### `submit(withoutFocus?: boolean | 'warningsWithoutFocus'): Promise<void>`
+### `submit(withoutFocus?: boolean): Promise<void>`
+либо
+### `submit(validationSettings?: { focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }): Promise<void>`
 
 При вызове этой функции загораются все невалидные контролы. Необходимо для реализации
 сценария [валидации при отправке формы](https://guides.kontur.ru/principles/validation/#07).
@@ -17,10 +19,13 @@
 
 Аргументы:
 
-- `withoutFocus`: `true` отключает автофокус невалидных контролов. `'warningsWithoutFocus'` отключает автофокус к валидациям с уровнем варнинг (`level = 'warning'`). Дефолтное значение `false`.
+- `withoutFocus`: `true` отключает автофокус невалидных контролов.
+- `validationSettings`: `{ focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `Error`
 
 
-### `validate(withoutFocus?: boolean | 'warningsWithoutFocus'): Promise<boolean>`
+### `validate(withoutFocus?: boolean): Promise<boolean>`
+либо
+###`validate(validationSettings?: { focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }): Promise<boolean>`
 
 При вызове этой функции загораются все невалидные контролы так же как и при вызове
 функции `submit()`. Кроме того функция возвращает признак валидности формы.
@@ -43,8 +48,8 @@
 
 Аргументы:
 
-- `withoutFocus`: `true` отключает автофокус невалидных контролов. `'warningsWithoutFocus'` отключает автофокус к валидациям с уровнем варнинг (`level = 'warning'`). Дефолтное значение `false`.
-
+- `withoutFocus`: `true` отключает автофокус невалидных контролов.
+- `validationSettings`: `{ focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `Error`
 
 ### `children`
 

--- a/packages/react-ui-validations/docs/Pages/Api.md
+++ b/packages/react-ui-validations/docs/Pages/Api.md
@@ -4,13 +4,10 @@
 
 Контейнер, внутри которого находятся валидируемые контролы.
 
-### `submit(withoutFocus?: boolean): Promise<void>`
-либо
-### `submit(validationSettings?: { focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }): Promise<void>`
+### `submit(): Promise<void>`
 
 При вызове этой функции загораются все невалидные контролы. Необходимо для реализации
 сценария [валидации при отправке формы](https://guides.kontur.ru/principles/validation/#07).
-
 
     <ValidationContainer ref='container'>
         // ...
@@ -19,13 +16,24 @@
 
 Аргументы:
 
-- `withoutFocus`: `true` отключает автофокус невалидных контролов.
-- `validationSettings`: `{ focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `FocusMode.Error`
+    submit(withoutFocus?: boolean): Promise<void>
+    submit(validationSettings: ValidationSettings): Promise<void>
 
+где
 
-### `validate(withoutFocus?: boolean): Promise<boolean>`
-либо
-###`validate(validationSettings?: { focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }): Promise<boolean>`
+    interface ValidationSettings {
+      focusMode: FocusMode;
+    }
+    enum FocusMode {
+      Errors,
+      ErrorsAndWarnings,
+      None,
+    }
+
+- `withoutFocus`: отключает автофокус невалидных контролов.
+- `validationSettings.focusMode` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `FocusMode.Errors`
+
+### `validate(): Promise<boolean>`
 
 При вызове этой функции загораются все невалидные контролы так же как и при вызове
 функции `submit()`. Кроме того функция возвращает признак валидности формы.
@@ -46,10 +54,7 @@
         );
     }
 
-Аргументы:
-
-- `withoutFocus`: `true` отключает автофокус невалидных контролов.
-- `validationSettings`: `{ focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `FocusMode.Error`
+Аргументы аналогичны `submit()` - смотри выше.
 
 ### `children`
 

--- a/packages/react-ui-validations/docs/Pages/Api.md
+++ b/packages/react-ui-validations/docs/Pages/Api.md
@@ -6,7 +6,7 @@
 
 ### `submit(withoutFocus?: boolean): Promise<void>`
 либо
-### `submit(validationSettings?: { focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }): Promise<void>`
+### `submit(validationSettings?: { focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }): Promise<void>`
 
 При вызове этой функции загораются все невалидные контролы. Необходимо для реализации
 сценария [валидации при отправке формы](https://guides.kontur.ru/principles/validation/#07).
@@ -20,12 +20,12 @@
 Аргументы:
 
 - `withoutFocus`: `true` отключает автофокус невалидных контролов.
-- `validationSettings`: `{ focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `Error`
+- `validationSettings`: `{ focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `FocusMode.Error`
 
 
 ### `validate(withoutFocus?: boolean): Promise<boolean>`
 либо
-###`validate(validationSettings?: { focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }): Promise<boolean>`
+###`validate(validationSettings?: { focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }): Promise<boolean>`
 
 При вызове этой функции загораются все невалидные контролы так же как и при вызове
 функции `submit()`. Кроме того функция возвращает признак валидности формы.
@@ -49,7 +49,7 @@
 Аргументы:
 
 - `withoutFocus`: `true` отключает автофокус невалидных контролов.
-- `validationSettings`: `{ focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None' }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `Error`
+- `validationSettings`: `{ focusMode: FocusMode.Errors | FocusMode.ErrorsAndWarnings | FocusMode.None }` - позволяет указать уровень валидации для автофокуса. Дефолтное значение -  `FocusMode.Error`
 
 ### `children`
 

--- a/packages/react-ui-validations/selenium-tests/ValidationTests/Storybook/Sync/SubmitValidation.cs
+++ b/packages/react-ui-validations/selenium-tests/ValidationTests/Storybook/Sync/SubmitValidation.cs
@@ -165,7 +165,7 @@ namespace SKBKontur.ValidationTests.Storybook.Sync
             page.Input.SetValue("bad");
             page.SubmitButton.Click();
             page.Input.WaitWarning();
-            page.Input.WaitFocus();
+            page.Input.WaitNotFocus();
         }
     }
 }

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -11,6 +11,8 @@ export interface ScrollOffset {
   bottom?: number;
 }
 
+export type WithoutFocusType = boolean | 'warningsWithoutFocus';
+
 export interface ValidationContainerProps {
   children?: React.ReactNode;
   onValidationUpdated?: (isValid?: Nullable<boolean>) => void;
@@ -42,14 +44,14 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
 
   private childContext: ValidationContextWrapper | null = null;
 
-  public async submit(withoutFocus: boolean | 'warningsWithoutFocus' = false): Promise<void> {
+  public async submit(withoutFocus: WithoutFocusType = false): Promise<void> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
     await this.childContext.validate(withoutFocus);
   }
 
-  public validate(withoutFocus: boolean | 'warningsWithoutFocus' = false): Promise<boolean> {
+  public validate(withoutFocus: WithoutFocusType = false): Promise<boolean> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -42,18 +42,18 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
 
   private childContext: ValidationContextWrapper | null = null;
 
-  public async submit(withoutFocus = false): Promise<void> {
+  public async submit(withoutFocus = false, warningsWithoutFocus = false): Promise<void> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    await this.childContext.validate(withoutFocus);
+    await this.childContext.validate(withoutFocus, warningsWithoutFocus);
   }
 
-  public validate(withoutFocus = false): Promise<boolean> {
+  public validate(withoutFocus = false, warningsWithoutFocus = false): Promise<boolean> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    return this.childContext.validate(withoutFocus);
+    return this.childContext.validate(withoutFocus, warningsWithoutFocus);
   }
 
   public render() {

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -48,18 +48,24 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
 
   private childContext: ValidationContextWrapper | null = null;
 
-  public async submit(withoutFocus: validateArgumentType = { focusMode: 'Errors' }): Promise<void> {
+  submit(withoutFocus?: boolean): Promise<void>;
+  submit(validationSettings?: ValidationSettings): Promise<void>;
+
+  public async submit(settings: validateArgumentType = { focusMode: 'Errors' }): Promise<void> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    await this.childContext.validate(withoutFocus);
+    await this.childContext.validate(settings);
   }
 
-  public validate(withoutFocus: validateArgumentType = { focusMode: 'Errors' }): Promise<boolean> {
+  validate(withoutFocus?: boolean): Promise<boolean>;
+  validate(validationSettings?: ValidationSettings): Promise<boolean>;
+
+  public validate(settings: validateArgumentType = { focusMode: 'Errors' }): Promise<boolean> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    return this.childContext.validate(withoutFocus);
+    return this.childContext.validate(settings);
   }
 
   public render() {

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -42,18 +42,18 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
 
   private childContext: ValidationContextWrapper | null = null;
 
-  public async submit(withoutFocus = false, warningsWithoutFocus = false): Promise<void> {
+  public async submit(withoutFocus: boolean | 'warningsWithoutFocus' = false): Promise<void> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    await this.childContext.validate(withoutFocus, warningsWithoutFocus);
+    await this.childContext.validate(withoutFocus);
   }
 
-  public validate(withoutFocus = false, warningsWithoutFocus = false): Promise<boolean> {
+  public validate(withoutFocus: boolean | 'warningsWithoutFocus' = false): Promise<boolean> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    return this.childContext.validate(withoutFocus, warningsWithoutFocus);
+    return this.childContext.validate(withoutFocus);
   }
 
   public render() {

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -11,7 +11,11 @@ export interface ScrollOffset {
   bottom?: number;
 }
 
-export type WithoutFocusType = boolean | 'warningsWithoutFocus';
+interface ValidationSettings {
+  focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None';
+}
+
+export type validateArgumentType = boolean | ValidationSettings;
 
 export interface ValidationContainerProps {
   children?: React.ReactNode;
@@ -44,14 +48,14 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
 
   private childContext: ValidationContextWrapper | null = null;
 
-  public async submit(withoutFocus: WithoutFocusType = false): Promise<void> {
+  public async submit(withoutFocus: validateArgumentType = { focusMode: 'Errors' }): Promise<void> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
     await this.childContext.validate(withoutFocus);
   }
 
-  public validate(withoutFocus: WithoutFocusType = false): Promise<boolean> {
+  public validate(withoutFocus: validateArgumentType = { focusMode: 'Errors' }): Promise<boolean> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -11,11 +11,17 @@ export interface ScrollOffset {
   bottom?: number;
 }
 
-interface ValidationSettings {
-  focusMode: 'Errors' | 'ErrorsAndWarnings' | 'None';
+export enum FocusMode {
+  'Errors',
+  'ErrorsAndWarnings',
+  'None',
 }
 
-export type validateArgumentType = boolean | ValidationSettings;
+export interface ValidationSettings {
+  focusMode: FocusMode;
+}
+
+export type ValidateArgumentType = boolean | ValidationSettings;
 
 export interface ValidationContainerProps {
   children?: React.ReactNode;
@@ -48,24 +54,28 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
 
   private childContext: ValidationContextWrapper | null = null;
 
-  submit(withoutFocus?: boolean): Promise<void>;
-  submit(validationSettings?: ValidationSettings): Promise<void>;
+  public async submit(withoutFocus?: boolean): Promise<void>;
+  public async submit(validationSettings?: ValidationSettings): Promise<void>;
 
-  public async submit(settings: validateArgumentType = { focusMode: 'Errors' }): Promise<void> {
+  public async submit(
+    withoutFocusOrValidationSettings: ValidateArgumentType = { focusMode: FocusMode.Errors },
+  ): Promise<void> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    await this.childContext.validate(settings);
+    await this.childContext.validate(withoutFocusOrValidationSettings);
   }
 
-  validate(withoutFocus?: boolean): Promise<boolean>;
-  validate(validationSettings?: ValidationSettings): Promise<boolean>;
+  public async validate(withoutFocus?: boolean): Promise<boolean>;
+  public async validate(validationSettings?: ValidationSettings): Promise<boolean>;
 
-  public validate(settings: validateArgumentType = { focusMode: 'Errors' }): Promise<boolean> {
+  public validate(
+    withoutFocusOrValidationSettings: ValidateArgumentType = { focusMode: FocusMode.Errors },
+  ): Promise<boolean> {
     if (!this.childContext) {
       throw new Error('childContext is not defined');
     }
-    return this.childContext.validate(settings);
+    return this.childContext.validate(withoutFocusOrValidationSettings);
   }
 
   public render() {

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ValidationWrapperInternal } from './ValidationWrapperInternal';
-import { ScrollOffset } from './ValidationContainer';
+import { ScrollOffset, WithoutFocusType } from './ValidationContainer';
 import { isNullable } from './utils/isNullable';
 
 export interface ValidationContextSettings {
@@ -127,28 +127,18 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
     return wrappersWithPosition.map((x) => x.target);
   }
 
-  public async validate(withoutFocus: boolean | 'warningsWithoutFocus'): Promise<boolean> {
+  public async validate(withoutFocus: WithoutFocusType): Promise<boolean> {
     const warningsWithoutFocus = withoutFocus === 'warningsWithoutFocus';
     const withoutAnyFocus = warningsWithoutFocus ? false : withoutFocus;
     await Promise.all(this.childWrappers.map((x) => x.processSubmit()));
 
     const childrenWrappersSortedByPosition = this.getChildWrappersSortedByPosition();
-    const firstWarning = childrenWrappersSortedByPosition.find((x) => x.hasWarning());
     const firstError = childrenWrappersSortedByPosition.find((x) => x.hasError());
-    if (firstError && !firstWarning) {
-      if (!withoutAnyFocus) {
-        firstError.focus();
-      }
-    } else if (firstWarning && !firstError) {
-      if (!warningsWithoutFocus && !withoutAnyFocus) {
-        firstWarning.focus();
-      }
-    } else if (firstError && firstWarning) {
-      if (!withoutAnyFocus && !warningsWithoutFocus) {
-        childrenWrappersSortedByPosition.find((x) => x.hasError() || x.hasWarning())?.focus();
-      }
+    if (!withoutAnyFocus) {
       if (warningsWithoutFocus) {
-        firstError.focus();
+        firstError?.focus();
+      } else {
+        childrenWrappersSortedByPosition.find((x) => x.hasError() || x.hasWarning())?.focus();
       }
     }
     if (this.props.onValidationUpdated) {

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -127,7 +127,7 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
     return wrappersWithPosition.map((x) => x.target);
   }
 
-  public async validate(withoutFocus: boolean | 'warningsWithoutFocus' = false): Promise<boolean> {
+  public async validate(withoutFocus: boolean | 'warningsWithoutFocus'): Promise<boolean> {
     const warningsWithoutFocus = withoutFocus === 'warningsWithoutFocus';
     const withoutAnyFocus = warningsWithoutFocus ? false : withoutFocus;
     await Promise.all(this.childWrappers.map((x) => x.processSubmit()));

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -127,21 +127,32 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
     return wrappersWithPosition.map((x) => x.target);
   }
 
-  public async validate(withoutFocus: boolean): Promise<boolean> {
+  public async validate(withoutFocus: boolean, warningsWithoutFocus: boolean): Promise<boolean> {
     await Promise.all(this.childWrappers.map((x) => x.processSubmit()));
 
     const childrenWrappersSortedByPosition = this.getChildWrappersSortedByPosition();
-    const firstInvalid = childrenWrappersSortedByPosition.find((x) => x.hasError() || x.hasWarning());
-    const invalid = childrenWrappersSortedByPosition.some((x) => x.hasError());
-    if (firstInvalid) {
+    const firstWarning = childrenWrappersSortedByPosition.find((x) => x.hasWarning());
+    const firstError = childrenWrappersSortedByPosition.find((x) => x.hasError());
+    if (firstError && !firstWarning) {
       if (!withoutFocus) {
-        firstInvalid.focus();
+        firstError.focus();
+      }
+    } else if (firstWarning && !firstError) {
+      if (!warningsWithoutFocus) {
+        firstWarning.focus();
+      }
+    } else if (firstError && firstWarning) {
+      if (!withoutFocus) {
+        firstError.focus();
+      }
+      if (!warningsWithoutFocus) {
+        firstWarning.focus();
       }
     }
     if (this.props.onValidationUpdated) {
-      this.props.onValidationUpdated(!firstInvalid);
+      this.props.onValidationUpdated(!firstError && !firstWarning);
     }
-    return !invalid;
+    return !firstError && !firstWarning;
   }
 
   public render() {

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -13,6 +13,7 @@ import {
 
 import { ValidationContainer, ValidationContainerProps, ValidationWrapper } from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
+import { FocusMode } from '../src/ValidationContainer';
 
 describe('ValidationContainer', () => {
   it('renders passed children', () => {
@@ -97,7 +98,7 @@ describe('ValidationContainer', () => {
     it('with autofocus', async () => {
       const containerRef = renderValidationContainer(<Input />);
 
-      await containerRef.current?.validate({ focusMode: 'ErrorsAndWarnings' });
+      await containerRef.current?.validate({ focusMode: FocusMode.ErrorsAndWarnings });
 
       expect(screen.getByRole('textbox')).toHaveFocus();
     });
@@ -106,6 +107,14 @@ describe('ValidationContainer', () => {
       const containerRef = renderValidationContainer(<Input />);
 
       await containerRef.current?.validate();
+
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+
+    it('without autofocus', async () => {
+      const containerRef = renderValidationContainer(<Input />);
+
+      await containerRef.current?.validate(false);
 
       expect(screen.getByRole('textbox')).not.toHaveFocus();
     });

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -97,7 +97,7 @@ describe('ValidationContainer', () => {
     it('with autofocus', async () => {
       const containerRef = renderValidationContainer(<Input />);
 
-      await containerRef.current?.validate();
+      await containerRef.current?.validate({ focusMode: 'ErrorsAndWarnings' });
 
       expect(screen.getByRole('textbox')).toHaveFocus();
     });
@@ -105,7 +105,7 @@ describe('ValidationContainer', () => {
     it('without autofocus', async () => {
       const containerRef = renderValidationContainer(<Input />);
 
-      await containerRef.current?.validate('warningsWithoutFocus');
+      await containerRef.current?.validate();
 
       expect(screen.getByRole('textbox')).not.toHaveFocus();
     });

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -93,5 +93,21 @@ describe('ValidationContainer', () => {
 
       expect(result).toEqual(true);
     });
+
+    it('with autofocus', async () => {
+      const containerRef = renderValidationContainer(<Input />);
+
+      await containerRef.current?.validate();
+
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('without autofocus', async () => {
+      const containerRef = renderValidationContainer(<Input />);
+
+      await containerRef.current?.validate('warningsWithoutFocus');
+
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
## Проблема

В #2804 добавили автофокус если уровень валидации `warning`. Потом в #3026 мы вернули изначальное поведение, когда при уровне валидации `warning` разрешить сабмитить форму с первого раза. 

Некоторые команды попросили добавить возможность отключать автофокус только для варнингов, так как нет смысла фокусировать форму на варнинге и тут же ее отправлять. 

## Решение

В методе `validate` расширила тип аргумента: оставила `boolean` для обратной совместимости и добавила возможность прокинуть `'warningsWithoutFocus'` для отключения автофокуса при уровне валидации `warning`.

## Ссылки

fix IF-832

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
