### PR TITLE
feat(Dropdown): add prop menuPos for manual control of dropdown position

### DIFF
--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom with portal/chrome/opened bottom with portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom with portal/chrome/opened bottom with portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7857533420016a9c43dae4129dc57f2cd590f3abc1a8d03a7cd4d274d03af49
+size 7235

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom with portal/firefox/opened bottom with portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom with portal/firefox/opened bottom with portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fc7713858022f55e2e802af9f53b58f45de805a513ca57621007c1bc8862798
+size 8556

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom without portal/chrome/opened bottom without portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom without portal/chrome/opened bottom without portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f44b91033aac908119e62b162012ca97b408dddd50368b549ed42590fdd334d
+size 6911

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom without portal/firefox/opened bottom without portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened bottom without portal/firefox/opened bottom without portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afd1617e7b1ad7aa61a2d90cfa6c7c59142f3be9f251af94a5ef4dba971e1c5a
+size 8563

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top with portal/chrome/opened top with portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top with portal/chrome/opened top with portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:845552225bee773484a7113ddeeea78303046ab8e40d46becbf2c495d0b4c396
+size 7460

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top with portal/firefox/opened top with portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top with portal/firefox/opened top with portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:391bb51641179ef15627a25da0dc14421049a54367392339412acfb9f016df00
+size 9251

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top without portal/chrome/opened top without portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top without portal/chrome/opened top without portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41bce805b56c09f5b3f7d12d0a93b6ed2c31d7d4f7ff06e174b3043893a70f4b
+size 7282

--- a/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top without portal/firefox/opened top without portal.png
+++ b/packages/react-ui/.creevey/images/Dropdown/with manual position/opened top without portal/firefox/opened top without portal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b354b1b22b1c59f7da72b1dc1655c832da9f34dac56c30cda04d40e02f57affc
+size 8601

--- a/packages/react-ui/components/Dropdown/Dropdown.tsx
+++ b/packages/react-ui/components/Dropdown/Dropdown.tsx
@@ -13,6 +13,7 @@ import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
+import { DropdownContainerProps } from '../../internal/DropdownContainer';
 
 const PASS_PROPS = {
   _renderButton: true,
@@ -31,9 +32,10 @@ const PASS_PROPS = {
   onMouseEnter: true,
   onMouseLeave: true,
   onMouseOver: true,
+  menuPos: true,
 };
 
-export interface DropdownProps extends CommonProps {
+export interface DropdownProps extends CommonProps, Pick<DropdownContainerProps, 'menuPos'> {
   /**
    * Подпись на кнопке.
    */

--- a/packages/react-ui/components/Dropdown/__stories__/Dropdown.stories.tsx
+++ b/packages/react-ui/components/Dropdown/__stories__/Dropdown.stories.tsx
@@ -216,3 +216,82 @@ WithCustomSelectTheme.parameters = {
     },
   },
 };
+
+export const WithManualPosition: Story = () => {
+  const [menuPos, setMenuPos] = React.useState<'top' | 'bottom'>('top');
+  const [isPortalDisabled, setIsPortalDisabled] = React.useState(false);
+
+  return (
+    <div style={{ marginTop: '50px' }}>
+      <Dropdown disablePortal={isPortalDisabled} menuPos={menuPos} caption="Открыть">
+        <MenuItem>Menu item</MenuItem>
+      </Dropdown>
+      <button data-tid="pos" onClick={() => setMenuPos(menuPos === 'top' ? 'bottom' : 'top')}>
+        change pos to {menuPos === 'top' ? 'bottom' : 'top'}
+      </button>
+      <button data-tid="portal" onClick={() => setIsPortalDisabled(!isPortalDisabled)}>
+        {isPortalDisabled ? 'enable' : 'disable'} portal
+      </button>
+    </div>
+  );
+};
+WithManualPosition.storyName = 'with manual position';
+WithManualPosition.parameters = {
+  creevey: {
+    skip: { in: /^(?!\b(chrome|firefox)\b)/ },
+    tests: {
+      async 'opened top with portal'() {
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+          .click(this.browser.findElement({ css: '[data-comp-name~="Dropdown"]' }))
+          .perform();
+        await delay(1000);
+
+        await this.expect(await this.takeScreenshot()).to.matchImage('opened top with portal');
+      },
+      async 'opened bottom with portal'() {
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+          .click(this.browser.findElement({ css: '[data-tid~="pos"]' }))
+          .pause(1000)
+          .click(this.browser.findElement({ css: '[data-comp-name~="Dropdown"]' }))
+          .perform();
+        await delay(1000);
+
+        await this.expect(await this.takeScreenshot()).to.matchImage('opened bottom with portal');
+      },
+      async 'opened top without portal'() {
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+          .click(this.browser.findElement({ css: '[data-tid~="portal"]' }))
+          .pause(1000)
+          .click(this.browser.findElement({ css: '[data-comp-name~="Dropdown"]' }))
+          .perform();
+        await delay(1000);
+
+        await this.expect(await this.takeScreenshot()).to.matchImage('opened top without portal');
+      },
+      async 'opened bottom without portal'() {
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+          .click(this.browser.findElement({ css: '[data-tid~="portal"]' }))
+          .pause(1000)
+          .click(this.browser.findElement({ css: '[data-tid~="pos"]' }))
+          .pause(1000)
+          .click(this.browser.findElement({ css: '[data-comp-name~="Dropdown"]' }))
+          .perform();
+        await delay(1000);
+
+        await this.expect(await this.takeScreenshot()).to.matchImage('opened bottom without portal');
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Проблема

В #3076 всем компонентам основанным на `DropdownContainer` (`ComboBox`, `DatePicker`, `Select`, `Autocomplete`) добавили проп `menuPos` для возможности задания позиции выпадающего окна вручную. 
`Dropdown` сделан на основе `Select` и про него забыли

## Решение

Добавила проп `menuPos` в `Dropdown`

## Ссылки

fix IF-963

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
