### PR TITLE
fix(Popup): support multiple mount/unmount cycles (React18 Dev StrictMode)

### DIFF
--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -222,12 +222,17 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   private isMobileLayout!: boolean;
   private setRootNode!: TSetRootNode;
   private refForTransition = React.createRef<HTMLDivElement>();
+  private hasAnchorElementListeners = false;
 
   public anchorElement: Nullable<Element> = null;
 
   public componentDidMount() {
     this.updateLocation();
     this.layoutEventsToken = LayoutEvents.addListener(this.handleLayoutEvent);
+
+    if (!this.hasAnchorElementListeners) {
+      this.addEventListeners(this.anchorElement);
+    }
   }
 
   public static getDerivedStateFromProps(props: Readonly<PopupProps>, state: PopupState) {
@@ -266,7 +271,9 @@ export class Popup extends React.Component<PopupProps, PopupState> {
 
   public componentWillUnmount() {
     this.cancelDelayedUpdateLocation();
-    this.removeEventListeners(this.anchorElement);
+    if (this.hasAnchorElementListeners) {
+      this.removeEventListeners(this.anchorElement);
+    }
     if (this.layoutEventsToken) {
       this.layoutEventsToken.remove();
       this.layoutEventsToken = null;
@@ -361,6 +368,8 @@ export class Popup extends React.Component<PopupProps, PopupState> {
       element.addEventListener('click', this.handleClick);
       element.addEventListener('focusin', this.handleFocus as EventListener);
       element.addEventListener('focusout', this.handleBlur as EventListener);
+
+      this.hasAnchorElementListeners = true;
     }
   }
 
@@ -374,6 +383,8 @@ export class Popup extends React.Component<PopupProps, PopupState> {
       element.removeEventListener('click', this.handleClick);
       element.removeEventListener('focusin', this.handleFocus as EventListener);
       element.removeEventListener('focusout', this.handleBlur as EventListener);
+
+      this.hasAnchorElementListeners = false;
     }
   }
 


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В dev-режиме React 18 с использованием StrictMode тултипы и хинты не работают должным образом. Подробности в задаче.

Дело в том, что React в таком режиме эмулирует двойной mount/unmount, лишний раз вызывая соответствующие методы жизненного цикла компонентов. Но в Popup, при размонтировании, в том числе при фейковом, каждый раз удаляются слушатели событий на `anchorElement`. А добавляются они только при настоящем монтировании - внутри рендера или ref. Т.е. проблема в отсутствии нужных слушателей событий после нескольких циклов mount/unmount. 

По сути компонент не устойчив к многократному монтированию и размонтированию, которые в будущем [станут нормой](https://react.dev/blog/2022/03/29/react-v18#new-strict-mode-behaviors).

<!-- Подробно опиши решаемую проблему. -->

## Решение

Отслеживать наличие слушателей после монтирования и добавлять их в случае отсутствия. 

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-1081, [песочница с проблемой](https://codesandbox.io/s/hint-tooltip-popup-react18-strictmode-p9wcge), [песочница с фиксом](https://codesandbox.io/s/hint-tooltip-popup-react18-strictmode-forked-b2xu7e), `@skbkontur/react-ui@0.0.0-2dd5039746`

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
