### PR TITLE
style: change link color

### DIFF
--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -8,8 +8,8 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static bgActive = '#141414';
 
   //#region Link
-  public static linkColor = '#3D3D3D';
-  public static linkHoverColor = '#292929';
+  public static linkColor = '#222222';
+  public static linkHoverColor = '#222222';
   public static linkActiveColor = '#141414';
 
   public static linkSuccessColor = '#477916';


### PR DESCRIPTION

## Проблема

Поменяли цвет текстовых ссылок: Был #3D3D3D, стал: #222222. При наведении был #292929, должен стать тоже: #222222. Подчеркивание берет прозрачность 48% тоже от этого цвета — #222222, при наведении — 100%.

## Решение

Поменял цвет. 

## Ссылки

файл в [фигме](https://www.figma.com/file/newCbSUe899sicnY2Kvd1m/Пул-задач-2022?type=design&node-id=10429%3A73841&t=70ITRQii7Gq6kOok-1) 

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
