### PR TITLE
fix(Switcher): deliver `corners` to `Button` when using `renderItem`

### DIFF
--- a/packages/react-ui/.creevey/images/Switcher/with custom render item/chrome.png
+++ b/packages/react-ui/.creevey/images/Switcher/with custom render item/chrome.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3cbb38f62f49850e14f808b3b9de33ee1f9ac0648712207c33ba7e6a4315d9a2
-size 9852
+oid sha256:5280ab96bf575d0c6daef24c58ea29fcc360a98344cb4d2ad8d2d40855cb43be
+size 9762

--- a/packages/react-ui/components/Group/Group.tsx
+++ b/packages/react-ui/components/Group/Group.tsx
@@ -36,23 +36,19 @@ const getLastChild = (children: React.ReactNode) => {
   return children?.[numberOfChildren - 1] as React.ReactNode;
 };
 
-const getButtonCorners = (
-  child: React.ReactNode,
-  firstChild: React.ReactNode,
-  lastChild: React.ReactNode,
-): React.CSSProperties => {
-  if (firstChild === lastChild) {
+export const getButtonCorners = (isFirstChild: boolean, isLastChild: boolean): React.CSSProperties => {
+  if (isFirstChild && isLastChild) {
     return {};
   }
 
-  if (child === firstChild) {
+  if (isFirstChild) {
     return {
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,
     };
   }
 
-  if (child === lastChild) {
+  if (isLastChild) {
     return {
       borderTopLeftRadius: 0,
       borderBottomLeftRadius: 0,
@@ -66,7 +62,7 @@ const getButtonCorners = (
 
 const passCornersIfButton = (child: React.ReactNode, firstChild: React.ReactNode, lastChild: React.ReactNode) => {
   if (isButton(child)) {
-    const corners = getButtonCorners(child, firstChild, lastChild);
+    const corners = getButtonCorners(child === firstChild, child === lastChild);
 
     return React.cloneElement(child, { corners });
   }

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { isKeyArrowHorizontal, isKeyArrowLeft, isKeyEnter } from '../../lib/events/keyboard/identifiers';
-import { Group } from '../Group';
+import { getButtonCorners, Group } from '../Group';
 import { Button, ButtonProps, ButtonSize } from '../Button';
 import { Nullable } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -220,6 +220,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         disableFocus: true,
         size,
         disabled,
+        corners: getButtonCorners(i === 0, i === items.length - 1),
       };
 
       const buttonProps = {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

При использовании пропа `renderItem` в `Switcher` , компонент Group не может задетектить кнопку, чтобы убирать скругления углов.

<img width="444" alt="image" src="https://user-images.githubusercontent.com/2708211/202896001-2437cb1f-79b7-4227-a783-29849528a132.png">


## Решение

Научил `Switcher` самостоятельно убирать скругления углов.

<img width="453" alt="image" src="https://user-images.githubusercontent.com/2708211/202896034-5ed86de0-fc4c-419a-bf53-15a9298adb7b.png">

## Ссылки

IF-847

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
