### PR TITLE
feat(DropdownMenu, TooltipMenu, Kebab): Добавил возможность выключать автоматическое добавление отступа пунктам меню

### DIFF
--- a/packages/react-ui/components/DropdownMenu/DropdownMenu.md
+++ b/packages/react-ui/components/DropdownMenu/DropdownMenu.md
@@ -113,6 +113,34 @@ import { Button, MenuHeader, MenuItem, MenuSeparator } from '@skbkontur/react-ui
 </DropdownMenu>;
 ```
 
+С иконками и включенным по-умолчанию автоматическим выравниванием текста.
+
+```jsx harmony
+import { Button, MenuHeader, MenuItem, MenuSeparator, DropdownMenu } from '@skbkontur/react-ui';
+import OkIcon from '@skbkontur/react-icons/Ok';
+
+<DropdownMenu caption={<Button use="primary">Открыть меню</Button>}>
+  <MenuHeader>MenuHeader</MenuHeader>
+  <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+  <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+  <MenuItem>MenuItem3</MenuItem>
+</DropdownMenu>;
+```
+
+С иконками и отключенным автоматическим выравниванием текста.
+
+```jsx harmony
+import { Button, MenuHeader, MenuItem, MenuSeparator, DropdownMenu } from '@skbkontur/react-ui';
+import OkIcon from '@skbkontur/react-icons/Ok';
+
+<DropdownMenu caption={<Button use="primary">Открыть меню</Button>} enableTextAlignment={false}>
+  <MenuHeader>MenuHeader</MenuHeader>
+  <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+  <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+  <MenuItem>MenuItem3</MenuItem>
+</DropdownMenu>
+```
+
 Меню с отключенной анимацией.
 
 ```jsx harmony

