### PR TITLE
fix(Button, Input, Kebab): resize icons according to control's size

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -466,6 +466,8 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
       const sizes = getButtonIconSizes(this.theme);
       return React.cloneElement(icon, { size: icon.props.size ?? sizes[this.getProps().size] });
     }
+
+    return icon;
   }
 
   private getSizeClassName() {

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { AriaAttributes } from 'react';
 
-import { isReactUIComponent } from '../../lib/utils';
+import { isKonturIcon, isReactUIComponent } from '../../lib/utils';
 import { isIE11, isEdge, isSafari } from '../../lib/client';
 import { keyListener } from '../../lib/events/keyListener';
 import { Theme, ThemeIn } from '../../lib/theming/Theme';
@@ -16,7 +16,7 @@ import { Spinner } from '../Spinner';
 import { LoadingIcon } from '../../internal/icons2022/LoadingIcon';
 
 import { styles, activeStyles, globalClasses } from './Button.styles';
-import { ButtonIcon } from './ButtonIcon';
+import { ButtonIcon, getButtonIconSizes } from './ButtonIcon';
 import { useButtonArrow } from './ButtonArrow';
 import { getInnerLinkTheme } from './getInnerLinkTheme';
 
@@ -440,7 +440,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
     if (_isTheme2022 && isLink && !loading) {
       captionNode = (
         <ThemeContext.Provider value={getInnerLinkTheme(this.theme)}>
-          <Link focused={isFocused} disabled={disabled} icon={icon} as="span" tabIndex={-1}>
+          <Link focused={isFocused} disabled={disabled} icon={this.renderIcon2022(icon)} as="span" tabIndex={-1}>
             {children}
           </Link>
         </ThemeContext.Provider>
@@ -459,6 +459,13 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
         </span>
       </CommonWrapper>
     );
+  }
+
+  private renderIcon2022(icon: React.ReactElement | undefined) {
+    if (icon && isKonturIcon(icon)) {
+      const sizes = getButtonIconSizes(this.theme);
+      return React.cloneElement(icon, { size: icon.props.size ?? sizes[this.getProps().size] });
+    }
   }
 
   private getSizeClassName() {

--- a/packages/react-ui/components/Button/ButtonIcon.tsx
+++ b/packages/react-ui/components/Button/ButtonIcon.tsx
@@ -1,16 +1,26 @@
 import React, { useContext } from 'react';
 
+import { Theme } from '../../lib/theming/Theme';
+import { isKonturIcon } from '../../lib/utils';
 import { cx } from '../../lib/theming/Emotion';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { ZERO_WIDTH_SPACE } from '../../lib/chars';
 import { LoadingIcon } from '../../internal/icons2022/LoadingIcon';
 
-import { ButtonProps } from './Button';
+import { ButtonProps, ButtonSize } from './Button';
 import { globalClasses, styles } from './Button.styles';
 
 type ButtonIconProps = Pick<ButtonProps, 'size' | 'icon' | 'loading' | 'disabled' | 'use'> & {
   hasChildren: boolean;
+};
+
+export const getButtonIconSizes = (theme: Theme): Record<ButtonSize, number> => {
+  return {
+    small: parseInt(theme.btnIconSizeSmall),
+    medium: parseInt(theme.btnIconSizeMedium),
+    large: parseInt(theme.btnIconSizeLarge),
+  };
 };
 
 export const ButtonIcon: React.FunctionComponent<ButtonIconProps> = ({
@@ -43,6 +53,12 @@ export const ButtonIcon: React.FunctionComponent<ButtonIconProps> = ({
       }
     : {};
 
+  let _icon = icon;
+  const sizes = getButtonIconSizes(theme);
+  if (icon && isTheme2022(theme) && isKonturIcon(icon)) {
+    _icon = React.cloneElement(icon, { size: icon.props.size ?? sizes[size] });
+  }
+
   return (
     <span
       style={style}
@@ -52,7 +68,7 @@ export const ButtonIcon: React.FunctionComponent<ButtonIconProps> = ({
       })}
     >
       {space}
-      {loading ? <LoadingIcon size={size} /> : icon}
+      {loading ? <LoadingIcon size={size} /> : _icon}
     </span>
   );
 };

--- a/packages/react-ui/components/Input/InputLayout/InputLayoutAsideIcon.tsx
+++ b/packages/react-ui/components/Input/InputLayout/InputLayoutAsideIcon.tsx
@@ -1,26 +1,37 @@
 import React from 'react';
+import { isElement } from 'react-is';
 
+import { isKonturIcon } from '../../../lib/utils';
 import { InputProps, InputSize } from '../Input';
 import { cx } from '../../../lib/theming/Emotion';
 import { ThemeContext } from '../../../lib/theming/ThemeContext';
 
 import { InputLayoutContext } from './InputLayoutContext';
 import { stylesLayout } from './InputLayout.styles';
-
 export interface InputLayoutAsideIconProps {
   icon: InputProps['leftIcon'] | InputProps['rightIcon'];
   side: 'left' | 'right';
 }
 
-export const InputLayoutAsideIcon: React.FunctionComponent<InputLayoutAsideIconProps> = ({ icon = null, side }) => {
+export const InputLayoutAsideIcon: React.FunctionComponent<InputLayoutAsideIconProps> = ({ icon, side }) => {
   const theme = React.useContext(ThemeContext);
   const { focused, disabled, size } = React.useContext(InputLayoutContext);
 
+  const sizes: Record<InputSize, number> = {
+    small: parseInt(theme.inputIconSizeSmall),
+    medium: parseInt(theme.inputIconSizeMedium),
+    large: parseInt(theme.inputIconSizeLarge),
+  };
   const gaps: Record<InputSize, number> = {
     small: parseInt(theme.inputIconGapSmall),
     medium: parseInt(theme.inputIconGapMedium),
     large: parseInt(theme.inputIconGapLarge),
   };
+
+  let _icon = null;
+  if (icon && isElement(icon)) {
+    _icon = isKonturIcon(icon) ? React.cloneElement(icon, { size: icon.props.size ?? sizes[size] }) : icon;
+  }
 
   const style: React.CSSProperties = {};
   if (side) {
@@ -32,7 +43,7 @@ export const InputLayoutAsideIcon: React.FunctionComponent<InputLayoutAsideIconP
   }
 
   return (
-    icon && (
+    _icon && (
       <span
         style={style}
         className={cx(
@@ -42,7 +53,7 @@ export const InputLayoutAsideIcon: React.FunctionComponent<InputLayoutAsideIconP
           disabled && stylesLayout.iconDisabled(),
         )}
       >
-        {icon}
+        {_icon}
       </span>
     )
   );

--- a/packages/react-ui/components/Kebab/Kebab.tsx
+++ b/packages/react-ui/components/Kebab/Kebab.tsx
@@ -1,6 +1,8 @@
 import React, { AriaAttributes } from 'react';
 import PropTypes from 'prop-types';
+import { isElement } from 'react-is';
 
+import { isKonturIcon } from '../../lib/utils';
 import { isKeyArrowVertical, isKeyEnter, isKeySpace, someKeys } from '../../lib/events/keyboard/identifiers';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { keyListener } from '../../lib/events/keyListener';
@@ -17,6 +19,7 @@ import { cx } from '../../lib/theming/Emotion';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
+import { ButtonSize } from '../Button';
 
 import { styles } from './Kebab.styles';
 import { KebabIcon } from './KebabIcon';
@@ -228,9 +231,22 @@ export class Kebab extends React.Component<KebabProps, KebabState> {
   }
 
   private renderIcon2022() {
-    const { size, icon } = this.getProps();
+    const { size, icon = <KebabIcon /> } = this.getProps();
 
-    return icon ?? <KebabIcon size={size} color={this.theme.kebabIconColor} />;
+    if (isElement(icon) && isKonturIcon(icon)) {
+      const sizes: Record<ButtonSize, number> = {
+        small: parseInt(this.theme.kebabIconSizeSmall),
+        medium: parseInt(this.theme.kebabIconSizeMedium),
+        large: parseInt(this.theme.kebabIconSizeLarge),
+      };
+
+      return React.cloneElement(icon, {
+        size: icon.props.size ?? sizes[size],
+        color: icon.props.color ?? this.theme.kebabIconColor,
+      });
+    }
+
+    return icon;
   }
 }
 

--- a/packages/react-ui/internal/icons2022/iconSizer.tsx
+++ b/packages/react-ui/internal/icons2022/iconSizer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { forwardRefAndName } from '../../lib/forwardRefAndName';
+import { forwardRefAndIconName } from '../../lib/forwardRefAndName';
 
 import { IconProps as BaseIconProps } from './BaseIcon';
 import { ALIASES_TO_SIZES, DEFAULT_ICON_ALIAS, IconSizeAliases } from './iconConstants';
@@ -20,14 +20,17 @@ const getAliasFromSize = (size: number) =>
   )[0][0] as IconSizeAliases;
 
 export const iconSizer = <T extends IconSizingProps>(sizes: Sizes, iconName: string) =>
-  forwardRefAndName<SVGSVGElement, IconSizingProps & T>(iconName, ({ size = DEFAULT_ICON_ALIAS, ...props }, ref) => {
-    let alias: IconSizeAliases = DEFAULT_ICON_ALIAS;
-    if (size !== alias && isAlias(size)) {
-      alias = size;
-    } else if (typeof size === 'number') {
-      alias = getAliasFromSize(size);
-    }
-    const Icon = sizes[alias]();
+  forwardRefAndIconName<SVGSVGElement, IconSizingProps & T>(
+    iconName,
+    ({ size = DEFAULT_ICON_ALIAS, ...props }, ref) => {
+      let alias: IconSizeAliases = DEFAULT_ICON_ALIAS;
+      if (size !== alias && isAlias(size)) {
+        alias = size;
+      } else if (typeof size === 'number') {
+        alias = getAliasFromSize(size);
+      }
+      const Icon = sizes[alias]();
 
-    return React.cloneElement(Icon, { ref, ...props });
-  });
+      return React.cloneElement(Icon, { ref, ...props });
+    },
+  );

--- a/packages/react-ui/lib/forwardRefAndName.ts
+++ b/packages/react-ui/lib/forwardRefAndName.ts
@@ -21,3 +21,24 @@ export function forwardRefAndName<ElementType, Props>(
 ): ReactUIComponentWithRef<ElementType, Props> {
   return forwardName<ElementType, Props>(name, forwardRef(render) as ReactUIComponentWithRef<ElementType, Props>);
 }
+
+export interface ReactUIIconWithRef<T, P> extends ReactUIComponentWithRef<T, P> {
+  __KONTUR_ICON__: boolean;
+}
+
+function forwardIconName<ElementType, Props>(
+  name: string,
+  render: ReactUIIconWithRef<ElementType, Props>,
+): ReactUIIconWithRef<ElementType, Props> {
+  render.displayName = name;
+  render.__KONTUR_REACT_UI__ = name;
+  render.__KONTUR_ICON__ = true;
+  return render;
+}
+
+export function forwardRefAndIconName<ElementType, Props>(
+  name: string,
+  render: React.ForwardRefRenderFunction<ElementType, Props>,
+): ReactUIIconWithRef<ElementType, Props> {
+  return forwardIconName<ElementType, Props>(name, forwardRef(render) as ReactUIIconWithRef<ElementType, Props>);
+}

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -220,3 +220,7 @@ export const isInputLike =
   isReactUIComponent<AutocompleteProps>('Autocomplete') ||
   isReactUIComponent<PasswordInputProps>('PasswordInput') ||
   isReactUIComponent<CurrencyInputProps>('CurrencyInput');
+
+export const isKonturIcon = (icon: React.ReactElement) => {
+  return Object.prototype.hasOwnProperty.call(icon?.type, '__KONTUR_ICON__');
+};


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

- В #3175 была удалена логика (пункт 4 описания пулл-реквеста), с помощью которой ресайзились кастомные иконки пользователей
- Также в `4.14.0` у пользователей пропала возможность изменять размер иконок с помощью пропа `size`, который они передают на свои иконки
- Выравнивание кастомных иконок теперь реализуется на стороне библиотеки иконок, поэтому чтобы получить правильное выравнивание пользователям нужно будет обновить библиотеку иконок

## Решение

- Вернул логику для ресайза иконок и добавил условие, которое проверяет что ресайзатся именно наши иконки
- Вернул возможность менять размер иконок с помощью пропа `size`

## Ссылки

IF-1253

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
