### PR TITLE
chore(ComboBox): propagate `disabled` attribute to hidden input

### DIFF
--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -36,6 +36,7 @@ export type InputLikeTextState = Omit<InputState, 'needsPolyfillPlaceholder'>;
 export const InputLikeTextDataTids = {
   root: 'InputLikeText__root',
   input: 'InputLikeText__input',
+  hiddenInput: 'InputLikeText__hiddenInput',
 } as const;
 
 type DefaultProps = Required<Pick<InputLikeTextProps, 'size'>>;
@@ -205,7 +206,7 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
         onKeyDown={this.handleKeyDown}
         onMouseDown={this.handleMouseDown}
       >
-        <input type="hidden" value={value} />
+        <input data-tid={InputLikeTextDataTids.hiddenInput} type="hidden" value={value} disabled={disabled} />
         {leftSide}
         <span className={wrapperClass}>
           <span

--- a/packages/react-ui/internal/InputLikeText/__tests__/InputLikeText-test.tsx
+++ b/packages/react-ui/internal/InputLikeText/__tests__/InputLikeText-test.tsx
@@ -15,3 +15,10 @@ describe('placeholder', () => {
     expect(wrapper.text()).toBe(value.toString());
   });
 });
+
+describe('hidden input', () => {
+  it('renders disabled', () => {
+    const wrapper = mount(<InputLikeText disabled>value</InputLikeText>);
+    expect(wrapper.find('input').prop('disabled')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Проблема

В тестах невозможно понять, что `ComboBox` находится в состоянии `disabled`: ни на одном элементе внутри нет такого атрибута. 

## Решение

Когда `ComboBox` не в состоянии редактирования, он использует `InputLikeText` для отображения значения. Он рендерит скрытый input и на него уже можно навесить `disabled`. В тестах достаточно найти этот input (можно по новому `data-tid`) и прочитать у него атрибут disabled.

## Ссылки

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