--- a/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
@@ -10,7 +10,9 @@ import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 
-export interface DropdownMenuProps extends CommonProps, Pick<PopupMenuProps, 'onOpen' | 'onClose'> {
+export interface DropdownMenuProps
+  extends CommonProps,
+    Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'preventIconPadding'> {
   /** Максимальная высота меню */
   menuMaxHeight?: React.CSSProperties['maxWidth'];
   /** Ширина меню */
@@ -114,6 +116,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
           caption={this.props.caption}
           menuMaxHeight={this.props.menuMaxHeight}
           menuWidth={this.props.menuWidth}
+          preventIconPadding={this.props.preventIconPadding}
           popupHasPin={false}
           positions={positions}
           disableAnimations={disableAnimations}

--- a/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
@@ -12,7 +12,7 @@ import { createPropsGetter } from '../../lib/createPropsGetter';
 
 export interface DropdownMenuProps
   extends CommonProps,
-    Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'preventIconPadding'> {
+    Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'enableTextAlignment'> {
   /** Максимальная высота меню */
   menuMaxHeight?: React.CSSProperties['maxWidth'];
   /** Ширина меню */
@@ -108,7 +108,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
     if (!this.props.caption) {
       return null;
     }
-    const { positions, disableAnimations } = this.getProps();
+    const { positions, disableAnimations, enableTextAlignment } = this.getProps();
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <PopupMenu
@@ -116,7 +116,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
           caption={this.props.caption}
           menuMaxHeight={this.props.menuMaxHeight}
           menuWidth={this.props.menuWidth}
-          preventIconPadding={this.props.preventIconPadding}
+          enableTextAlignment={enableTextAlignment}
           popupHasPin={false}
           positions={positions}
           disableAnimations={disableAnimations}

--- a/packages/react-ui/components/DropdownMenu/__stories__/DropdownMenu.stories.tsx
+++ b/packages/react-ui/components/DropdownMenu/__stories__/DropdownMenu.stories.tsx
@@ -15,6 +15,7 @@ import { Toast } from '../../Toast';
 import { Input } from '../../Input';
 import { Gapped } from '../../Gapped';
 import { delay } from '../../../lib/utils';
+import { OkIcon } from '../../../internal/icons/16px';
 
 export default {
   title: 'DropdownMenu',
@@ -490,3 +491,25 @@ class DropdownWithScrollStateChange extends React.Component<DropdownMenuProps> {
     this.setState({ value: '' });
   };
 }
+
+export const WithItemsAndIcons = () => (
+  <DropdownMenu caption={<Button>Click me</Button>}>
+    <MenuHeader>MenuHeader</MenuHeader>
+    <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+    <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+    <MenuItem>MenuItem3</MenuItem>
+  </DropdownMenu>
+);
+
+export const WithItemsAndIconsWithoutTextAlignment = () => (
+  <DropdownMenu caption={<Button>Click me</Button>} enableTextAlignment={false}>
+    <MenuHeader>MenuHeader</MenuHeader>
+    <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+    <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+    <MenuItem>MenuItem3</MenuItem>
+  </DropdownMenu>
+);
+
+WithItemsAndIconsWithoutTextAlignment.parameters = {
+  creevey: { skip: { 'themes dont affect logic': { in: /^(?!\bchrome\b)/ } } },
+};

--- a/packages/react-ui/components/Kebab/Kebab.md
+++ b/packages/react-ui/components/Kebab/Kebab.md
@@ -160,6 +160,34 @@ let Card = ({ title }) => (
 <Card title="С кастомным действием" />
 ```
 
+С иконками и включенным по-умолчанию автоматическим выравниванием текста.
+
+```jsx harmony
+import { Button, MenuHeader, MenuItem, MenuSeparator, Kebab } from '@skbkontur/react-ui';
+import OkIcon from '@skbkontur/react-icons/Ok';
+
+<Kebab>
+  <MenuHeader>MenuHeader</MenuHeader>
+  <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+  <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+  <MenuItem>MenuItem3</MenuItem>
+</Kebab>;
+```
+
+С иконками и отключенным автоматическим выравниванием текста.
+
+```jsx harmony
+import { Button, MenuHeader, MenuItem, MenuSeparator, Kebab } from '@skbkontur/react-ui';
+import OkIcon from '@skbkontur/react-icons/Ok';
+
+<Kebab enableTextAlignment={false}>
+  <MenuHeader>MenuHeader</MenuHeader>
+  <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+  <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+  <MenuItem>MenuItem3</MenuItem>
+</Kebab>
+```
+
 Отключенное кебаб-меню.
 
 ```jsx harmony

--- a/packages/react-ui/components/Kebab/Kebab.tsx
+++ b/packages/react-ui/components/Kebab/Kebab.tsx
@@ -19,7 +19,7 @@ import { createPropsGetter } from '../../lib/createPropsGetter';
 
 import { styles } from './Kebab.styles';
 
-export interface KebabProps extends CommonProps, Pick<PopupMenuProps, 'onOpen' | 'onClose'> {
+export interface KebabProps extends CommonProps, Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'preventIconPadding'> {
   disabled?: boolean;
   size?: 'small' | 'medium' | 'large';
   /**
@@ -126,6 +126,7 @@ export class Kebab extends React.Component<KebabProps, KebabState> {
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <PopupMenu
           popupHasPin
+          preventIconPadding={this.props.preventIconPadding}
           positions={positions}
           onChangeMenuState={this.handleChangeMenuState}
           caption={this.renderCaption}

--- a/packages/react-ui/components/Kebab/Kebab.tsx
+++ b/packages/react-ui/components/Kebab/Kebab.tsx
@@ -19,7 +19,7 @@ import { createPropsGetter } from '../../lib/createPropsGetter';
 
 import { styles } from './Kebab.styles';
 
-export interface KebabProps extends CommonProps, Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'preventIconPadding'> {
+export interface KebabProps extends CommonProps, Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'enableTextAlignment'> {
   disabled?: boolean;
   size?: 'small' | 'medium' | 'large';
   /**
@@ -121,12 +121,12 @@ export class Kebab extends React.Component<KebabProps, KebabState> {
 
   private renderMain() {
     const { disabled } = this.props;
-    const { positions, disableAnimations, onOpen, onClose } = this.getProps();
+    const { positions, disableAnimations, enableTextAlignment, onOpen, onClose } = this.getProps();
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <PopupMenu
           popupHasPin
-          preventIconPadding={this.props.preventIconPadding}
+          enableTextAlignment={enableTextAlignment}
           positions={positions}
           onChangeMenuState={this.handleChangeMenuState}
           caption={this.renderCaption}

--- a/packages/react-ui/components/Kebab/__stories__/Kebab.stories.tsx
+++ b/packages/react-ui/components/Kebab/__stories__/Kebab.stories.tsx
@@ -5,6 +5,7 @@ import OkIcon from '@skbkontur/react-icons/Ok';
 import { Meta, Story, CreeveyTests } from '../../../typings/stories';
 import { Kebab } from '../Kebab';
 import { MenuItem } from '../../MenuItem';
+import { MenuHeader } from '../../MenuHeader';
 import { KebabProps } from '..';
 
 import { defaultItemsList, manyItemsList } from './Kebab.items';
@@ -217,3 +218,29 @@ class SomethingWithKebab extends React.Component<SomethingWithKebabProps> {
     );
   }
 }
+
+export const WithItemsAndIcons = () => (
+  <div style={{ width: 200, textAlign: 'center' }}>
+    <Kebab>
+      <MenuHeader>MenuHeader</MenuHeader>
+      <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+      <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+      <MenuItem>MenuItem3</MenuItem>
+    </Kebab>
+  </div>
+);
+
+export const WithItemsAndIconsWithoutTextAlignment = () => (
+  <div style={{ width: 200, textAlign: 'center' }}>
+    <Kebab enableTextAlignment={false}>
+      <MenuHeader>MenuHeader</MenuHeader>
+      <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+      <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+      <MenuItem>MenuItem3</MenuItem>
+    </Kebab>
+  </div>
+);
+
+WithItemsAndIconsWithoutTextAlignment.parameters = {
+  creevey: { skip: { 'themes dont affect logic': { in: /^(?!\bchrome\b)/ } } },
+};

--- a/packages/react-ui/components/TooltipMenu/TooltipMenu.md
+++ b/packages/react-ui/components/TooltipMenu/TooltipMenu.md
@@ -180,6 +180,34 @@ import { Button, MenuHeader, MenuItem, MenuSeparator } from '@skbkontur/react-ui
 </TooltipMenu>;
 ```
 
+С иконками и включенным по-умолчанию автоматическим выравниванием текста.
+
+```jsx harmony
+import { Button, MenuHeader, MenuItem, MenuSeparator, TooltipMenu } from '@skbkontur/react-ui';
+import OkIcon from '@skbkontur/react-icons/Ok';
+
+<TooltipMenu caption={<Button use="primary">Открыть меню</Button>}>
+  <MenuHeader>MenuHeader</MenuHeader>
+  <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+  <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+  <MenuItem>MenuItem3</MenuItem>
+</TooltipMenu>;
+```
+
+С иконками и отключенным автоматическим выравниванием текста.
+
+```jsx harmony
+import { Button, MenuHeader, MenuItem, MenuSeparator, TooltipMenu } from '@skbkontur/react-ui';
+import OkIcon from '@skbkontur/react-icons/Ok';
+
+<TooltipMenu caption={<Button use="primary">Открыть меню</Button>} enableTextAlignment={false}>
+  <MenuHeader>MenuHeader</MenuHeader>
+  <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+  <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+  <MenuItem>MenuItem3</MenuItem>
+</TooltipMenu>
+```
+
 Условный рендер элементов тултип-меню (с сохранением поведения [MenuItem](#/Components/MenuItem)).
 
 ```jsx harmony

--- a/packages/react-ui/components/TooltipMenu/TooltipMenu.tsx
+++ b/packages/react-ui/components/TooltipMenu/TooltipMenu.tsx
@@ -13,7 +13,9 @@ import { createPropsGetter } from '../../lib/createPropsGetter';
 
 export type TooltipMenuChildType = React.ReactElement<MenuItemProps | unknown | MenuHeaderProps>;
 
-export interface TooltipMenuProps extends CommonProps, Pick<PopupMenuProps, 'onOpen' | 'onClose'> {
+export interface TooltipMenuProps
+  extends CommonProps,
+    Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'preventIconPadding'> {
   children?: TooltipMenuChildType | TooltipMenuChildType[];
   /** Максимальная высота меню */
   menuMaxHeight?: number | string;
@@ -124,6 +126,7 @@ export class TooltipMenu extends React.Component<TooltipMenuProps> {
           caption={this.props.caption}
           header={this.props.header}
           footer={this.props.footer}
+          preventIconPadding={this.props.preventIconPadding}
           positions={this.props.positions}
           onOpen={this.props.onOpen}
           onClose={this.props.onClose}

--- a/packages/react-ui/components/TooltipMenu/TooltipMenu.tsx
+++ b/packages/react-ui/components/TooltipMenu/TooltipMenu.tsx
@@ -15,7 +15,7 @@ export type TooltipMenuChildType = React.ReactElement<MenuItemProps | unknown | 
 
 export interface TooltipMenuProps
   extends CommonProps,
-    Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'preventIconPadding'> {
+    Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'enableTextAlignment'> {
   children?: TooltipMenuChildType | TooltipMenuChildType[];
   /** Максимальная высота меню */
   menuMaxHeight?: number | string;
@@ -117,6 +117,8 @@ export class TooltipMenu extends React.Component<TooltipMenuProps> {
       return null;
     }
 
+    const { enableTextAlignment, disableAnimations } = this.getProps();
+
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <PopupMenu
@@ -126,12 +128,12 @@ export class TooltipMenu extends React.Component<TooltipMenuProps> {
           caption={this.props.caption}
           header={this.props.header}
           footer={this.props.footer}
-          preventIconPadding={this.props.preventIconPadding}
+          enableTextAlignment={enableTextAlignment}
           positions={this.props.positions}
           onOpen={this.props.onOpen}
           onClose={this.props.onClose}
           popupHasPin
-          disableAnimations={this.getProps().disableAnimations}
+          disableAnimations={disableAnimations}
         >
           {this.props.children}
         </PopupMenu>

--- a/packages/react-ui/components/TooltipMenu/__stories__/TooltipMenu.stories.tsx
+++ b/packages/react-ui/components/TooltipMenu/__stories__/TooltipMenu.stories.tsx
@@ -202,3 +202,42 @@ export const MenuWithoutAnimations = () => (
 );
 MenuWithoutAnimations.storyName = 'Menu without animations';
 MenuWithoutAnimations.parameters = { creevey: { skip: true } };
+
+export const WithItemsAndIcons = () => (
+  <div style={{ width: 200, textAlign: 'center' }}>
+    <TooltipMenu
+      caption={
+        <span style={{ display: 'inline-block' }} tabIndex={0}>
+          <MenuIcon size={32} />
+        </span>
+      }
+    >
+      <MenuHeader>MenuHeader</MenuHeader>
+      <MenuItem icon={<LightbulbIcon />}>MenuItem1</MenuItem>
+      <MenuItem icon={<LightbulbIcon />}>MenuItem2</MenuItem>
+      <MenuItem>MenuItem3</MenuItem>
+    </TooltipMenu>
+  </div>
+);
+
+export const WithItemsAndIconsWithoutTextAlignment = () => (
+  <div style={{ width: 200, textAlign: 'center' }}>
+    <TooltipMenu
+      caption={
+        <span style={{ display: 'inline-block' }} tabIndex={0}>
+          <MenuIcon size={32} />
+        </span>
+      }
+      enableTextAlignment={false}
+    >
+      <MenuHeader>MenuHeader</MenuHeader>
+      <MenuItem icon={<LightbulbIcon />}>MenuItem1</MenuItem>
+      <MenuItem icon={<LightbulbIcon />}>MenuItem2</MenuItem>
+      <MenuItem>MenuItem3</MenuItem>
+    </TooltipMenu>
+  </div>
+);
+
+WithItemsAndIconsWithoutTextAlignment.parameters = {
+  creevey: { skip: { 'themes dont affect logic': { in: /^(?!\bchrome\b)/ } } },
+};

--- a/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
+++ b/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
@@ -31,6 +31,8 @@ interface MenuProps {
   onItemClick?: (event: React.SyntheticEvent<HTMLElement>) => void;
   width?: number | string;
   preventWindowScroll?: boolean;
+  // Выключает добавление паддинга, пунктам меню без иконок, если у других пунктов меню есть иконка
+  preventIconPadding?: boolean;
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
 
   header?: React.ReactNode;
@@ -119,9 +121,9 @@ export class InternalMenu extends React.PureComponent<MenuProps, MenuState> {
   }
 
   private renderMain() {
-    const enableIconPadding = React.Children.toArray(this.props.children).some(
-      (x) => React.isValidElement(x) && x.props.icon,
-    );
+    const enableIconPadding =
+      !this.props.preventIconPadding &&
+      React.Children.toArray(this.props.children).some((x) => React.isValidElement(x) && x.props.icon);
 
     if (this.isEmpty()) {
       return null;

--- a/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
+++ b/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
@@ -18,8 +18,9 @@ import { ThemeFactory } from '../../lib/theming/ThemeFactory';
 import { styles } from './InternalMenu.styles';
 import { isActiveElement } from './isActiveElement';
 import { addIconPaddingIfPartOfMenu } from './addIconPaddingIfPartOfMenu';
+import { isIconPaddingEnabled } from './isIconPaddingEnabled';
 
-interface MenuProps {
+export interface InternalMenuProps {
   children?: React.ReactNode;
   hasShadow?: boolean;
   /**
@@ -31,8 +32,13 @@ interface MenuProps {
   onItemClick?: (event: React.SyntheticEvent<HTMLElement>) => void;
   width?: number | string;
   preventWindowScroll?: boolean;
-  // Выключает добавление паддинга, пунктам меню без иконок, если у других пунктов меню есть иконка
-  preventIconPadding?: boolean;
+  /**
+   * Выравнивает текст всех пунктов меню относительно друг друга.
+   * Так, если хотя бы у одного пункта меню есть иконка, текст в  остальных пунктах меню будет выровнен относительно пункта меню с иконкой
+   *
+   * @default true
+   */
+  enableTextAlignment?: boolean;
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
 
   header?: React.ReactNode;
@@ -55,19 +61,26 @@ export const InternalMenuDataTids = {
 
 type DefaultProps = Required<
   Pick<
-    MenuProps,
-    'width' | 'maxHeight' | 'hasShadow' | 'preventWindowScroll' | 'cyclicSelection' | 'initialSelectedItemIndex'
+    InternalMenuProps,
+    | 'width'
+    | 'maxHeight'
+    | 'hasShadow'
+    | 'preventWindowScroll'
+    | 'cyclicSelection'
+    | 'initialSelectedItemIndex'
+    | 'enableTextAlignment'
   >
 >;
 
 @rootNode
-export class InternalMenu extends React.PureComponent<MenuProps, MenuState> {
+export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuState> {
   public static __KONTUR_REACT_UI__ = 'InternalMenu';
 
   public static defaultProps: DefaultProps = {
     width: 'auto',
     maxHeight: 300,
     hasShadow: true,
+    enableTextAlignment: true,
     preventWindowScroll: true,
     cyclicSelection: true,
     initialSelectedItemIndex: -1,
@@ -93,7 +106,7 @@ export class InternalMenu extends React.PureComponent<MenuProps, MenuState> {
     this.calculateMaxHeight();
   }
 
-  public componentDidUpdate(prevProps: MenuProps) {
+  public componentDidUpdate(prevProps: InternalMenuProps) {
     if (this.shouldRecalculateMaxHeight(prevProps)) {
       this.calculateMaxHeight();
     }
@@ -121,9 +134,7 @@ export class InternalMenu extends React.PureComponent<MenuProps, MenuState> {
   }
 
   private renderMain() {
-    const enableIconPadding =
-      !this.props.preventIconPadding &&
-      React.Children.toArray(this.props.children).some((x) => React.isValidElement(x) && x.props.icon);
+    const enableIconPadding = isIconPaddingEnabled(this.props.children, this.props.enableTextAlignment);
 
     if (this.isEmpty()) {
       return null;
@@ -247,7 +258,7 @@ export class InternalMenu extends React.PureComponent<MenuProps, MenuState> {
     }
   };
 
-  private shouldRecalculateMaxHeight = (prevProps: MenuProps): boolean => {
+  private shouldRecalculateMaxHeight = (prevProps: InternalMenuProps): boolean => {
     const { header, footer, children } = this.props;
     const maxHeight = this.getProps().maxHeight;
     const prevMaxHeight = prevProps.maxHeight;

--- a/packages/react-ui/internal/InternalMenu/isIconPaddingEnabled.ts
+++ b/packages/react-ui/internal/InternalMenu/isIconPaddingEnabled.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { InternalMenuProps } from './InternalMenu';
+
+export const isIconPaddingEnabled = (
+  children: InternalMenuProps['children'],
+  enableTextAlignment: InternalMenuProps['enableTextAlignment'],
+) =>
+  Boolean(enableTextAlignment && React.Children.toArray(children).some((x) => React.isValidElement(x) && x.props.icon));

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -12,21 +12,19 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { addIconPaddingIfPartOfMenu } from '../InternalMenu/addIconPaddingIfPartOfMenu';
 import { isIE11 } from '../../lib/client';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import { InternalMenuProps } from '../InternalMenu';
+import { isIconPaddingEnabled } from '../InternalMenu/isIconPaddingEnabled';
 
 import { styles } from './Menu.styles';
 import { isActiveElement } from './isActiveElement';
 
-export interface MenuProps {
+export interface MenuProps extends Pick<InternalMenuProps, 'enableTextAlignment'> {
   children: React.ReactNode;
   hasShadow?: boolean;
   maxHeight?: number | string;
   onItemClick?: () => void;
   width?: number | string;
   preventWindowScroll?: boolean;
-  /**
-   * Выключает добавление паддинга, пунктам меню без иконок, если у других пунктов меню есть иконка
-   */
-  preventIconPadding?: boolean;
   /**
    * Отключение кастомного скролла контейнера
    */
@@ -42,7 +40,9 @@ export const MenuDataTids = {
   root: 'Menu__root',
 } as const;
 
-type DefaultProps = Required<Pick<MenuProps, 'align' | 'width' | 'maxHeight' | 'hasShadow' | 'preventWindowScroll'>>;
+type DefaultProps = Required<
+  Pick<MenuProps, 'align' | 'width' | 'maxHeight' | 'hasShadow' | 'preventWindowScroll' | 'enableTextAlignment'>
+>;
 
 @responsiveLayout
 @rootNode
@@ -55,6 +55,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
     maxHeight: 300,
     hasShadow: true,
     preventWindowScroll: true,
+    enableTextAlignment: true,
   };
 
   private getProps = createPropsGetter(Menu.defaultProps);
@@ -162,9 +163,7 @@ export class Menu extends React.Component<MenuProps, MenuState> {
   }
 
   private getChildList = () => {
-    const enableIconPadding =
-      !this.props.preventIconPadding &&
-      React.Children.toArray(this.props.children).some((x) => React.isValidElement(x) && x.props.icon);
+    const enableIconPadding = isIconPaddingEnabled(this.props.children, this.props.enableTextAlignment);
 
     return React.Children.map(this.props.children, (child, index) => {
       if (!child) {

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -24,6 +24,10 @@ export interface MenuProps {
   width?: number | string;
   preventWindowScroll?: boolean;
   /**
+   * Выключает добавление паддинга, пунктам меню без иконок, если у других пунктов меню есть иконка
+   */
+  preventIconPadding?: boolean;
+  /**
    * Отключение кастомного скролла контейнера
    */
   disableScrollContainer?: boolean;
@@ -158,9 +162,9 @@ export class Menu extends React.Component<MenuProps, MenuState> {
   }
 
   private getChildList = () => {
-    const enableIconPadding = React.Children.toArray(this.props.children).some(
-      (x) => React.isValidElement(x) && x.props.icon,
-    );
+    const enableIconPadding =
+      !this.props.preventIconPadding &&
+      React.Children.toArray(this.props.children).some((x) => React.isValidElement(x) && x.props.icon);
 
     return React.Children.map(this.props.children, (child, index) => {
       if (!child) {

--- a/packages/react-ui/internal/Menu/__stories__/Menu.stories.tsx
+++ b/packages/react-ui/internal/Menu/__stories__/Menu.stories.tsx
@@ -37,14 +37,18 @@ export const WithItemsWithIcons = () => (
   </Menu>
 );
 
-export const WithItemsWithIconsPreventIconPadding = () => (
-  <Menu preventIconPadding>
+export const WithItemsWithIconsWithoutTextAlignment = () => (
+  <Menu enableTextAlignment={false}>
     <MenuHeader>MenuHeader</MenuHeader>
     <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
     <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
     <MenuItem>MenuItem3</MenuItem>
   </Menu>
 );
+
+WithItemsWithIconsWithoutTextAlignment.parameters = {
+  creevey: { skip: { 'themes dont affect logic': { in: /^(?!\bchrome\b)/ } } },
+};
 
 export const WithHeader = () => (
   <Menu>

--- a/packages/react-ui/internal/Menu/__stories__/Menu.stories.tsx
+++ b/packages/react-ui/internal/Menu/__stories__/Menu.stories.tsx
@@ -37,6 +37,15 @@ export const WithItemsWithIcons = () => (
   </Menu>
 );
 
+export const WithItemsWithIconsPreventIconPadding = () => (
+  <Menu preventIconPadding>
+    <MenuHeader>MenuHeader</MenuHeader>
+    <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+    <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+    <MenuItem>MenuItem3</MenuItem>
+  </Menu>
+);
+
 export const WithHeader = () => (
   <Menu>
     <MenuHeader>MenuHeader</MenuHeader>

--- a/packages/react-ui/internal/PopupMenu/PopupMenu.tsx
+++ b/packages/react-ui/internal/PopupMenu/PopupMenu.tsx
@@ -46,6 +46,8 @@ export interface PopupMenuProps extends CommonProps {
   header?: React.ReactNode;
   footer?: React.ReactNode;
 
+  /** Выключает добавление паддинга, пунктам меню без иконок, если у других пунктов меню есть иконка */
+  preventIconPadding?: boolean;
   /**  Массив разрешенных положений меню относительно caption'а. */
   positions?: PopupPositionsType[];
   /** Колбэк, вызываемый после открытия/закрытия меню */
@@ -152,6 +154,7 @@ export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
                   maxHeight={this.isMobileLayout ? 'none' : this.props.menuMaxHeight || 'none'}
                   onKeyDown={this.handleKeyDown}
                   onItemClick={this.handleItemSelection}
+                  preventIconPadding={this.props.preventIconPadding}
                   cyclicSelection={false}
                   ref={this.refInternalMenu}
                   initialSelectedItemIndex={this.state.firstItemShouldBeSelected ? 0 : -1}

--- a/packages/react-ui/internal/PopupMenu/PopupMenu.tsx
+++ b/packages/react-ui/internal/PopupMenu/PopupMenu.tsx
@@ -7,7 +7,7 @@ import {
   isKeySpace,
   someKeys,
 } from '../../lib/events/keyboard/identifiers';
-import { InternalMenu } from '../InternalMenu';
+import { InternalMenu, InternalMenuProps } from '../InternalMenu';
 import { Popup, PopupPositionsType } from '../Popup';
 import { RenderLayer } from '../RenderLayer';
 import { Nullable } from '../../typings/utility-types';
@@ -26,7 +26,7 @@ export interface PopupMenuCaptionProps {
   toggleMenu: () => void;
 }
 
-export interface PopupMenuProps extends CommonProps {
+export interface PopupMenuProps extends CommonProps, Pick<InternalMenuProps, 'enableTextAlignment'> {
   children?: React.ReactNode;
   /** Максимальная высота меню */
   menuMaxHeight?: number | string;
@@ -46,8 +46,6 @@ export interface PopupMenuProps extends CommonProps {
   header?: React.ReactNode;
   footer?: React.ReactNode;
 
-  /** Выключает добавление паддинга, пунктам меню без иконок, если у других пунктов меню есть иконка */
-  preventIconPadding?: boolean;
   /**  Массив разрешенных положений меню относительно caption'а. */
   positions?: PopupPositionsType[];
   /** Колбэк, вызываемый после открытия/закрытия меню */
@@ -125,7 +123,7 @@ export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
   private setRootNode!: TSetRootNode;
 
   public render() {
-    const { popupHasPin, disableAnimations } = this.getProps();
+    const { popupHasPin, disableAnimations, enableTextAlignment } = this.getProps();
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <RenderLayer
@@ -154,7 +152,7 @@ export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
                   maxHeight={this.isMobileLayout ? 'none' : this.props.menuMaxHeight || 'none'}
                   onKeyDown={this.handleKeyDown}
                   onItemClick={this.handleItemSelection}
-                  preventIconPadding={this.props.preventIconPadding}
+                  enableTextAlignment={enableTextAlignment}
                   cyclicSelection={false}
                   ref={this.refInternalMenu}
                   initialSelectedItemIndex={this.state.firstItemShouldBeSelected ? 0 : -1}

--- a/packages/react-ui/internal/PopupMenu/__stories__/PopupMenu.stories.tsx
+++ b/packages/react-ui/internal/PopupMenu/__stories__/PopupMenu.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Meta } from '../../../typings/stories';
+import { OkIcon } from '../../icons/16px';
+import { PopupMenu } from '../PopupMenu';
+import { MenuItem } from '../../../components/MenuItem';
+import { MenuHeader } from '../../../components/MenuHeader';
+import { Button } from '../../../components/Button';
+
+export default {
+  title: 'PopupMenu',
+  parameters: { creevey: { captureElement: '#popup_menu-test-container' } },
+  decorators: [
+    (Story) => (
+      <div id="popup_menu-test-container" style={{ padding: 10 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta;
+
+export const WithItems = () => (
+  <PopupMenu caption={<Button>Click me</Button>}>
+    <MenuItem>MenuItem1</MenuItem>
+    <MenuItem>MenuItem2</MenuItem>
+    <MenuItem>MenuItem3</MenuItem>
+  </PopupMenu>
+);
+WithItems.storyName = 'with Items';
+
+export const WithItemsWithIcons = () => (
+  <PopupMenu caption={<Button>Click me</Button>}>
+    <MenuHeader>MenuHeader</MenuHeader>
+    <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+    <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+    <MenuItem>MenuItem3</MenuItem>
+  </PopupMenu>
+);
+
+export const WithItemsWithIconsWithoutTextAlignment = () => (
+  <PopupMenu caption={<Button>Click me</Button>} enableTextAlignment={false}>
+    <MenuHeader>MenuHeader</MenuHeader>
+    <MenuItem icon={<OkIcon />}>MenuItem1</MenuItem>
+    <MenuItem icon={<OkIcon />}>MenuItem2</MenuItem>
+    <MenuItem>MenuItem3</MenuItem>
+  </PopupMenu>
+);
+
+WithItemsWithIconsWithoutTextAlignment.parameters = {
+  creevey: { skip: { 'themes dont affect logic': { in: /^(?!\bchrome\b)/ } } },
+};


### PR DESCRIPTION
## Проблема

Сейчас различные меню автоматически добавляют отступ всем пунктам меню, если хотя бы у одного есть иконка, это не всегда нужно 
## Решение

Добавил возможность выключать это поведение у всего меню


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности — добавил новый кейс в Storybook
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
