### PR TITLE
fix(Calendar): return customization of current day border in theme 2022

### DIFF
--- a/packages/react-ui/components/Calendar/DayCellView.styles.ts
+++ b/packages/react-ui/components/Calendar/DayCellView.styles.ts
@@ -59,10 +59,10 @@ export const styles = memoizeStyle({
     `;
   },
 
-  today2022() {
+  today2022(t: Theme) {
     return css`
       .${globalClasses.todayCaption} {
-        border-bottom: solid 1px;
+        border-bottom: ${t.calendarCellTodayBorder};
       }
     `;
   },

--- a/packages/react-ui/components/Calendar/DayCellView.tsx
+++ b/packages/react-ui/components/Calendar/DayCellView.tsx
@@ -43,7 +43,7 @@ export function DayCellView(props: DayCellViewProps) {
       className={cx({
         [styles.cell(theme)]: true,
         [styles.today(theme)]: isToday && !_isTheme2022,
-        [styles.today2022()]: isToday && _isTheme2022,
+        [styles.today2022(theme)]: isToday && _isTheme2022,
         [styles.selected(theme)]: Boolean(value && CDS.isEqual(date, value)),
         [styles.weekend(theme)]: Boolean(isWeekend),
       })}

--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -408,7 +408,7 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static calendarCellHoverColor = '';
   public static calendarCellActiveHoverColor = '';
   public static calendarCellSelectedBgColor = '#EBEBEB';
-  public static calendarCellTodayBorder = 'inherit';
+  public static calendarCellTodayBorder = '1px solid';
   //#endregion
 
   //#region DateSelect


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В теме 2022 перестала работать переменная `calendarCellTodayBorder`

## Решение

Прокинул актуальное значение для бордера в тему 2022

## Ссылки

IF-1263

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
