### PR TITLE
fix(Paging): global styles may cause circles to shrink

### DIFF
--- a/packages/react-ui/components/Paging/Paging.styles.ts
+++ b/packages/react-ui/components/Paging/Paging.styles.ts
@@ -82,6 +82,7 @@ export const styles = memoizeStyle({
 
   pageLink(t: Theme) {
     return css`
+      box-sizing: content-box;
       border-radius: ${t.pagingPageLinkBorderRadius};
       color: ${t.pagingForwardLinkColor};
       cursor: pointer;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

При задании глобального стиля `box-sizing: border-box` (с помощью универсального селектора `*`) кружки `Paging`'а сжимаются в колбаски

![image](https://user-images.githubusercontent.com/48599460/227456576-ca31aa0c-ecbf-4b49-821c-f35fb54f1b19.png)


[Песочница](https://stackblitz.com/edit/react-c8cs7g?file=package.json,src%2FApp.js,src%2Fstyle.css) с воспроизведением бага

## Решение

Задал стиль `box-sizing: content-box` для кружков, чтобы глобальные стили не переписывали это значение 

P.S.
Нормальные тесты на это поведение написать не получается в голову приходят только костыльные варианты, поэтому опустил их

## Ссылки

IF-1109

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
