### PR TITLE
test(FxInput): remove using enzyme

### DIFF
--- a/packages/react-ui/components/FxInput/__tests__/FxInput-test.tsx
+++ b/packages/react-ui/components/FxInput/__tests__/FxInput-test.tsx
@@ -1,36 +1,27 @@
 import React, { useState } from 'react';
-import { render as renderRTL, screen } from '@testing-library/react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { FxInput, FxInputProps } from '../FxInput';
-import { buildMountAttachTarget, getAttachedTarget } from '../../../lib/__tests__/testUtils';
-
-const render = (
-  props: FxInputProps = {
-    onValueChange: () => {
-      /**/
-    },
-  },
-) => mount<FxInput, FxInputProps>(<FxInput {...props} />, { attachTo: getAttachedTarget() });
+import { FxInput, FxInputDataTids } from '../FxInput';
 
 describe('FxInput', () => {
-  buildMountAttachTarget();
-
   it('render without crash', () => {
-    expect(render).not.toThrow();
+    const onValueChange = jest.fn();
+    render(<FxInput onValueChange={onValueChange} />);
+    expect(screen.getByTestId(FxInputDataTids.root)).toBeInTheDocument();
   });
 
   it('programmatically set focus and blur', () => {
-    const wrapper = render();
-    const input = wrapper.find('input');
+    const onValueChange = jest.fn();
+    const refFxInput = React.createRef<FxInput>();
+    render(<FxInput onValueChange={onValueChange} ref={refFxInput} />);
+    const input = screen.getByRole('textbox');
 
-    wrapper.instance().focus();
+    refFxInput.current?.focus();
+    expect(input).toHaveFocus();
 
-    expect(input.instance()).toHaveFocus();
-
-    wrapper.instance().blur();
-
+    refFxInput.current?.blur();
+    expect(input).not.toHaveFocus();
     expect(document.body).toHaveFocus();
   });
 
@@ -46,7 +37,7 @@ describe('FxInput', () => {
       );
     };
 
-    renderRTL(<Comp />);
+    render(<Comp />);
 
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('12345');


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Повысить покрытие тестами компонент, перевести тесты с использования enzyme на RTL

## Решение

Тесты, которые были на enzyme, переписаны с использованием RTL
Добавлены новые тесты на логику компонента

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
