### PR TITLE
docs(ComboBox): add example with reset method

### DIFF
--- a/packages/react-ui/components/ComboBox/ComboBox.md
+++ b/packages/react-ui/components/ComboBox/ComboBox.md
@@ -463,6 +463,48 @@ class ComboboxExample extends React.Component {
 <ComboboxExample />;
 ```
 
+
+При изменении значения и блюре `ComboBox` остается в состоянии `editing` и не дает изменить значение через проп `value`. Поэтому, для того чтобы задать новое значение, необходимо вызвать метод `reset`.
+
+```jsx harmony
+import { Button } from '@skbkontur/react-ui';
+
+  const [selected, setSelected] = React.useState({ value: 1, label: "First" });
+  const ref = React.useRef();
+
+  const handleButtonClick = () => {
+    if (ref.current) {
+      ref.current.reset();
+    }
+    setSelected({ value: 3, label: "Third" });
+  };
+
+  const getItems = (q) =>
+    Promise.resolve(
+      [
+        { value: 1, label: "First" },
+        { value: 2, label: "Second" },
+        { value: 3, label: "Third" }
+      ].filter(
+        (x) =>
+          x.label.toLowerCase().includes(q.toLowerCase()) ||
+          x.value.toString(10) === q
+      )
+    );
+
+  <div>
+    <ComboBox
+      ref={ref}
+      getItems={getItems}
+      onValueChange={setSelected}
+      placeholder="Enter number"
+      value={selected}
+    />
+    <Button onClick={handleButtonClick}>Make it three!</Button>
+  </div>
+
+```
+
 #### Локали по умолчанию
 
 ```typescript static


### PR DESCRIPTION
## Проблема

При потере фокуса `ComboBox` остаётся в режиме `editing` и игнорирует новый `value` в пропах. 

## Решение

В качестве первой итерации по решению проблемы решили добавить в документацию пример, где объясняется, что в этом случае нужно использовать метод `reset`

## Ссылки

fix IF-938

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
