### PR TITLE
docs: add Select of theme instead Toggle of dark theme

### DIFF
--- a/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.tsx
+++ b/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.tsx
@@ -5,6 +5,7 @@ import { useStyleGuideContext } from 'react-styleguidist/lib/client/rsg-componen
 import { cx } from '../../../lib/theming/Emotion';
 import { styles } from './StyleGuideWrapper.styles';
 import { DARK_THEME } from '../../../lib/theming/themes/DarkTheme';
+import { DEFAULT_THEME_WRAPPER } from '../ThemeSwitcher/constants';
 
 interface StyleGuideRendererProps {
   children: React.ReactNode;
@@ -16,10 +17,13 @@ interface StyleGuideRendererProps {
 
 function StyleGuideRenderer({ children, hasSidebar, toc, title, version }: StyleGuideRendererProps) {
   const { codeRevision, config, slots, displayMode, cssRevision } = useStyleGuideContext();
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState(DEFAULT_THEME_WRAPPER);
   document.body.style.fontFamily = 'Lab Grotesque, Roboto, Helvetica Neue, Arial, sans-serif';
   document.body.style.fontSize = '14px';
-  if (theme === 'dark') {
+
+  const isThemeDark = theme.toLowerCase().includes('dark');
+
+  if (isThemeDark) {
     document.documentElement.style.height = '100%';
     document.body.style.height = '100%';
     const root = document.getElementById('rsg-root');
@@ -29,9 +33,9 @@ function StyleGuideRenderer({ children, hasSidebar, toc, title, version }: Style
   }
   return (
     <Context.Provider value={{ theme, setTheme, codeRevision, config, slots, displayMode, cssRevision }}>
-      <div className={cx(styles.root(), { [styles.darkRoot(DARK_THEME)]: theme === 'dark' })}>
+      <div className={cx(styles.root(), { [styles.darkRoot(DARK_THEME)]: isThemeDark })}>
         <main className={styles.wrapper()}>
-          <div className={cx(styles.content(), { [styles.darkContent(DARK_THEME)]: theme === 'dark' })}>{children}</div>
+          <div className={cx(styles.content(), { [styles.darkContent(DARK_THEME)]: isThemeDark })}>{children}</div>
         </main>
         {hasSidebar && (
           <div data-testid="sidebar" className={styles.sidebar()}>

--- a/packages/react-ui/.styleguide/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/packages/react-ui/.styleguide/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -2,14 +2,14 @@ import React, { useContext } from 'react';
 import Context from 'react-styleguidist/lib/client/rsg-components/Context';
 
 import { Select } from '../../../components/Select';
-import { DARK_THEME } from '../../../lib/theming/themes/DarkTheme';
+import { THEME_2022_DARK } from '../../../lib/theming/themes/Theme2022Dark';
 import { ThemeContext } from '../../../lib/theming/ThemeContext';
 import { THEMES } from './constants';
 
 const ThemeSwitcher = () => {
   const { theme, setTheme } = useContext(Context);
   return (
-    <ThemeContext.Provider value={DARK_THEME}>
+    <ThemeContext.Provider value={THEME_2022_DARK}>
       <Select
         value={theme}
         items={Object.keys(THEMES)}

--- a/packages/react-ui/.styleguide/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/packages/react-ui/.styleguide/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,24 +1,22 @@
 import React, { useContext } from 'react';
 import Context from 'react-styleguidist/lib/client/rsg-components/Context';
 
-import { Toggle } from '../../../components/Toggle';
+import { Select } from '../../../components/Select';
 import { DARK_THEME } from '../../../lib/theming/themes/DarkTheme';
 import { ThemeContext } from '../../../lib/theming/ThemeContext';
+import { THEMES } from './constants';
 
 const ThemeSwitcher = () => {
   const { theme, setTheme } = useContext(Context);
-  const handleValueChange = () => {
-    if (theme === 'light') {
-      setTheme('dark');
-    } else {
-      setTheme('light');
-    }
-  };
   return (
     <ThemeContext.Provider value={DARK_THEME}>
-      <Toggle checked={theme === 'dark'} onValueChange={handleValueChange} style={{ margin: '24px 10px' }}>
-        Dark Theme
-      </Toggle>
+      <Select
+        value={theme}
+        items={Object.keys(THEMES)}
+        onValueChange={setTheme}
+        width="100%"
+        style={{ marginTop: 24 }}
+      />
     </ThemeContext.Provider>
   );
 };

--- a/packages/react-ui/.styleguide/components/ThemeSwitcher/constants.ts
+++ b/packages/react-ui/.styleguide/components/ThemeSwitcher/constants.ts
@@ -1,0 +1,8 @@
+import { DARK_THEME } from '../../../lib/theming/themes/DarkTheme';
+import { DEFAULT_THEME } from '../../../lib/theming/themes/DefaultTheme';
+import { THEME_2022 } from '../../../lib/theming/themes/Theme2022';
+import { THEME_2022_DARK } from '../../../lib/theming/themes/Theme2022Dark';
+
+export const THEMES = { DEFAULT_THEME, DARK_THEME, THEME_2022, THEME_2022_DARK } as const;
+
+export const DEFAULT_THEME_WRAPPER: keyof typeof THEMES = 'DEFAULT_THEME';

--- a/packages/react-ui/.styleguide/components/ThemeWrapper/ThemeWrapper.tsx
+++ b/packages/react-ui/.styleguide/components/ThemeWrapper/ThemeWrapper.tsx
@@ -1,13 +1,11 @@
 import React, { useContext } from 'react';
 
-import { ThemeContext, DEFAULT_THEME } from '@skbkontur/react-ui';
-import { DARK_THEME } from '../../../lib/theming/themes/DarkTheme';
+import { ThemeContext } from '@skbkontur/react-ui';
 import Context from 'react-styleguidist/lib/client/rsg-components/Context';
+import { THEMES } from '../ThemeSwitcher/constants';
 
 function ThemeWrapper({ children }: any): any {
   const { theme } = useContext(Context);
-  return (
-    <ThemeContext.Provider value={theme === 'light' ? DEFAULT_THEME : DARK_THEME}>{children}</ThemeContext.Provider>
-  );
+  return <ThemeContext.Provider value={THEMES[theme as keyof typeof THEMES]}>{children}</ThemeContext.Provider>;
 }
 export default ThemeWrapper;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В документации не хватает возможности переключать готовые темы кастомизации.

<!-- Подробно опиши решаемую проблему. -->

## Решение

Добавил Селект выбора тем. Задал ему тему `THEME_2022_DARK`.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/2708211/219343889-8f02357d-0136-42d7-884a-413cb86c9ec9.png">


<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

`F-936`

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
