### PR TITLE
chore: fix RegExp to check email in documentation

### DIFF
--- a/packages/react-ui-validations/docs/Pages/Examples/Editors/Editors.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Examples/Editors/Editors.demo.tsx
@@ -50,7 +50,7 @@ const validate = createValidator<ContactInfo>((b) => {
     (x) => x.email,
     (b) => {
       b.invalid((x) => !x, 'Укажите адрес почты', 'submit');
-      b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]{2,}$/.test(x), 'Неверный адрес почты');
+      b.invalid((x) => !x.includes('@'), 'Неверный адрес почты');
     },
   );
   b.prop(

--- a/packages/react-ui-validations/docs/Pages/Examples/GuidesExample/GuidesExample.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Examples/GuidesExample/GuidesExample.demo.tsx
@@ -87,7 +87,7 @@ const isValidKpp = (value: string): boolean => {
 };
 
 const isValidEmail = (value: string): boolean => {
-  return /^[a-z]+@[a-z]+\.[a-z]{2,}$/.test(value);
+  return value.includes('@');
 };
 
 const isValidPhone = (value: string): boolean => {

--- a/packages/react-ui-validations/docs/Pages/Validator/Arrays/Arrays.md
+++ b/packages/react-ui-validations/docs/Pages/Validator/Arrays/Arrays.md
@@ -9,7 +9,7 @@
     const validate = createValidator<string[]>(b => {
       b.array(x => x, b => {
         b.invalid(x => !x, "Укажите email", "submit");
-        b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+        b.invalid(x => !x.includes('@'), "Неверный формат email");
       });
     });
 

--- a/packages/react-ui-validations/docs/Pages/Validator/Arrays/ObjectArray.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/Arrays/ObjectArray.demo.tsx
@@ -25,7 +25,7 @@ const validate = createValidator<ContactInfo[]>((b) => {
         (x) => x.email,
         (b) => {
           b.invalid((x) => !x, 'Укажите email', 'submit');
-          b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+          b.invalid((x) => !x.includes('@'), 'Неверный формат email');
         },
       );
     },

--- a/packages/react-ui-validations/docs/Pages/Validator/Arrays/PrimitiveTypeArray.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/Arrays/PrimitiveTypeArray.demo.tsx
@@ -11,7 +11,7 @@ const validate = createValidator<string[]>((b) => {
     (x) => x,
     (b) => {
       b.invalid((x) => !x, 'Укажите email', 'submit');
-      b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+      b.invalid((x) => !x.includes('@'), 'Неверный формат email');
     },
   );
 });

--- a/packages/react-ui-validations/docs/Pages/Validator/MissingNodes/MissingObjectNode.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/MissingNodes/MissingObjectNode.demo.tsx
@@ -30,7 +30,7 @@ const validate = createValidator<Data>((b) => {
         (x) => x.email,
         (b) => {
           b.invalid((x) => !x, 'Укажите email', 'submit');
-          b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+          b.invalid((x) => !x.includes('@'), 'Неверный формат email');
         },
       );
     },

--- a/packages/react-ui-validations/docs/Pages/Validator/MissingNodes/MissingUiNode.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/MissingNodes/MissingUiNode.demo.tsx
@@ -31,7 +31,7 @@ const validate = createValidator<Data>((b) => {
         (x) => x.email,
         (b) => {
           b.invalid((x) => !x, 'Укажите email', 'submit');
-          b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+          b.invalid((x) => !x.includes('@'), 'Неверный формат email');
         },
       );
     },

--- a/packages/react-ui-validations/docs/Pages/Validator/Objects/FlatObject.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/Objects/FlatObject.demo.tsx
@@ -22,7 +22,7 @@ const validate = createValidator<ContactInfo>((b) => {
     (x) => x.email,
     (b) => {
       b.invalid((x) => !x, 'Укажите email', 'submit');
-      b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+      b.invalid((x) => !x.includes('@'), 'Неверный формат email');
     },
   );
 });

--- a/packages/react-ui-validations/docs/Pages/Validator/Objects/NestedObject.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/Objects/NestedObject.demo.tsx
@@ -38,7 +38,7 @@ const validate = createValidator<ContactInfo>((b) => {
     (x) => x.email,
     (b) => {
       b.invalid((x) => !x, 'Укажите email', 'submit');
-      b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+      b.invalid((x) => !x.includes('@'), 'Неверный формат email');
     },
   );
 });

--- a/packages/react-ui-validations/docs/Pages/Validator/Objects/Objects.md
+++ b/packages/react-ui-validations/docs/Pages/Validator/Objects/Objects.md
@@ -23,7 +23,7 @@ Validator позволяет декларативно описать все ва
       });
       b.prop(x => x.email, b => {
         b.invalid(x => !x, "Укажите email", "submit");
-        b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+        b.invalid(x => !x.includes('@'), "Неверный формат email");
       });
     });
 
