### PR TITLE
docs(contributing): change https clone link to ssh clone link

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -106,19 +106,19 @@
 Перейдите в выбранную директорию для [клонирования](https://help.github.com/en/articles/cloning-a-repository) и выполните команду:
 
 ```
-git clone https://github.com/skbkontur/retail-ui.git
+git clone git@github.com:skbkontur/retail-ui.git
 ```
 
 Или, в случае форка:
 
 ```
-git clone https://github.com/%YOUR_USER_NAME%/retail-ui.git
+git clone git@github.com:%YOUR_USER_NAME%/retail-ui.git
 ```
 
 Работая с форком, полезно добавить upstream в качестве удаленного репозитория:
 
 ```
- git remote add upstream https://github.com/skbkontur/retail-ui.git
+ git remote add upstream git@github.com:skbkontur/retail-ui.git
 ```
 
 Теперь легко можно [синхронизировать](https://help.github.com/en/articles/syncing-a-fork) свой форк с основным репозиторием:


### PR DESCRIPTION
## Проблема

<!-- Подробно опиши решаемую проблему. -->
При клонировании репозитория по ссылке https нет возможности делать push.

## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Меняем ссылку для клонирования с https на ssh.

## Ссылки

-

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
