### PR TITLE
feat(Menu): menu vertical offset and new theme variable menuOffsetY

### DIFF
--- a/packages/react-ui/internal/Menu/Menu.styles.ts
+++ b/packages/react-ui/internal/Menu/Menu.styles.ts
@@ -9,6 +9,7 @@ export const styles = memoizeStyle({
       box-sizing: content-box;
       overflow: auto;
       padding: 0 ${t.menuPaddingX};
+      margin: ${t.menuOffsetY} 0;
       border-radius: ${t.menuBorderRadius};
     `;
   },

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -923,6 +923,7 @@ export class DefaultTheme {
   public static menuShadow = '0 4px 12px rgba(0, 0, 0, 0.16)';
   public static menuPaddingY = '4px';
   public static menuPaddingX = '0px';
+  public static menuOffsetY = '0px';
   // menuItem
   public static get menuItemTextColor() {
     return this.textColorDefault;

--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -59,6 +59,7 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
 
   public static menuBorderRadius = '8px';
   public static menuPaddingX = '4px';
+  public static menuOffsetY = '4px';
   public static menuItemHoverBg = '#EBEBEB';
   public static menuItemHoverColor = '#222';
   public static menuItemBorderRadius = '6px';


### PR DESCRIPTION
Closes #3077

<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В теме 2022 у выпадающего меню есть отступы от полей ввода/кнопок.
В библиотеке отступы отсутствовали, переменные темы тоже.

## Решение

Добавил `margin-top` и `margin-bottom` для `Menu`, равные `4px` для `Theme2022`.
Добавил переменную темы `menuOffsetY` для кастомизации отступа.

## Ссылки

close https://github.com/skbkontur/retail-ui/issues/3077

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
