### PR TITLE
chore(Storybook): fix mobile view of components on theme change

### DIFF
--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -61,15 +61,29 @@ const MOBILE_REGEXP = /Mobile.*/i;
 
 export const decorators: Meta['decorators'] = [
   (Story, context) => {
-    const theme = themes[context.globals.theme] || DEFAULT_THEME;
+    const storybookTheme = themes[context.globals.theme] || DEFAULT_THEME;
     const root = document.getElementById('root');
 
     if (root) {
-      if ([DARK_THEME, THEME_2022_DARK].includes(theme)) {
+      if ([DARK_THEME, THEME_2022_DARK].includes(storybookTheme)) {
         root.classList.add('dark');
       } else {
         root.classList.remove('dark');
       }
+    }
+
+    if (storybookTheme !== DEFAULT_THEME) {
+      return (
+        <ThemeContext.Consumer>
+          {(theme) => {
+            return (
+              <ThemeContext.Provider value={ThemeFactory.create(theme, storybookTheme)}>
+                <Story />
+              </ThemeContext.Provider>
+            );
+          }}
+        </ThemeContext.Consumer>
+      );
     }
 
     return <Story />;
@@ -79,20 +93,24 @@ export const decorators: Meta['decorators'] = [
       <Story />
     </div>
   ),
-  (Story, context) => {
-    const theme = themes[context.globals.theme] || DEFAULT_THEME;
-
+  (Story) => {
     return (
-      <ThemeContext.Provider
-        value={ThemeFactory.create(
-          {
-            mobileMediaQuery: '(max-width: 576px)',
-          },
-          theme,
-        )}
-      >
-        <Story />
-      </ThemeContext.Provider>
+      <ThemeContext.Consumer>
+        {(theme) => {
+          return (
+            <ThemeContext.Provider
+              value={ThemeFactory.create(
+                {
+                  mobileMediaQuery: '(max-width: 576px)',
+                },
+                theme,
+              )}
+            >
+              <Story />
+            </ThemeContext.Provider>
+          );
+        }}
+      </ThemeContext.Consumer>
     );
   },
 ];

--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -74,7 +74,14 @@ export const decorators: Meta['decorators'] = [
 
     if (theme !== DEFAULT_THEME) {
       return (
-        <ThemeContext.Provider value={theme}>
+        <ThemeContext.Provider
+          value={ThemeFactory.create(
+            {
+              mobileMediaQuery: '(max-width: 576px)',
+            },
+            theme,
+          )}
+        >
           <Story />
         </ThemeContext.Provider>
       );

--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -73,18 +73,7 @@ export const decorators: Meta['decorators'] = [
     }
 
     if (theme !== DEFAULT_THEME) {
-      return (
-        <ThemeContext.Provider
-          value={ThemeFactory.create(
-            {
-              mobileMediaQuery: '(max-width: 576px)',
-            },
-            theme,
-          )}
-        >
-          <Story />
-        </ThemeContext.Provider>
-      );
+      return <Story />;
     }
 
     return <Story />;
@@ -95,28 +84,20 @@ export const decorators: Meta['decorators'] = [
     </div>
   ),
   (Story, context) => {
-    if (MOBILE_REGEXP.test(context.story) || MOBILE_REGEXP.test(context.name)) {
-      return (
-        <ThemeContext.Consumer>
-          {(theme) => {
-            return (
-              <ThemeContext.Provider
-                value={ThemeFactory.create(
-                  {
-                    mobileMediaQuery: '(max-width: 576px)',
-                  },
-                  theme,
-                )}
-              >
-                <Story />
-              </ThemeContext.Provider>
-            );
-          }}
-        </ThemeContext.Consumer>
-      );
-    }
+    const theme = themes[context.globals.theme] || DEFAULT_THEME;
 
-    return <Story />;
+    return (
+      <ThemeContext.Provider
+        value={ThemeFactory.create(
+          {
+            mobileMediaQuery: '(max-width: 576px)',
+          },
+          theme,
+        )}
+      >
+        <Story />
+      </ThemeContext.Provider>
+    );
   },
 ];
 

--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -72,10 +72,6 @@ export const decorators: Meta['decorators'] = [
       }
     }
 
-    if (theme !== DEFAULT_THEME) {
-      return <Story />;
-    }
-
     return <Story />;
   },
   (Story) => (


### PR DESCRIPTION
## Проблема

При изменении темы в `Storybook` с темы по умолчанию (`DEFAULT_THEME`) на любую другую перестает отображаться мобильный вид контролов

## Решение

У нас в качестве `mobileMediaQuery` по умолчанию задано квери вида: `(max-width: 576px) and (hover: none) and (pointer: coarse)`. То есть, помимо того, что ширина экрана должна быть меньше `576px` мы должны ещё и взаимодействовать с тач-устройством, чтобы это квери сработало. Вне зависимости от того, изменён ли у нас вьюпорт средствами `Storybook`'а или нет второе условие никогда не выполнится. Поэтому для `Storybook`'а квери подменяется на `(max-width: 576px)`, но это происходит только для `DEFAULT_THEME`, из-за чего в остальных темах ломается мобильное отображение. Распространил упрощенную версию квери на остальные темы

P.S.
Значение `(max-width: 576px)` можно забирать из `DEFAULT_THEME_MOBILE`. Но я не уверен, как сильно на него можно полагаться. Насколько понимаю, эта тема используется для настройки скриншотов в `chromeMobile` т. е. в теории значения для `Storybook`'а и `Creevey` должны быть совместимы, но мне нужен апрув на использование переменной

## Ссылки

IF-984

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
