### PR TITLE
docs(validations): add page how to use custom controls

### DIFF
--- a/packages/react-ui-validations/docs/Layout.tsx
+++ b/packages/react-ui-validations/docs/Layout.tsx
@@ -17,7 +17,7 @@ export const Layout = withRouter((props) => {
         <MainHeader>
           <h3>react-ui-validations</h3>
         </MainHeader>
-        <div>
+        <div style={{ paddingBottom: 50 }}>
           <NavigationLink activeClassName={'active'} to="/api">
             API reference
           </NavigationLink>

--- a/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.demo.tsx
@@ -1,0 +1,58 @@
+import React, { CSSProperties, SyntheticEvent } from 'react';
+
+import { ValidationContainer, ValidationInfo, ValidationWrapper } from '../../../../src';
+
+interface CustomControls<E = HTMLElement> {
+  ref?: React.ForwardedRef<E>;
+  error?: boolean;
+  warning?: boolean;
+  onBlur?: React.EventHandler<SyntheticEvent>;
+  onChange: React.ChangeEventHandler<E>;
+}
+
+interface MyInputProps extends CustomControls<HTMLInputElement> {
+  value?: string;
+  onValueChange?: unknown;
+}
+
+const CoverMyInput = React.forwardRef<HTMLInputElement, MyInputProps>(function MyInput(
+  { error, warning, onValueChange, ...props },
+  ref,
+) {
+  const style: CSSProperties = {};
+  if (error) {
+    style.borderColor = 'red';
+  }
+  if (warning) {
+    style.borderColor = 'orange';
+  }
+  return <input type="text" ref={ref} style={style} {...props} />;
+});
+
+const CustomControlsDemo = () => {
+  const [value, setValue] = React.useState('error');
+  let validationInfo: ValidationInfo | null = null;
+
+  switch (value) {
+    case 'error':
+      validationInfo = { type: 'lostfocus', message: <b>Ошибка</b>, level: 'error' };
+      break;
+    case 'warning':
+      validationInfo = {
+        type: 'lostfocus',
+        message: <b>Предупреждение</b>,
+        level: 'warning',
+      };
+      break;
+  }
+
+  return (
+    <ValidationContainer>
+      <ValidationWrapper validationInfo={validationInfo}>
+        <CoverMyInput value={value} onChange={(e) => setValue(e.target.value)} />
+      </ValidationWrapper>
+    </ValidationContainer>
+  );
+};
+
+export default CustomControlsDemo;

--- a/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.demo.tsx
+++ b/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.demo.tsx
@@ -1,57 +1,131 @@
-import React, { CSSProperties, SyntheticEvent } from 'react';
+import React from 'react';
+import { Button, Gapped, Input, Select } from '@skbkontur/react-ui';
 
-import { ValidationContainer, ValidationInfo, ValidationWrapper } from '../../../../src';
+import {
+  ValidationBehaviour,
+  ValidationContainer,
+  ValidationInfo,
+  ValidationWrapper,
+} from '../../../../src';
+import { Form } from '../../../Common/Form';
 
-interface CustomControls<E = HTMLElement> {
-  ref?: React.ForwardedRef<E>;
+interface CustomControlProps<Elem = HTMLElement> {
+  ref?: React.ForwardedRef<Elem>;
   error?: boolean;
   warning?: boolean;
-  onBlur?: React.EventHandler<SyntheticEvent>;
-  onChange: React.ChangeEventHandler<E>;
+  onBlur?: React.FocusEventHandler<Elem>;
+  onChange?: React.ChangeEventHandler<Elem>;
 }
 
-interface MyInputProps extends CustomControls<HTMLInputElement> {
-  value?: string;
+interface CustomInputProps
+  extends CustomControlProps<HTMLInputElement>,
+    React.InputHTMLAttributes<HTMLInputElement> {
   onValueChange?: unknown;
 }
 
-const CoverMyInput = React.forwardRef<HTMLInputElement, MyInputProps>(function MyInput(
+const CustomInput = React.forwardRef<HTMLInputElement, CustomInputProps>(function MyInput(
   { error, warning, onValueChange, ...props },
   ref,
 ) {
-  const style: CSSProperties = {};
+  const style: React.CSSProperties = {};
   if (error) {
     style.borderColor = 'red';
+    style.backgroundColor = '#ff000020';
   }
   if (warning) {
     style.borderColor = 'orange';
+    style.backgroundColor = '#ffa50020';
   }
   return <input type="text" ref={ref} style={style} {...props} />;
 });
 
 const CustomControlsDemo = () => {
-  const [value, setValue] = React.useState('error');
-  let validationInfo: ValidationInfo | null = null;
+  const container = React.useRef<ValidationContainer>(null);
+  const [value1, setValue1] = React.useState('error');
+  const [value2, setValue2] = React.useState('error');
+  const [isValid, setIsValid] = React.useState<boolean | null>(null);
+  const [type, setType] = React.useState<ValidationBehaviour>('submit');
 
-  switch (value) {
-    case 'error':
-      validationInfo = { type: 'lostfocus', message: <b>Ошибка</b>, level: 'error' };
-      break;
-    case 'warning':
-      validationInfo = {
-        type: 'lostfocus',
-        message: <b>Предупреждение</b>,
-        level: 'warning',
-      };
-      break;
-  }
+  const submitHandler = async () => {
+    setIsValid(Boolean(await container.current?.validate()));
+  };
+
+  const typeChangeHandler = (typeValue: ValidationBehaviour) => {
+    if (typeValue !== 'submit') {
+      setIsValid(null);
+    }
+    setType(typeValue);
+  };
+
+  const renderValidStatus = () => {
+    switch (isValid) {
+      case null:
+        return <b>Отправьте форму</b>;
+      case false:
+        return <b style={{ color: '#d70c17' }}>Форма невалидна</b>;
+      case true:
+        return <b style={{ color: '#5199db' }}>Форма валидна</b>;
+      default:
+        return null;
+    }
+  };
+
+  const validate = (value: string): ValidationInfo | null => {
+    switch (value) {
+      case 'error':
+        return { type, message: <b>Ошибка</b>, level: 'error' };
+      case 'warning':
+        return {
+          type,
+          message: <b>Предупреждение</b>,
+          level: 'warning',
+        };
+    }
+    return null;
+  };
 
   return (
-    <ValidationContainer>
-      <ValidationWrapper validationInfo={validationInfo}>
-        <CoverMyInput value={value} onChange={(e) => setValue(e.target.value)} />
-      </ValidationWrapper>
-    </ValidationContainer>
+    <Form>
+      <ValidationContainer ref={container}>
+        <Gapped gap={10} vertical>
+          <Form.Line title="Тип валидации">
+            <Gapped>
+              <Select
+                onValueChange={typeChangeHandler}
+                items={[
+                  ['lostfocus', 'lostfocus'],
+                  ['immediate', 'immediate'],
+                  ['submit', 'submit'],
+                ]}
+                defaultValue={type}
+              />
+              {type === 'submit' && (
+                <Gapped>
+                  <Button use="primary" onClick={submitHandler}>
+                    Submit
+                  </Button>
+                  {renderValidStatus()}
+                </Gapped>
+              )}
+            </Gapped>
+          </Form.Line>
+          <span>
+            Введите <code>«error»</code> или <code>«warning»</code> для вызова
+            соответствующих уровней валидации
+          </span>
+          <Form.Line title="Кастомный input">
+            <ValidationWrapper validationInfo={validate(value1)}>
+              <CustomInput value={value1} onChange={(e) => setValue1(e.target.value)} />
+            </ValidationWrapper>
+          </Form.Line>
+          <Form.Line title="Input из react-ui">
+            <ValidationWrapper validationInfo={validate(value2)}>
+              <Input value={value2} onValueChange={setValue2} />
+            </ValidationWrapper>
+          </Form.Line>
+        </Gapped>
+      </ValidationContainer>
+    </Form>
   );
 };
 

--- a/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.md
+++ b/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.md
@@ -1,0 +1,27 @@
+# Кастомные Контролы
+
+Валидации можно использовать с собственными контролами. Или с обёртками над контролами из библиотеки [react-ui](https://tech.skbkontur.ru/react-ui/#/Readme).
+
+Для этого в таком контроле/обёртке необходимо обеспечить следующие пропы:
+
+1. `ref` - DOM элемент нужен для правильной авто-прокрутки страницы до элемента с ошибкой ([подробнее](#/scroll-to-validation)).
+1. `error` - сеттит true, для соответствующего уровня валидации.
+1. `warning` - сеттит true, для соответствующего уровня валидации.
+1. `onBlur` - обеспечивает работу зависимых валидаций ([подробнее](#/dependent-validation)).
+1. `onChange` - отслеживается начало процесса ввода данных.
+
+В типах их можно представить так:
+
+    interface CustomControlProps<E = HTMLElement> {
+        ref?: React.ForwardedRef<E>;
+        error?: boolean;
+        warning?: boolean;
+        onBlur?: React.EventHandler<SyntheticEvent>;
+        onChange?: React.ChangeEventHandler<E>;
+    }
+
+Для контролов `react-ui` также прокидывается проп `onValueChange`. Чтобы избежать предупреждения в консоле (`Unknown event handler property 'onValueChange'`), этот проп можно "вырезать" из пропов (см. пример). 
+
+### Пример ([песочница](https://codesandbox.io/s/validations-custom-controls-ktf4gy))
+    
+    !!DemoWithCode!!./CustomControls

--- a/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.md
+++ b/packages/react-ui-validations/docs/Pages/Examples/CustomControls/CustomControls.md
@@ -12,16 +12,16 @@
 
 В типах их можно представить так:
 
-    interface CustomControlProps<E = HTMLElement> {
-        ref?: React.ForwardedRef<E>;
+    interface CustomControlProps<Elem = HTMLElement> {
+        ref?: React.ForwardedRef<Elem>;
         error?: boolean;
         warning?: boolean;
-        onBlur?: React.EventHandler<SyntheticEvent>;
-        onChange?: React.ChangeEventHandler<E>;
+        onBlur?: React.FocusEventHandler<Elem>;
+        onChange?: React.ChangeEventHandler<Elem>;
     }
 
 Для контролов `react-ui` также прокидывается проп `onValueChange`. Чтобы избежать предупреждения в консоле (`Unknown event handler property 'onValueChange'`), этот проп можно "вырезать" из пропов (см. пример). 
 
-### Пример ([песочница](https://codesandbox.io/s/validations-custom-controls-ktf4gy))
+### Пример
     
     !!DemoWithCode!!./CustomControls

--- a/packages/react-ui-validations/docs/Pages/Examples/index.ts
+++ b/packages/react-ui-validations/docs/Pages/Examples/index.ts
@@ -1,6 +1,7 @@
 import GuidesExample from './GuidesExample/GuidesExample.md';
 import ArrayExample from './ArrayExample/ArrayExample.md';
 import Editors from './Editors/Editors.md';
+import CustomControls from './CustomControls/CustomControls.md';
 
 export const Examples = {
   caption: 'Примеры',
@@ -19,6 +20,11 @@ export const Examples = {
       component: Editors,
       url: 'editors',
       caption: 'Редакторы',
+    },
+    {
+      component: CustomControls,
+      url: 'custom-controls',
+      caption: 'Кастомные контролы',
     },
   ],
 };

--- a/packages/react-ui-validations/docs/index.html
+++ b/packages/react-ui-validations/docs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link rel="stylesheet" href="https://s.kontur.ru/common-v2/fonts/LabGrotesque/LabGrotesque.css">
     <meta charset="UTF-8" />
     <title>React-UI Validations Docs</title>
   </head>

--- a/packages/react-ui-validations/docs/index.html
+++ b/packages/react-ui-validations/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://s.kontur.ru/common-v2/fonts/LabGrotesque/LabGrotesque.css">
+    <link rel="stylesheet" href="https://s.kontur.ru/common-v2/fonts/LabGrotesque/LabGrotesque.css" />
     <meta charset="UTF-8" />
     <title>React-UI Validations Docs</title>
   </head>

--- a/packages/react-ui-validations/docs/styles/typography.less
+++ b/packages/react-ui-validations/docs/styles/typography.less
@@ -1,52 +1,6 @@
 @import 'mixins.less';
 @import 'variables.less';
 
-// @font-face тут для мака
-// stylelint-disable no-unsupported-browser-features
-@font-face {
-  font-family: 'Segoe UI';
-  font-weight: 200;
-  src: local('Segoe UI Light');
-}
-
-@font-face {
-  font-family: 'Segoe UI';
-  font-weight: 300;
-  src: local('Segoe UI Semilight');
-}
-
-@font-face {
-  font-family: 'Segoe UI';
-  font-weight: 400;
-  src: local('Segoe UI');
-}
-
-@font-face {
-  font-family: 'Segoe UI';
-  font-weight: 600;
-  src: local('Segoe UI Semibold');
-}
-
-@font-face {
-  font-family: 'Segoe UI';
-  font-weight: 700;
-  src: local('Segoe UI Bold');
-}
-
-@font-face {
-  font-family: 'Segoe UI';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Segoe UI Italic');
-}
-
-@font-face {
-  font-family: 'Segoe UI';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Segoe UI Bold Italic');
-}
-
 body,
 html {
   font-family: @base-font-family;

--- a/packages/react-ui-validations/docs/styles/variables.less
+++ b/packages/react-ui-validations/docs/styles/variables.less
@@ -1,6 +1,6 @@
 @base-size: 5px;
 
-@base-font-family: 'Segoe UI', 'Helvetica', 'Arial', 'Tahoma', sans-serif;
+@base-font-family: 'Lab Grotesque', Roboto, 'Helvetica Neue', Arial, sans-serif;
 @base-font-size: 16px;
 @base-line-height: 24px;
 @lightbox-left-padding: @base-size * 3;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Время от времени пользователи приходят c такими вопросами по валидации, которые могут решиться созданием обёртки над контролами react-ui.
Также бывали вопросы об использовании с нашими валидациями контролов из другим библиотек или полностью кастомными компонентами.

<!-- Подробно опиши решаемую проблему. -->

## Решение

Текущая реализация валидаций принципиально способна работать не только с нашими контролами.
Но об этом ничего не написано в Доке, и можно понять только изучив исходники в репе.

Правки в Доке валидаций:
- Добавил простой пример и ссылку на песочницу.
- Заменил `Segoe UI`  на `Lab Grotesque`.
- Добавил небольшой отступ в меню, чтобы было видно последний пункт.
  <img width="286" alt="image" src="https://user-images.githubusercontent.com/2708211/212874371-df3119ca-7e1c-4840-a8b4-8853b2d7d328.png"> →  →  → <img width="232" alt="image" src="https://user-images.githubusercontent.com/2708211/212872898-5477ced6-51a7-453e-83a7-72295e985710.png">


<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

`IF-935`
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
