### PR TITLE
chore(TokenInput): add check for empty token on paste

### DIFF
--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -637,16 +637,14 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     if (this.type === TokenInputType.WithReference || !event.clipboardData) {
       return;
     }
-    let paste = event.clipboardData.getData('text');
+    const paste = event.clipboardData.getData('text');
     const { delimiters, selectedItems, valueToItem, onValueChange } = this.getProps();
     if (delimiters.some((delimiter) => paste.includes(delimiter))) {
       event.preventDefault();
       event.stopPropagation();
-      for (const delimiter of delimiters) {
-        paste = paste.split(delimiter).join(delimiters[0]);
-      }
-      const tokens = paste.split(delimiters[0]);
+      const tokens = paste.trim().split(new RegExp(`[${[',', ' '].join('')}]+`));
       const items = tokens
+        .filter(Boolean)
         .map((token) => valueToItem(token))
         .filter((item) => item && !this.hasValueInItems(selectedItems, item));
       const newItems = selectedItems.concat(items);

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -648,7 +648,7 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       const tokens = paste.split(delimiters[0]);
       const items = tokens
         .map((token) => valueToItem(token))
-        .filter((item) => !this.hasValueInItems(selectedItems, item));
+        .filter((item) => item && !this.hasValueInItems(selectedItems, item));
       const newItems = selectedItems.concat(items);
       onValueChange(newItems);
 

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -642,7 +642,7 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     if (delimiters.some((delimiter) => paste.includes(delimiter))) {
       event.preventDefault();
       event.stopPropagation();
-      const tokens = paste.trim().split(new RegExp(`[${[',', ' '].join('')}]+`));
+      const tokens = paste.trim().split(new RegExp(`[${delimiters.join('')}]+`));
       const items = tokens
         .filter(Boolean)
         .map((token) => valueToItem(token))


### PR DESCRIPTION
## Проблема

Если с помощью `ctrl+v` вставить строку: `'токен, токен'`, то `TokenInput` добавляет пустой токен посередине. 
Причина в том, что и запятая и пробел являются разделителями

## Решение

Решили добавить проверку на пустой токен

## Ссылки

fix IF-1097

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
