### PR TITLE
Добавление пропсов renderItem и onMonthChange. branch/KS-4180

### DIFF
--- a/packages/react-ui/components/DatePicker/DatePicker.md
+++ b/packages/react-ui/components/DatePicker/DatePicker.md
@@ -323,7 +323,7 @@ const CustomDayItem = ({ date }) => {
   );
 };
   
-const renderItem = (date) =>  <CustomDayItem date={date} />;
+const renderDay = (date) =>  <CustomDayItem date={date} />;
 
-<DatePicker value={value} onValueChange={setValue} renderItem={renderItem} />;
+<DatePicker value={value} onValueChange={setValue} renderDay={renderDay} />;
 ```

--- a/packages/react-ui/components/DatePicker/DatePicker.md
+++ b/packages/react-ui/components/DatePicker/DatePicker.md
@@ -305,3 +305,25 @@ const en_GB = {
   separator: DateSeparator.Slash,
 };
 ```
+
+### Кастомизирование отображения даты
+
+```jsx harmony
+import MagicWand from '@skbkontur/react-icons/MagicWand';
+
+const [value, setValue] = React.useState();
+  
+const CustomDayItem = ({ date }) => {
+  const isEven = (num) => num % 2 === 0;
+
+  return (
+    <div>
+      {isEven(date.date) ? <MagicWand /> : date.date}
+    </div>
+  );
+};
+  
+const renderItem = (date) =>  <CustomDayItem date={date} />;
+
+<DatePicker value={value} onValueChange={setValue} renderItem={renderItem} />;
+```

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -30,6 +30,17 @@ const INPUT_PASS_PROPS = {
 
 export const MIN_WIDTH = 120;
 
+export enum ScrollDirection {
+  Down = 1,
+  Up = -1,
+}
+
+export interface MonthChangeInfo {
+  month: number;
+  year: number;
+  scrollDirection: ScrollDirection;
+}
+
 export interface DatePickerProps<T> extends CommonProps {
   autoFocus?: boolean;
   disabled?: boolean;
@@ -76,6 +87,24 @@ export interface DatePickerProps<T> extends CommonProps {
    * @returns {boolean} `true` для выходного или `false` для рабочего дня
    */
   isHoliday: (day: T, isWeekend: boolean) => boolean;
+
+  /**
+   * Метод отрисовки дат в календаре
+   * @default (date) => date.date as number
+   * @param {CalendarDateShape} date - дата в формате `{ year: number; month: number; date: number; }`
+   *
+   * @returns {ReactNode} возвращает компонент, который отрисовывает контент числа месяца
+   */
+  renderItem: (date: CalendarDateShape) => React.ReactNode;
+
+  /**
+   * Вызывается при каждом изменении месяца
+   * @param {MonthChangeInfo} changeInfo - информация о изменении отображаемого месяца, где
+   * `month: number` - номер текущего отображаемого месяца от 0 до 11,
+   * `year: number` - отображаемый год,
+   * `scrollDirection` - направление скролла, где `1` - `Down`, `-1` - `Up`
+   */
+  onMonthChange?: (changeInfo: MonthChangeInfo) => void;
 }
 
 export interface DatePickerState {
@@ -137,12 +166,17 @@ export class DatePicker extends React.PureComponent<DatePickerProps<DatePickerVa
     onMouseOver: PropTypes.func,
 
     isHoliday: PropTypes.func.isRequired,
+
+    renderItem: PropTypes.func.isRequired,
+
+    onMonthChange: PropTypes.func,
   };
 
   public static defaultProps = {
     minDate: MIN_FULLDATE,
     maxDate: MAX_FULLDATE,
     isHoliday: (_day: DatePickerValue, isWeekend: boolean) => isWeekend,
+    renderItem: (date: CalendarDateShape) => date.date,
   };
 
   public static validate = (value: Nullable<string>, range: { minDate?: string; maxDate?: string } = {}) => {
@@ -259,6 +293,8 @@ export class DatePicker extends React.PureComponent<DatePickerProps<DatePickerVa
             onSelect={this.handleSelect}
             enableTodayLink={this.props.enableTodayLink}
             isHoliday={this.isHoliday}
+            renderItem={this.props.renderItem}
+            onMonthChange={this.props.onMonthChange}
           />
         </DropdownContainer>
       );

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -6,7 +6,7 @@ import { InternalDateTransformer } from '../../lib/date/InternalDateTransformer'
 import { MAX_FULLDATE, MIN_FULLDATE } from '../../lib/date/constants';
 import { InternalDateOrder, InternalDateSeparator, InternalDateValidateCheck } from '../../lib/date/types';
 import { Nullable } from '../../typings/utility-types';
-import { CalendarDateShape } from '../../internal/Calendar';
+import { CalendarDateShape, CalendarMonthChangeInfo } from '../../internal/Calendar';
 import { DateInput } from '../DateInput';
 import { DropdownContainer } from '../../internal/DropdownContainer';
 import { filterProps } from '../../lib/filterProps';
@@ -29,17 +29,6 @@ const INPUT_PASS_PROPS = {
 };
 
 export const MIN_WIDTH = 120;
-
-export enum ScrollDirection {
-  Down = 1,
-  Up = -1,
-}
-
-export interface MonthChangeInfo {
-  month: number;
-  year: number;
-  scrollDirection: ScrollDirection;
-}
 
 export interface DatePickerProps<T> extends CommonProps {
   autoFocus?: boolean;
@@ -95,16 +84,16 @@ export interface DatePickerProps<T> extends CommonProps {
    *
    * @returns {ReactNode} возвращает компонент, который отрисовывает контент числа месяца
    */
-  renderItem: (date: CalendarDateShape) => React.ReactNode;
+  renderDay: (date: CalendarDateShape) => React.ReactNode;
 
   /**
    * Вызывается при каждом изменении месяца
-   * @param {MonthChangeInfo} changeInfo - информация о изменении отображаемого месяца, где
+   * @param {CalendarMonthChangeInfo} changeInfo - информация о изменении отображаемого месяца, где
    * `month: number` - номер текущего отображаемого месяца от 0 до 11,
    * `year: number` - отображаемый год,
    * `scrollDirection` - направление скролла, где `1` - `Down`, `-1` - `Up`
    */
-  onMonthChange?: (changeInfo: MonthChangeInfo) => void;
+  onMonthChange?: (changeInfo: CalendarMonthChangeInfo) => void;
 }
 
 export interface DatePickerState {
@@ -167,7 +156,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps<DatePickerVa
 
     isHoliday: PropTypes.func.isRequired,
 
-    renderItem: PropTypes.func.isRequired,
+    renderDay: PropTypes.func.isRequired,
 
     onMonthChange: PropTypes.func,
   };
@@ -176,7 +165,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps<DatePickerVa
     minDate: MIN_FULLDATE,
     maxDate: MAX_FULLDATE,
     isHoliday: (_day: DatePickerValue, isWeekend: boolean) => isWeekend,
-    renderItem: (date: CalendarDateShape) => date.date,
+    renderDay: (date: CalendarDateShape) => date.date,
   };
 
   public static validate = (value: Nullable<string>, range: { minDate?: string; maxDate?: string } = {}) => {
@@ -293,7 +282,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps<DatePickerVa
             onSelect={this.handleSelect}
             enableTodayLink={this.props.enableTodayLink}
             isHoliday={this.isHoliday}
-            renderItem={this.props.renderItem}
+            renderDay={this.props.renderDay}
             onMonthChange={this.props.onMonthChange}
           />
         </DropdownContainer>

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -91,7 +91,6 @@ export interface DatePickerProps<T> extends CommonProps {
    * @param {CalendarMonthChangeInfo} changeInfo - информация о изменении отображаемого месяца, где
    * `month: number` - номер текущего отображаемого месяца от 0 до 11,
    * `year: number` - отображаемый год,
-   * `scrollDirection` - направление скролла, где `1` - `Down`, `-1` - `Up`
    */
   onMonthChange?: (changeInfo: CalendarMonthChangeInfo) => void;
 }

--- a/packages/react-ui/components/DatePicker/Picker.tsx
+++ b/packages/react-ui/components/DatePicker/Picker.tsx
@@ -3,7 +3,7 @@ import shallowEqual from 'shallowequal';
 
 import { InternalDate } from '../../lib/date/InternalDate';
 import { InternalDateGetter } from '../../lib/date/InternalDateGetter';
-import { Calendar, CalendarDateShape, isGreater, isLess } from '../../internal/Calendar';
+import { Calendar, CalendarDateShape, CalendarMonthChangeInfo, isGreater, isLess } from '../../internal/Calendar';
 import { locale } from '../../lib/locale/decorators';
 import { Nullable } from '../../typings/utility-types';
 import { Theme } from '../../lib/theming/Theme';
@@ -11,8 +11,6 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 
 import { styles } from './Picker.styles';
 import { DatePickerLocale, DatePickerLocaleHelper } from './locale';
-
-import { MonthChangeInfo } from './index';
 
 interface Props {
   maxDate?: CalendarDateShape;
@@ -22,8 +20,8 @@ interface Props {
   onSelect?: (date: CalendarDateShape) => void;
   enableTodayLink?: boolean;
   isHoliday?: (day: CalendarDateShape & { isWeekend: boolean }) => boolean;
-  renderItem?: (date: CalendarDateShape) => React.ReactNode | number;
-  onMonthChange?: (changeInfo: MonthChangeInfo) => void;
+  renderDay?: (date: CalendarDateShape) => React.ReactNode;
+  onMonthChange?: (changeInfo: CalendarMonthChangeInfo) => void;
 }
 
 interface State {
@@ -89,7 +87,7 @@ export class Picker extends React.Component<Props, State> {
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
           isHoliday={this.props.isHoliday}
-          renderItem={this.props.renderItem}
+          renderDay={this.props.renderDay}
           onMonthChange={this.props.onMonthChange}
         />
         {this.props.enableTodayLink && this.renderTodayLink()}{' '}

--- a/packages/react-ui/components/DatePicker/Picker.tsx
+++ b/packages/react-ui/components/DatePicker/Picker.tsx
@@ -12,6 +12,8 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { styles } from './Picker.styles';
 import { DatePickerLocale, DatePickerLocaleHelper } from './locale';
 
+import { MonthChangeInfo } from './index';
+
 interface Props {
   maxDate?: CalendarDateShape;
   minDate?: CalendarDateShape;
@@ -20,6 +22,8 @@ interface Props {
   onSelect?: (date: CalendarDateShape) => void;
   enableTodayLink?: boolean;
   isHoliday?: (day: CalendarDateShape & { isWeekend: boolean }) => boolean;
+  renderItem?: (date: CalendarDateShape) => React.ReactNode | number;
+  onMonthChange?: (changeInfo: MonthChangeInfo) => void;
 }
 
 interface State {
@@ -85,6 +89,8 @@ export class Picker extends React.Component<Props, State> {
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
           isHoliday={this.props.isHoliday}
+          renderItem={this.props.renderItem}
+          onMonthChange={this.props.onMonthChange}
         />
         {this.props.enableTodayLink && this.renderTodayLink()}{' '}
       </div>

--- a/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
+++ b/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions';
-import React, { useCallback, useState } from 'react';
+import React, { CSSProperties, useCallback, useState } from 'react';
 
 import { Meta, Story } from '../../../typings/stories';
 import { InternalDateOrder, InternalDateSeparator } from '../../../lib/date/types';
 import { Button } from '../../Button';
 import { Gapped } from '../../Gapped';
 import { Tooltip } from '../../Tooltip';
-import { DatePicker } from '../DatePicker';
+import { DatePicker, MonthChangeInfo } from '../DatePicker';
 import { LocaleContext, LangCodes } from '../../../lib/locale';
 import { delay, emptyHandler } from '../../../lib/utils';
 
@@ -364,3 +364,43 @@ DatePickerInRelativeBody.parameters = {
     },
   },
 };
+
+export const DatePickerWithMonthChangeHandel = () => {
+  const [month, setMonth] = useState(6);
+  const [year, setYear] = useState(2017);
+  const [value, setValue] = useState('02.07.2017');
+
+  const onMonthChange = (changeInfo: MonthChangeInfo): void => {
+    setMonth(changeInfo.month);
+    setYear(changeInfo.year);
+  };
+
+  const containerWithInfoStyle: CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    fontSize: '18px',
+    marginLeft: '64px',
+    width: '450px',
+    textAlign: 'center',
+  };
+  const containersStyle: CSSProperties = { display: 'flex', flexDirection: 'column' };
+  const monthYearStyle: CSSProperties = { border: '1px #c2b8b8 solid' };
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <DatePicker value={value} onValueChange={setValue} onMonthChange={onMonthChange} />
+      <div style={containerWithInfoStyle}>
+        <div style={containersStyle}>
+          <span>Отображаемый месяц</span>
+          <span style={monthYearStyle}>{month}</span>
+        </div>
+        <div style={containersStyle}>
+          <span>Отображаемый год</span>
+          <span style={monthYearStyle}>{year}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+DatePickerWithMonthChangeHandel.storyName = 'DatePicker with month change handel';
+DatePickerWithMonthChangeHandel.parameters = { creevey: { skip: [true] } };

--- a/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
+++ b/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
@@ -6,9 +6,10 @@ import { InternalDateOrder, InternalDateSeparator } from '../../../lib/date/type
 import { Button } from '../../Button';
 import { Gapped } from '../../Gapped';
 import { Tooltip } from '../../Tooltip';
-import { DatePicker, MonthChangeInfo } from '../DatePicker';
+import { DatePicker } from '../DatePicker';
 import { LocaleContext, LangCodes } from '../../../lib/locale';
 import { delay, emptyHandler } from '../../../lib/utils';
+import { CalendarMonthChangeInfo } from '../../../internal/Calendar';
 
 class DatePickerWithError extends React.Component<any, any> {
   public state = {
@@ -370,7 +371,7 @@ export const DatePickerWithMonthChangeHandel = () => {
   const [year, setYear] = useState(2017);
   const [value, setValue] = useState('02.07.2017');
 
-  const onMonthChange = (changeInfo: MonthChangeInfo): void => {
+  const onMonthChange = (changeInfo: CalendarMonthChangeInfo): void => {
     setMonth(changeInfo.month);
     setYear(changeInfo.year);
   };

--- a/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
+++ b/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
@@ -124,7 +124,7 @@ describe('DatePicker', () => {
     const CustomDayItem: React.FC<{ date: CalendarDateShape }> = ({ date }) => <span>{date.date}</span>;
 
     const datePicker = renderDatePicker({
-      renderItem: (date) => <CustomDayItem date={date} />,
+      renderDay: (date: CalendarDateShape): React.ReactNode => <CustomDayItem date={date} />,
     });
     datePicker.setState({ opened: true });
     const customDayItem = datePicker.find('CustomDayItem');

--- a/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
+++ b/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { InternalDate } from '../../../lib/date/InternalDate';
 import { InternalDateGetter } from '../../../lib/date/InternalDateGetter';
 import { InternalDateConstructorProps, InternalDateSeparator } from '../../../lib/date/types';
-import { Calendar } from '../../../internal/Calendar';
+import { Calendar, CalendarDateShape } from '../../../internal/Calendar';
 import { DateSelect } from '../../../internal/DateSelect';
 import { DropdownContainer } from '../../../internal/DropdownContainer';
 import { defaultLangCode } from '../../../lib/locale/constants';
@@ -118,6 +118,18 @@ describe('DatePicker', () => {
       autoFocus: true,
     });
     expect(datePicker.find(DropdownContainer)).toHaveLength(1);
+  });
+
+  it('renders day cells with renderItem prop', () => {
+    const CustomDayItem: React.FC<{ date: CalendarDateShape }> = ({ date }) => <span>{date.date}</span>;
+
+    const datePicker = renderDatePicker({
+      renderItem: (date) => <CustomDayItem date={date} />,
+    });
+    datePicker.setState({ opened: true });
+    const customDayItem = datePicker.find('CustomDayItem');
+
+    expect(customDayItem.exists());
   });
 
   describe('Locale', () => {

--- a/packages/react-ui/internal/Calendar/Calendar.styles.ts
+++ b/packages/react-ui/internal/Calendar/Calendar.styles.ts
@@ -3,7 +3,7 @@ import { Theme } from '../../lib/theming/Theme';
 
 export const styles = memoizeStyle({
   root(t: Theme) {
-    const width = parseInt(t.calendarCellSize) * 7;
+    const width = parseInt(t.calendarCellWidth) * 7;
     return css`
       box-sizing: content-box;
       color: ${t.textColorDefault};

--- a/packages/react-ui/internal/Calendar/Calendar.tsx
+++ b/packages/react-ui/internal/Calendar/Calendar.tsx
@@ -17,15 +17,9 @@ import { Month } from './Month';
 import { styles } from './Calendar.styles';
 import { CalendarDateShape, create, isGreater, isLess } from './CalendarDateShape';
 
-export enum CalendarScrollDirection {
-  Down = 1,
-  Up = -1,
-}
-
 export interface CalendarMonthChangeInfo {
   month: number;
   year: number;
-  scrollDirection: CalendarScrollDirection;
 }
 
 export interface CalendarProps {
@@ -413,7 +407,6 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     const changeInfo = {
       month: currentMonth.month,
       year: currentMonth.year,
-      scrollDirection: this.state.scrollDirection,
     };
 
     handler(changeInfo);

--- a/packages/react-ui/internal/Calendar/Calendar.tsx
+++ b/packages/react-ui/internal/Calendar/Calendar.tsx
@@ -7,7 +7,6 @@ import { Nullable } from '../../typings/utility-types';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Animation } from '../../lib/animation';
-import { MonthChangeInfo } from '../../components/DatePicker';
 import { isMobile } from '../../lib/client';
 
 import { themeConfig } from './config';
@@ -18,6 +17,17 @@ import { Month } from './Month';
 import { styles } from './Calendar.styles';
 import { CalendarDateShape, create, isGreater, isLess } from './CalendarDateShape';
 
+export enum CalendarScrollDirection {
+  Down = 1,
+  Up = -1,
+}
+
+export interface CalendarMonthChangeInfo {
+  month: number;
+  year: number;
+  scrollDirection: CalendarScrollDirection;
+}
+
 export interface CalendarProps {
   initialMonth?: number;
   initialYear?: number;
@@ -26,8 +36,8 @@ export interface CalendarProps {
   maxDate?: CalendarDateShape;
   minDate?: CalendarDateShape;
   isHoliday?: (day: CalendarDateShape & { isWeekend: boolean }) => boolean;
-  renderItem?: (date: CalendarDateShape) => React.ReactNode | number;
-  onMonthChange?: (changeInfo: MonthChangeInfo) => void;
+  renderDay?: (date: CalendarDateShape) => React.ReactNode;
+  onMonthChange?: (changeInfo: CalendarMonthChangeInfo) => void;
 }
 
 export interface CalendarState {
@@ -270,7 +280,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
         onDateClick={this.props.onSelect}
         onMonthYearChange={this.handleMonthYearChange}
         isHoliday={this.props.isHoliday}
-        renderItem={this.props.renderItem}
+        renderDay={this.props.renderDay}
       />
     );
   }
@@ -395,7 +405,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
       .filter(([top, month]) => CalendarUtils.isMonthVisible(top, month, this.theme));
   }
 
-  private monthsChangeHandle(handler: (changeInfo: MonthChangeInfo) => void, visibleMonths: MonthViewModel[]): void {
+  private monthsChangeHandle(
+    handler: (changeInfo: CalendarMonthChangeInfo) => void,
+    visibleMonths: MonthViewModel[],
+  ): void {
     const currentMonth = visibleMonths[0];
     const changeInfo = {
       month: currentMonth.month,

--- a/packages/react-ui/internal/Calendar/DayCellView.styles.ts
+++ b/packages/react-ui/internal/Calendar/DayCellView.styles.ts
@@ -16,10 +16,10 @@ export const styles = memoizeStyle({
       user-select: none;
       position: relative;
 
-      width: ${t.calendarCellSize};
-      height: ${t.calendarCellSize};
-      line-height: ${parseInt(t.calendarCellSize) - 2}px;
-      border-radius: 50%;
+      width: ${t.calendarCellWidth};
+      height: ${t.calendarCellHeight};
+      line-height: ${t.calendarCellLineHeight};
+      border-radius: ${t.calendarCellBorderRadius};
 
       &:hover {
         background-color: ${t.calendarCellHoverBgColor};

--- a/packages/react-ui/internal/Calendar/DayCellView.tsx
+++ b/packages/react-ui/internal/Calendar/DayCellView.tsx
@@ -15,10 +15,11 @@ interface DayCellViewProps {
   maxDate?: CDS.CalendarDateShape;
   onDateClick?: (day: CDS.CalendarDateShape) => void;
   isWeekend?: boolean;
+  renderItem: (date: CDS.CalendarDateShape) => React.ReactNode | number;
 }
 
 export function DayCellView(props: DayCellViewProps) {
-  const { date, minDate, maxDate, today, value, isWeekend, onDateClick } = props;
+  const { date, minDate, maxDate, today, value, isWeekend, onDateClick, renderItem } = props;
   const theme = useContext(ThemeContext);
 
   const handleClick = () => {
@@ -38,7 +39,7 @@ export function DayCellView(props: DayCellViewProps) {
       })}
       onClick={handleClick}
     >
-      {date.date}
+      {renderItem(date)}
     </button>
   );
 }

--- a/packages/react-ui/internal/Calendar/Month.tsx
+++ b/packages/react-ui/internal/Calendar/Month.tsx
@@ -23,6 +23,7 @@ interface MonthProps {
   onDateClick?: (date: CDS.CalendarDateShape) => void;
   onMonthYearChange: (month: number, year: number) => void;
   isHoliday?: (day: CDS.CalendarDateShape & { isWeekend: boolean }) => boolean;
+  renderItem?: (date: CDS.CalendarDateShape) => React.ReactNode | number;
 }
 
 export class Month extends React.Component<MonthProps> {
@@ -99,6 +100,7 @@ export class Month extends React.Component<MonthProps> {
         value={this.props.value}
         onDateClick={this.props.onDateClick}
         isHoliday={this.props.isHoliday}
+        renderItem={this.props.renderItem}
       />
     );
   }
@@ -138,6 +140,7 @@ interface MonthDayGridProps {
   value?: Nullable<CDS.CalendarDateShape>;
   onDateClick?: (x0: CDS.CalendarDateShape) => void;
   isHoliday: (day: CDS.CalendarDateShape & { isWeekend: boolean }) => boolean;
+  renderItem: (date: CDS.CalendarDateShape) => React.ReactNode | number;
 }
 
 class MonthDayGrid extends React.Component<MonthDayGridProps> {
@@ -145,6 +148,7 @@ class MonthDayGrid extends React.Component<MonthDayGridProps> {
 
   public static defaultProps = {
     isHoliday: (day: CDS.CalendarDateShape & { isWeekend: boolean }) => day.isWeekend,
+    renderItem: (date: CDS.CalendarDateShape) => date.date,
   };
 
   public shouldComponentUpdate(nextProps: MonthDayGridProps) {
@@ -179,7 +183,7 @@ class MonthDayGrid extends React.Component<MonthDayGridProps> {
       <div>
         <div
           style={{
-            width: this.props.offset * themeConfig(this.theme).DAY_SIZE,
+            width: this.props.offset * themeConfig(this.theme).DAY_WIDTH,
             display: 'inline-block',
           }}
         />
@@ -196,6 +200,7 @@ class MonthDayGrid extends React.Component<MonthDayGridProps> {
               value={this.props.value}
               isWeekend={isWeekend}
               onDateClick={this.props.onDateClick}
+              renderItem={this.props.renderItem}
             />
           );
         })}

--- a/packages/react-ui/internal/Calendar/Month.tsx
+++ b/packages/react-ui/internal/Calendar/Month.tsx
@@ -23,7 +23,7 @@ interface MonthProps {
   onDateClick?: (date: CDS.CalendarDateShape) => void;
   onMonthYearChange: (month: number, year: number) => void;
   isHoliday?: (day: CDS.CalendarDateShape & { isWeekend: boolean }) => boolean;
-  renderItem?: (date: CDS.CalendarDateShape) => React.ReactNode | number;
+  renderDay?: (date: CDS.CalendarDateShape) => React.ReactNode;
 }
 
 export class Month extends React.Component<MonthProps> {
@@ -100,7 +100,7 @@ export class Month extends React.Component<MonthProps> {
         value={this.props.value}
         onDateClick={this.props.onDateClick}
         isHoliday={this.props.isHoliday}
-        renderItem={this.props.renderItem}
+        renderItem={this.props.renderDay}
       />
     );
   }
@@ -140,7 +140,7 @@ interface MonthDayGridProps {
   value?: Nullable<CDS.CalendarDateShape>;
   onDateClick?: (x0: CDS.CalendarDateShape) => void;
   isHoliday: (day: CDS.CalendarDateShape & { isWeekend: boolean }) => boolean;
-  renderItem: (date: CDS.CalendarDateShape) => React.ReactNode | number;
+  renderItem: (date: CDS.CalendarDateShape) => React.ReactNode;
 }
 
 class MonthDayGrid extends React.Component<MonthDayGridProps> {

--- a/packages/react-ui/internal/Calendar/MonthView.styles.ts
+++ b/packages/react-ui/internal/Calendar/MonthView.styles.ts
@@ -21,7 +21,7 @@ export const styles = memoizeStyle({
   },
 
   month(t: Theme) {
-    const width = parseInt(t.calendarCellSize) * 7;
+    const width = parseInt(t.calendarCellWidth) * 7;
     return css`
       position: absolute;
       width: ${width}px;

--- a/packages/react-ui/internal/Calendar/MonthViewModel.ts
+++ b/packages/react-ui/internal/Calendar/MonthViewModel.ts
@@ -24,8 +24,8 @@ export class MonthViewModel {
   public isFirstInYear: boolean;
 
   public getHeight(theme: Theme): number {
-    const { DAY_SIZE, MONTH_TITLE_OFFSET_HEIGHT, MONTH_BOTTOM_MARGIN } = themeConfig(theme);
-    return getMonthHeight(this.daysCount, this.offset, DAY_SIZE, MONTH_TITLE_OFFSET_HEIGHT, MONTH_BOTTOM_MARGIN);
+    const { DAY_HEIGHT, MONTH_TITLE_OFFSET_HEIGHT, MONTH_BOTTOM_MARGIN } = themeConfig(theme);
+    return getMonthHeight(this.daysCount, this.offset, DAY_HEIGHT, MONTH_TITLE_OFFSET_HEIGHT, MONTH_BOTTOM_MARGIN);
   }
 
   private constructor(month: number, year: number) {

--- a/packages/react-ui/internal/Calendar/__stories__/Calendar.stories.tsx
+++ b/packages/react-ui/internal/Calendar/__stories__/Calendar.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Education from '@skbkontur/react-icons/Education';
 
 import { InternalDateTransformer } from '../../../lib/date/InternalDateTransformer';
 import { Nullable } from '../../../typings/utility-types';
@@ -6,6 +7,9 @@ import { Button } from '../../../components/Button';
 import { Gapped } from '../../../components/Gapped';
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { Calendar } from '../Calendar';
+import { CalendarDateShape } from '../CalendarDateShape';
+import { ThemeContext } from '../../../lib/theming/ThemeContext';
+import { ThemeFactory } from '../../../lib/theming/ThemeFactory';
 
 export default { title: 'Calendar', parameters: { creevey: { skip: [true] } } };
 
@@ -47,6 +51,21 @@ export const CalendarWithHolidays = () => {
 };
 CalendarWithHolidays.storyName = 'Calendar with holidays';
 
+export const CalendarWithCustomDates = () => {
+  const MyTheme = ThemeFactory.create({
+    calendarCellBorderRadius: '32px',
+    calendarCellHeight: '42px',
+    calendarCellLineHeight: '16px',
+  });
+
+  return (
+    <ThemeContext.Provider value={MyTheme}>
+      <Calendar renderItem={(date) => <CustomDayItem date={date} />} />
+    </ThemeContext.Provider>
+  );
+};
+CalendarWithCustomDates.storyName = 'Calendar with custom dates';
+
 const initialDate = { year: 2018, month: 0, date: 1 };
 const datesToScroll = [
   { year: 2017, month: 5, date: 1 },
@@ -84,3 +103,14 @@ class CalendarWithButtons extends React.Component {
     );
   }
 }
+
+const CustomDayItem: React.FC<{ date: CalendarDateShape }> = ({ date }) => {
+  const isEven = (num: number): boolean => num % 2 === 0;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <span style={{ flexGrow: 1, paddingTop: '4px' }}>{date.date}</span>
+      <div style={{ flexGrow: 1, minHeight: '16px' }}>{isEven(date.date) && <Education />}</div>
+    </div>
+  );
+};

--- a/packages/react-ui/internal/Calendar/__stories__/Calendar.stories.tsx
+++ b/packages/react-ui/internal/Calendar/__stories__/Calendar.stories.tsx
@@ -60,7 +60,7 @@ export const CalendarWithCustomDates = () => {
 
   return (
     <ThemeContext.Provider value={MyTheme}>
-      <Calendar renderItem={(date) => <CustomDayItem date={date} />} />
+      <Calendar renderDay={(date) => <CustomDayItem date={date} />} />
     </ThemeContext.Provider>
   );
 };

--- a/packages/react-ui/internal/Calendar/config.ts
+++ b/packages/react-ui/internal/Calendar/config.ts
@@ -7,7 +7,8 @@ const getConfig = memo(
     monthTitlePaddingTop: string,
     monthTitlePaddingBottom: string,
     monthTitleMarginBottom: string,
-    cellSize: string,
+    cellWidth: string,
+    cellHeight: string,
     wrapperHeight: string,
     monthMarginBottom: string,
     maxMonthsToAppendOnScroll: string,
@@ -15,7 +16,8 @@ const getConfig = memo(
     const monthTitleHeight =
       parseInt(monthTitleLineHeight) + parseInt(monthTitlePaddingTop) + parseInt(monthTitlePaddingBottom);
     return {
-      DAY_SIZE: parseInt(cellSize),
+      DAY_WIDTH: parseInt(cellWidth),
+      DAY_HEIGHT: parseInt(cellHeight),
       MONTH_TITLE_HEIGHT: monthTitleHeight,
       MONTH_TITLE_OFFSET_HEIGHT: monthTitleHeight + parseInt(monthTitleMarginBottom) + 1, // + 1px separator line
       WRAPPER_HEIGHT: parseInt(wrapperHeight),
@@ -31,7 +33,8 @@ export const themeConfig = (t: Theme) =>
     t.calendarMonthTitlePaddingTop,
     t.calendarMonthTitlePaddingBottom,
     t.calendarMonthTitleMarginBottom,
-    t.calendarCellSize,
+    t.calendarCellWidth,
+    t.calendarCellHeight,
     t.calendarWrapperHeight,
     t.calendarMonthMarginBottom,
     t.calendarMaxMonthsToAppendOnScroll,

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -678,9 +678,12 @@ export class DefaultTheme {
   public static calendarCellActiveHoverColor = 'white';
   public static calendarCellWeekendColor = '#f00';
   public static calendarCellTodayBorder = '1px solid #8b8b8b';
+  public static calendarCellBorderRadius = '50%';
   public static calendarCellSelectedBgColor = '#e9e9e9';
   public static calendarCellSelectedFontColor = 'inherit';
-  public static calendarCellSize = '30px';
+  public static calendarCellHeight = '30px';
+  public static calendarCellWidth = '30px';
+  public static calendarCellLineHeight = `${parseInt(DefaultTheme.calendarCellHeight) - 2}px`;
   public static calendarMonthHeaderStickedBgColor = 'white';
   public static calendarMonthTitleBorderBottomColor = '#dfdede';
   public static get calendarCellHoverBgColor() {

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -681,9 +681,16 @@ export class DefaultTheme {
   public static calendarCellBorderRadius = '50%';
   public static calendarCellSelectedBgColor = '#e9e9e9';
   public static calendarCellSelectedFontColor = 'inherit';
-  public static calendarCellHeight = '30px';
-  public static calendarCellWidth = '30px';
-  public static calendarCellLineHeight = `${parseInt(DefaultTheme.calendarCellHeight) - 2}px`;
+  public static calendarCellSize = '30px'; // deprecated
+  public static get calendarCellHeight() {
+    return this.calendarCellSize;
+  }
+  public static get calendarCellWidth() {
+    return this.calendarCellSize;
+  }
+  public static get calendarCellLineHeight() {
+    return `${parseInt(this.calendarCellHeight) - 2}px`;
+  }
   public static calendarMonthHeaderStickedBgColor = 'white';
   public static calendarMonthTitleBorderBottomColor = '#dfdede';
   public static get calendarCellHoverBgColor() {

--- a/packages/react-ui/internal/themes/Theme8px.ts
+++ b/packages/react-ui/internal/themes/Theme8px.ts
@@ -437,7 +437,8 @@ export class Theme8px extends (class {} as typeof DefaultThemeInternal) {
   public static switcherButtonPaddingXLarge = '15px';
   //#endregion
   //#region Calendar
-  public static calendarCellSize = '32px';
+  public static calendarCellHeight = '32px';
+  public static calendarCellWidth = '32px';
   public static calendarPaddingX = '18px';
   public static calendarMonthTitleMarginBottom = '6px';
   public static calendarMonthTitleLineHeight = '20px';


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
В рамках проекта Контур.Продажи (как и в других проектах) появилась потребность в разрезе месяца\даты показывать дополнительную информацию вместе с датой в календаре.
На примере проекта Контур.Продажи: пользователю нужно показывать кол-во запланированных звонков в разрезе даты. Более подробно [проблема описана здесь](https://yt.skbkontur.ru/issue/KS-3821/Kalendar-5.-Pri-planirovanii-sobytiya-otobrazhat-Ispolnitelyu-informaciyu-o-kolichestve-sobytij-na-datu-v-kartochke-sdelki).
<!-- Подробно опиши решаемую проблему. -->

## Решение
Было принято решение использовать `DatePicker ` для решения задачи и внести некоторые доработки в компоненты.

Что сделано:
1. Добавлен пропс `renderItem`, который рендерит кастомный элемент даты месяца. Если такой пропс не передан, то рендерится число месяца.
2. Добавлен пропс `onMonthChange`, который возвращает первый отображаемый месяц и год при изменении месяца при скролле или через селект, а также при изменении года.
3. Выполнен небольшой рефакторинг некоторых методов для унификации их работы, а также стилей для расширения возможности задать собственные стили ячейкам дат через контекст.
4. Добавлено описание работы пропса `renderItem` и тесты.

Трудности:
Не получилось локально запустить скриншотные тесты, также есть проблемы при прогоне селениум тестов в TC и там же скриншотных тестов для IE. Договорились, что пока запустим процесс ревью без учета этих моментов.
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки
close [IF-818](https://yt.skbkontur.ru/issue/IF-818)
close [IF-949](https://yt.skbkontur.ru/issue/IF-949)
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

6. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ✅ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

7. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

8. Прочее
  ⬜ все тесты и линтеры на CI проходят (проходят не все тесты, обсудили лично с Егором Погадаевым)
  ⬜ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
