### PR TITLE
fix(ComboBox): use `flushSync` only in React@18

### DIFF
--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -346,7 +346,10 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       );
     };
 
-    if (sync) {
+    // Auto-batching React@18 creates problems that are fixed with flushSync
+    // https://github.com/skbkontur/retail-ui/pull/3144#issuecomment-1535235366
+    const isReact18 = React.version.search('18') === 0;
+    if (sync && isReact18) {
       return ReactDOM.flushSync(() => {
         updateState(action);
       });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Метод `flushSync()` (https://github.com/skbkontur/retail-ui/pull/3144) мог крашить всё приложение в `React@16`
В [песочнице](https://codesandbox.io/s/cool-tharp-gckcn7?file=/src/index.js) если в `ComboBox` ввести своё значение и убрать фокус то приложение развалиться.

Ранее также возникала проблема с варнингом (https://github.com/skbkontur/retail-ui/pull/3189) при вызове `flushSync()` из методов ЖЦ.

## Решение

Т.к. `flushSync()` помогает исключительно в `React@18`, то решил добавить флаг `isReact18`, чтобы в остальных версиях всё работало по старому.

<img src="https://github.com/skbkontur/retail-ui/assets/2708211/5dc3237a-68b7-43d1-b200-51b037e6171d" align="top" /> Если в Реакте 18 использовать старый метод `ReactDOM.render` вместо нового `createRoot`, то не будут доступны новые фичи и фактически Реакт будет работать в режиме 17 версии. 
Об этом сообщит такое предупреждение в консоле:
![image](https://github.com/skbkontur/retail-ui/assets/2708211/06eb85b3-3407-484f-bd4c-a73df054fa87)

Это можем привести к варнингу, которую правили здесь https://github.com/skbkontur/retail-ui/pull/3189.
Но т.к. такое использование Реакта 18 не рекомендуется, то я решил никак это не править.
В таком сценарии проще прямо использовать Рекст 17, и этого варнинга не будет, т.к компонент будет работать по старой логике.


## Ссылки

`IF-1319`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
