### PR TITLE
docs(Hint): add examples using `useWrapper` prop & custom wrapper

### DIFF
--- a/packages/react-ui/components/Hint/Hint.md
+++ b/packages/react-ui/components/Hint/Hint.md
@@ -64,7 +64,7 @@ const [isOpen, setIsOpen] = React.useState(false);
 
 ```jsx harmony
 <Hint useWrapper text="Подсказа всё равно отображается">
-  <button>native button</button>
+  <button disabled>native button</button>
 </Hint>
 ```
 

--- a/packages/react-ui/components/Hint/Hint.md
+++ b/packages/react-ui/components/Hint/Hint.md
@@ -54,3 +54,32 @@ const [isOpen, setIsOpen] = React.useState(false);
 ```jsx harmony
 <Hint disableAnimations text={"Нет анимации :("}>Есть анимация?</Hint>
 ```
+
+### Использование встроеной и кастомной обёртки
+
+Подсказка должна отображаться даже на отключённых компонентах. Из коробки это работает только с контролами `react-ui`. 
+
+Нативные элементы, поддерживающие атрибут `disabled`, отключают необходимые события мыши.
+В подобных случаях следуют использовать проп `useWrapper`:
+
+```jsx harmony
+<Hint useWrapper text="Подсказа всё равно отображается">
+  <button>native button</button>
+</Hint>
+```
+
+Т.к. встроённая обёртка это `<span>` без стилей, то она может работать некорректно в определённых ситуациях.
+В таких случаях стоит использовать собственную обётку:
+
+```jsx harmony
+<>
+  <Hint useWrapper text="Подсказа">
+    <button disabled style={{ height: 40 }}>useWrapper prop</button>
+  </Hint>
+  <Hint text="Подсказа">
+    <span style={{ display: 'inline-block' }}>
+      <button disabled style={{ height: 40 }}>custom wrapper</button>
+    </span>
+  </Hint>
+</>
+```


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Есть сценарии, когда необходимо использовать проп `useWrapper` или кастомную обёртку для правильной работы Хинта.
Эти сценарии кажутся редкими, а любое комплексное исправление ломающим.

Поэтому решили добавить информацию об этом в Доку с примерами обходных решений.

<!-- Подробно опиши решаемую проблему. -->

## Решение

Добавил примеры использования встроеной и кастомной обёртки.

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

`F-948`

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
