### PR TITLE
fix(ComboBox): flushSync throws an error into console

### DIFF
--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -329,30 +329,30 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     this.dispatch({ type: 'Reset' });
   }
 
-  private updateState = (action: CustomComboBoxAction<T>) => {
-    let effects: Array<CustomComboBoxEffect<T>>;
-    let nextState: Pick<CustomComboBoxState<T>, never>;
-
-    this.setState(
-      (state) => {
-        const stateAndEffect = this.reducer(state, this.props, action);
-        [nextState, effects] = stateAndEffect instanceof Array ? stateAndEffect : [stateAndEffect, []];
-        return nextState;
-      },
-      () => {
-        effects.forEach(this.handleEffect);
-      },
-    );
-  };
-
   private dispatch = (action: CustomComboBoxAction<T>, sync = true) => {
+    const updateState = (action: CustomComboBoxAction<T>) => {
+      let effects: Array<CustomComboBoxEffect<T>>;
+      let nextState: Pick<CustomComboBoxState<T>, never>;
+
+      this.setState(
+        (state) => {
+          const stateAndEffect = this.reducer(state, this.props, action);
+          [nextState, effects] = stateAndEffect instanceof Array ? stateAndEffect : [stateAndEffect, []];
+          return nextState;
+        },
+        () => {
+          effects.forEach(this.handleEffect);
+        },
+      );
+    };
+
     if (sync) {
       return ReactDOM.flushSync(() => {
-        this.updateState(action);
+        updateState(action);
       });
     }
 
-    return this.updateState(action);
+    return updateState(action);
   };
 
   private handleEffect = (effect: CustomComboBoxEffect<T>) => {

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -309,9 +309,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   }
 
   public componentDidMount() {
-    setTimeout(() => {
-      this.dispatch({ type: 'Mount' });
-    }, 0);
+    this.dispatch({ type: 'Mount' }, false);
     if (this.props.autoFocus) {
       this.focus();
     }
@@ -321,9 +319,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     if (prevState.editing && !this.state.editing) {
       this.handleBlur();
     }
-    setTimeout(() => {
-      this.dispatch({ type: 'DidUpdate', prevProps, prevState });
-    }, 0);
+    this.dispatch({ type: 'DidUpdate', prevProps, prevState }, false);
   }
 
   /**
@@ -333,11 +329,11 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     this.dispatch({ type: 'Reset' });
   }
 
-  private dispatch = (action: CustomComboBoxAction<T>) => {
+  private dispatch = (action: CustomComboBoxAction<T>, sync = true) => {
     let effects: Array<CustomComboBoxEffect<T>>;
     let nextState: Pick<CustomComboBoxState<T>, never>;
 
-    ReactDOM.flushSync(() => {
+    const updateState = () => {
       this.setState(
         (state) => {
           const stateAndEffect = this.reducer(state, this.props, action);
@@ -350,7 +346,13 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
           effects.forEach(this.handleEffect);
         },
       );
-    });
+    };
+
+    if (sync) {
+      return ReactDOM.flushSync(updateState);
+    }
+
+    return updateState();
   };
 
   private handleEffect = (effect: CustomComboBoxEffect<T>) => {

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -309,7 +309,9 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   }
 
   public componentDidMount() {
-    this.dispatch({ type: 'Mount' });
+    setTimeout(() => {
+      this.dispatch({ type: 'Mount' });
+    }, 0);
     if (this.props.autoFocus) {
       this.focus();
     }
@@ -319,7 +321,9 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     if (prevState.editing && !this.state.editing) {
       this.handleBlur();
     }
-    this.dispatch({ type: 'DidUpdate', prevProps, prevState });
+    setTimeout(() => {
+      this.dispatch({ type: 'DidUpdate', prevProps, prevState });
+    }, 0);
   }
 
   /**

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -309,7 +309,9 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   }
 
   public componentDidMount() {
-    this.dispatch({ type: 'Mount' }, false);
+    setTimeout(() => {
+      this.dispatch({ type: 'Mount' });
+    }, 0);
     if (this.props.autoFocus) {
       this.focus();
     }
@@ -319,7 +321,9 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     if (prevState.editing && !this.state.editing) {
       this.handleBlur();
     }
-    this.dispatch({ type: 'DidUpdate', prevProps, prevState }, false);
+    setTimeout(() => {
+      this.dispatch({ type: 'DidUpdate', prevProps, prevState });
+    }, 0);
   }
 
   /**
@@ -329,30 +333,22 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     this.dispatch({ type: 'Reset' });
   }
 
-  private dispatch = (action: CustomComboBoxAction<T>, sync = true) => {
+  private dispatch = (action: CustomComboBoxAction<T>) => {
     let effects: Array<CustomComboBoxEffect<T>>;
     let nextState: Pick<CustomComboBoxState<T>, never>;
 
-    const updateState = () => {
+    ReactDOM.flushSync(() => {
       this.setState(
         (state) => {
           const stateAndEffect = this.reducer(state, this.props, action);
-
           [nextState, effects] = stateAndEffect instanceof Array ? stateAndEffect : [stateAndEffect, []];
-
           return nextState;
         },
         () => {
           effects.forEach(this.handleEffect);
         },
       );
-    };
-
-    if (sync) {
-      return ReactDOM.flushSync(updateState);
-    }
-
-    return updateState();
+    });
   };
 
   private handleEffect = (effect: CustomComboBoxEffect<T>) => {


### PR DESCRIPTION
## Проблема

После #3144 в консоль стала падать ошибка:
```diff
- flushSync was called from inside a lifecycle method.
- React cannot flush when React is already rendering.
- Consider moving this call to a scheduler task or micro task.
```

Ошибка была вызвана тем, что метод `dispatch` вызывался в методах жизненного цикла `componentDidMount` и `componentDidUpdate`.

## Решение

Так как в #3144 исправлялся другой баг, а покрыть тестами его не удалось важно было удостовериться в том, что фикс не сломает всё снова.

[Песочница](https://codesandbox.io/s/validations-objects-react-18-ojmzni?file=/src/index.tsx) с багом (`@skbkontur/react-ui@4.13.3`). Для воспроизведения нужно ввести в первый инпут валидное значение и затем нажать на кнопку "Submit" - у второго поля не появится тултип валидации:

https://github.com/skbkontur/retail-ui/assets/48599460/06daf593-c307-4936-a07b-2e8472771def

---

**Попытка №1:**
❌ Как предлагал ворнинг обернул вызовы `dispatch` в жизненных циклах в `setTimeout`. Баг из #3144 с таким решением не воспроизводился и ворнинг также пропал из консоли, но при этом упали несколько наших кейсов. Создал отдельную  [песочницу](https://codesandbox.io/s/validations-objects-react-18-forked-9ylt95) с этим решением

**Попытка №2**
✅ Перестал вызывать `flushSync` внутри методов жизненных циклов. Создал отдельную [песочницу](https://codesandbox.io/s/validations-objects-react-18-forked-q8fsm3?file=/src/index.tsx) с этим решением

https://github.com/skbkontur/retail-ui/assets/48599460/ebcc7c45-c2e3-47cd-b8cc-049d324e21ad



---
P. S. По ходу решения задачи выяснилось, что проблема с зависающим фокусом в `<DatePicker />` не связана с ошибкой в консоли. Вынес баг в отдельную задачу - IF-1285

## Ссылки

IF-1266

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