@@ -58,7 +58,7 @@ Validator позволяет декларативно описать все ва
 
     b.prop(x => x.email, b => {
       b.invalid(x => !x, "Укажите email", "submit");
-      b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+      b.invalid(x => !x.includes('@'), "Неверный формат email");
     });
 
 ### Получение объектов валидаций
@@ -88,7 +88,7 @@ Validator позволяет декларативно описать все ва
 
     const validateEmail = createValidator<string>(b => {
       b.invalid(x => !x, "Укажите email", "submit");
-      b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+      b.invalid(x => !x.includes('@'), "Неверный формат email");
     });
 
 Объект валидации извлекается из корневого узла дерева валидаций.
@@ -125,7 +125,7 @@ Validator позволяет декларативно описать все ва
       });
       b.prop(x => x.email, b => {
         b.invalid(x => !x, "Укажите email", "submit");
-        b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+        b.invalid(x => !x.includes('@'), "Неверный формат email");
       });
     });
 

--- a/packages/react-ui-validations/docs/Pages/Validator/Objects/PrimitiveType.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/Objects/PrimitiveType.demo.tsx
@@ -12,7 +12,7 @@ interface PrimitiveTypeDemoState {
 
 const validate = createValidator<string>((b) => {
   b.invalid((x) => !x, 'Укажите email', 'submit');
-  b.invalid((x) => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), 'Неверный формат email');
+  b.invalid((x) => !x.includes('@'), 'Неверный формат email');
 });
 
 export default class PrimitiveTypeDemo extends React.Component {

--- a/packages/react-ui-validations/docs/Pages/Validator/Reusable/Reusable.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Validator/Reusable/Reusable.demo.tsx
@@ -17,7 +17,7 @@ interface ReusableDemoState {
 }
 
 const isValidEmail = (value: string): boolean => {
-  return /^[a-z]+@[a-z]+\.[a-z]+$/.test(value);
+  return value.includes('@');
 };
 
 const emailRequired = (b: ValidationBuilder<unknown, string>): void => {

--- a/packages/react-ui-validations/docs/Pages/Validator/Reusable/Reusable.md
+++ b/packages/react-ui-validations/docs/Pages/Validator/Reusable/Reusable.md
@@ -9,7 +9,7 @@
 Она может быть использована не только в UI-валидациях.
 
     const isValidEmail = (value: string): boolean => {
-      return /^[a-z]+@[a-z]+\.[a-z]+$/.test(value);
+      return value.includes('@');
     };
 
     const validate = createValidator<string>(b => {
@@ -24,7 +24,7 @@
     };
 
     const emailFormat = (b: ValidationBuilder<unknown, string>): void => {
-      b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+      b.invalid(x => !x.includes('@'), "Неверный формат email");
     };
 
     const validate = createValidator<string>(b => {
@@ -37,7 +37,7 @@
 
     const validateEmail: ValidationRule<unknown, string> = b => {
       b.invalid(x => !x, "Укажите email", "submit");
-      b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+      b.invalid(x => !x.includes('@'), "Неверный формат email");
     };
 
     const validate = createValidator<string>(validateEmail);
@@ -46,7 +46,7 @@
 
     const validateEmail = (b: ValidationBuilder<unknown, string>, required: boolean): void => {
       b.invalid(x => required && !x, "Укажите email", "submit");
-      b.invalid(x => !/^[a-z]+@[a-z]+\.[a-z]+$/.test(x), "Неверный формат email");
+      b.invalid(x => !x.includes('@'), "Неверный формат email");
     };
 
     const validate = createValidator<string>(b => {


### PR DESCRIPTION
## Проблема

В [документации](http://tech.skbkontur.ru/react-ui-validations/#/object-validation:~:text=%D0%9E%D0%BF%D0%B8%D1%81%D0%B0%D0%BD%D0%B8%D0%B5%20%D0%BF%D1%80%D0%B0%D0%B2%D0%B8%D0%BB%20%D0%B2%D0%B0%D0%BB%D0%B8%D0%B4%D0%B0%D1%86%D0%B8%D0%B9) для проверки валидности email используется слишком строгая регулярка, которая не обеспечивает валидацию Internationalized Mail Address standards: rfc5322 или нового rfc653x

Матчасть:

 - https://www.netmeister.org/blog/email.html
 - https://habr.com/ru/post/175375/
 - https://habr.com/ru/post/55820/
 - https://habr.com/ru/post/274985/
 - https://habr.com/ru/post/434640/
 
Если коротко:
1. email может содержать практически все символы ! $ & * - = ^ ` | ~ # % ' + / ? _ { }
2. email может содержать больше одного символа @ 
3. доменные имена могут не содержать точки

## Решение

> Если же вы все равно не можете успокоиться, пока не проверите адрес на корректность, просто проверьте на наличие в нем символа `@`. 

Заменила регулярку на проверку на наличие символа `@`

## Ссылки

fix IF-710

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

4. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

5. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
