### PR TITLE
fix(Modal,SidePage): use safety `globalThat` instead of `global`

### DIFF
--- a/packages/react-ui/lib/ModalStack.ts
+++ b/packages/react-ui/lib/ModalStack.ts
@@ -4,6 +4,8 @@ import EventEmitter from 'eventemitter3';
 import { SidePageProps } from '../components/SidePage';
 import { ModalProps } from '../components/Modal';
 
+import { globalThat } from './SSRSafe';
+
 interface StackInfo {
   emitter: EventEmitter;
   mounted: React.Component[];
@@ -66,7 +68,7 @@ export class ModalStack {
   }
 
   private static getStackInfo(): StackInfo {
-    const globalWithStack = global as GlobalWithStackInfo;
+    const globalWithStack = globalThat as GlobalWithStackInfo;
     return (
       globalWithStack.__ReactUIStackInfo ||
       (globalWithStack.__ReactUIStackInfo = {

--- a/packages/react-ui/lib/net/fetch.ts
+++ b/packages/react-ui/lib/net/fetch.ts
@@ -1,3 +1,5 @@
+import { globalThat } from '../SSRSafe';
+
 interface ApiResponseType {
   ok: boolean;
   status: number;
@@ -34,9 +36,7 @@ export function fetch(uri: string, options: { method?: 'GET' | 'POST'; body?: st
 }
 
 function createXHR() {
-  // @ts-expect-error: XDomainRequest is IE-specific API, therefore it was removed from `lib.d.ts`. See: https://github.com/Microsoft/TypeScript/issues/2927.
-  if (global.XDomainRequest) {
-    // @ts-expect-error: Read the comment above.
+  if ('XDomainRequest' in globalThat) {
     return new XDomainRequest();
   }
   return new XMLHttpRequest();

--- a/packages/react-ui/typings/global.d.ts
+++ b/packages/react-ui/typings/global.d.ts
@@ -4,3 +4,7 @@ declare interface Window {
 }
 
 declare var __RetailUiZIndexes: number[];
+
+// XDomainRequest is IE-specific API, therefore it was removed from `lib.d.ts`
+// See: https://github.com/Microsoft/TypeScript/issues/2927
+declare var XDomainRequest: typeof XMLHttpRequest;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Хэлпер `ModalStack` напрямую обращается к переменной `global`, которой по-умолчанию нет в глобальной области браузеров. Это может ломать компоненты `<Modal>` и `<SidePage>`, которые используют этот хэпер.


## Решение

Заменить прямое обращение к `global` на безопасную переменную `globalThat`, которую мы сами объявляем.
В зависимости от окружения она будет ссылаться на `window` в браузерах, или на `global` в Node.js.

## Ссылки

Fix `IF-1150`

Демка с проблемой
https://stackblitz.com/edit/vitejs-vite-4kqgqj?file=src%2FApp.tsx,vite.config.ts&terminal=dev

Демка с исправлением
https://stackblitz.com/edit/vitejs-vite-9z3nbb?file=src%2FApp.tsx,package.json&terminal=dev


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
