### PR TITLE
feat(icons): add aria-hidden attribute

### DIFF
--- a/packages/react-ui/internal/icons/16px/index.tsx
+++ b/packages/react-ui/internal/icons/16px/index.tsx
@@ -22,6 +22,7 @@ const SvgIcon = forwardRefAndName<HTMLElement, SvgIconProps>(
           className: styles.icon(),
           fill: 'currentColor',
           focusable: 'false',
+          'aria-hidden': 'true',
         })}
       </span>
     );

--- a/packages/react-ui/internal/icons/20px/svg.tsx
+++ b/packages/react-ui/internal/icons/20px/svg.tsx
@@ -13,6 +13,7 @@ export const SvgIcon: React.FunctionComponent<SVGIconProps> = ({ children, color
       className: styles.icon(),
       fill: color,
       focusable: 'false',
+      'aria-hidden': 'true',
     })}
   </span>
 );

--- a/packages/react-ui/internal/icons/CrossIcon.tsx
+++ b/packages/react-ui/internal/icons/CrossIcon.tsx
@@ -8,6 +8,7 @@ export const CrossIcon = () => (
     focusable="false"
     strokeLinejoin="round"
     viewBox="0 0 10 10"
+    aria-hidden="true"
   >
     <polygon id="Path" points="6 5 10 9 9 10 5 6 1 10 0 9 4 5 0 1 1 0 5 4 9 0 10 1" />
   </svg>

--- a/packages/react-ui/internal/icons/SpinnerIcon.tsx
+++ b/packages/react-ui/internal/icons/SpinnerIcon.tsx
@@ -101,6 +101,8 @@ export const SpinnerIcon = ({ size, className, dimmed, inline, width, color }: S
         strokeDashoffset="0"
         strokeWidth={width || currentSize.width}
         ref={svgRef}
+        focusable="false"
+        aria-hidden="true"
       >
         <circle cx={currentSize.size / 2} cy={currentSize.size / 2} r={currentSize.radius} />
       </svg>


### PR DESCRIPTION
Improved accessibility by adding an attribute aria-hidden for interface icons

fix #3047

## Проблема

Svg изображения не скрыты доступно, они используются только для иконок в интерфейсе и могут быть скрыты

## Решение

Добавлен атрибут aria-hidden для иконок, эти иконки не несут полезной информации для пользователей со скринридерами, поэтому могут быть скрыты

## Ссылки

fix #3047

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
