### PR TITLE
fix(Switcher): fix keyboard navigation with disabled items

### DIFF
--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -172,12 +172,21 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
 
     if (isKeyArrowHorizontal(e)) {
       e.preventDefault();
-      const newFocusedIndex = this._getFocusedIndexByStep(isKeyArrowLeft(e), focusedIndex);
-      this._focus(newFocusedIndex);
+      this.move(isKeyArrowLeft(e));
     }
   };
 
-  private _getFocusedIndexByStep = (left: boolean, focusedIndex: number): number => {
+  private move = (left: boolean) => {
+    const selectedIndex = this.state.focusedIndex;
+
+    if (typeof selectedIndex !== 'number') {
+      return;
+    }
+    const newFocusedIndex = this._getNextFocusedIndex(left, selectedIndex);
+    this._focus(newFocusedIndex);
+  };
+
+  private _getNextFocusedIndex = (left: boolean, focusedIndex: number): number => {
     const { items, disabled } = this.props;
     if (disabled) {
       return focusedIndex;

--- a/packages/react-ui/components/Switcher/helpers.ts
+++ b/packages/react-ui/components/Switcher/helpers.ts
@@ -1,0 +1,1 @@
+export const mod = (n: number, mod: number) => ((n % mod) + mod) % mod;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
После добавления возможности прокидывать кастомные пропы в кнопки Свитчера, появилась возможность дизейблить их по отдельности.
Свитчер не учитывает выключенность кнопок и позволяет навигацию клавишами [влево]/[вправо] по ним, и выбора по [энтеру].
<!-- Подробно опиши решаемую проблему. -->

## Решение
Изменил логику перемещения по элементам с помощью клавиатуры.
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки
https://yt.skbkontur.ru/issue/IF-855
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
