### PR TITLE
feat(Link, Button): add theme variables for border-bottom

### DIFF
--- a/packages/react-ui/components/Button/getInnerLinkTheme.ts
+++ b/packages/react-ui/components/Button/getInnerLinkTheme.ts
@@ -5,6 +5,8 @@ export const getInnerLinkTheme = (theme: Theme): Theme => {
   return ThemeFactory.create(
     {
       linkLineBorderBottomStyle: theme.btnLinkLineBorderBottomStyle,
+      linkLineHoverBorderBottomStyle: theme.btnLinkHoverLineBorderBottomStyle,
+      linkLineBorderBottomOpacity: theme.btnLinkLineBorderBottomOpacity,
       linkLineBorderBottomWidth: theme.btnLinkLineBorderBottomWidth,
       linkDisabledColor: theme.btnLinkDisabledColor,
     },

--- a/packages/react-ui/components/Link/Link.mixins.ts
+++ b/packages/react-ui/components/Link/Link.mixins.ts
@@ -37,7 +37,7 @@ export const linkUseColorsMixin = (mainColor: string, hoverColor: string, active
   `;
 };
 
-export const linkUseLineWithoutOpacity = (linkLineHoverBorderBottomStyle: string) => {
+export const linkUseLineHovered = (linkLineHoverBorderBottomStyle: string) => {
   return `
     animation: none !important;
     border-bottom-style: ${linkLineHoverBorderBottomStyle};

--- a/packages/react-ui/components/Link/Link.mixins.ts
+++ b/packages/react-ui/components/Link/Link.mixins.ts
@@ -37,8 +37,9 @@ export const linkUseColorsMixin = (mainColor: string, hoverColor: string, active
   `;
 };
 
-export const linkUseLineWithoutOpacity = () => {
+export const linkUseLineWithoutOpacity = (linkLineHoverBorderBottomStyle: string) => {
   return `
     animation: none !important;
+    border-bottom-style: ${linkLineHoverBorderBottomStyle};
   `;
 };

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -1,7 +1,7 @@
 import { css, keyframes, memoizeStyle, prefix } from '../../lib/theming/Emotion';
 import { Theme } from '../../lib/theming/Theme';
 
-import { linkMixin, linkDisabledMixin, linkUseColorsMixin, linkUseLineWithoutOpacity } from './Link.mixins';
+import { linkMixin, linkDisabledMixin, linkUseColorsMixin, linkUseLineHovered } from './Link.mixins';
 
 export const globalClasses = prefix('link')({
   text: 'text',
@@ -47,7 +47,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkHoverColor};
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+        ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -56,7 +56,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkSuccessHoverColor} !important;
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+        ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -65,7 +65,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkDangerHoverColor} !important;
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+        ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -74,7 +74,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkGrayedHoverColor} !important;
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+        ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -116,7 +116,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkColor, t.linkHoverColor, t.linkActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+          ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -127,7 +127,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkSuccessColor, t.linkSuccessHoverColor, t.linkSuccessActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+          ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -138,7 +138,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkDangerColor, t.linkDangerHoverColor, t.linkDangerActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+          ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -149,7 +149,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkGrayedColor, t.linkGrayedHoverColor, t.linkGrayedActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+          ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -182,7 +182,7 @@ export const styles = memoizeStyle({
   disabledDark22Theme(t: Theme) {
     return css`
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
+        ${linkUseLineHovered(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -33,13 +33,14 @@ export const styles = memoizeStyle({
   },
 
   lineText(t: Theme) {
-    const delay = parseFloat(t.linkLineBorderBottomOpacity) - 0.99;
+    const delay = parseFloat(t.linkLineBorderBottomOpacity) - 1;
     return css`
       border-bottom-style: ${t.linkLineBorderBottomStyle};
       border-bottom-width: ${t.linkLineBorderBottomWidth};
       animation: ${line} 1s linear !important; // override creevey
       animation-play-state: paused !important;
       animation-delay: ${delay}s !important;
+      animation-fill-mode: forwards !important;
     `;
   },
 

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -33,12 +33,13 @@ export const styles = memoizeStyle({
   },
 
   lineText(t: Theme) {
+    const delay = parseFloat(t.linkLineBorderBottomOpacity) - 0.99;
     return css`
       border-bottom-style: ${t.linkLineBorderBottomStyle};
       border-bottom-width: ${t.linkLineBorderBottomWidth};
       animation: ${line} 1s linear !important; // override creevey
       animation-play-state: paused !important;
-      animation-delay: -0.5s !important;
+      animation-delay: ${delay}s !important;
     `;
   },
 
@@ -46,7 +47,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkHoverColor};
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity()}
+        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -55,7 +56,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkSuccessHoverColor} !important;
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity()}
+        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -64,7 +65,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkDangerHoverColor} !important;
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity()}
+        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -73,7 +74,7 @@ export const styles = memoizeStyle({
     return css`
       color: ${t.linkGrayedHoverColor} !important;
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity()}
+        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },
@@ -115,7 +116,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkColor, t.linkHoverColor, t.linkActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity()}
+          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -126,7 +127,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkSuccessColor, t.linkSuccessHoverColor, t.linkSuccessActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity()}
+          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -137,7 +138,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkDangerColor, t.linkDangerHoverColor, t.linkDangerActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity()}
+          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -148,7 +149,7 @@ export const styles = memoizeStyle({
       ${linkUseColorsMixin(t.linkGrayedColor, t.linkGrayedHoverColor, t.linkGrayedActiveColor)};
       .${globalClasses.text} {
         :hover {
-          ${linkUseLineWithoutOpacity()}
+          ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
         }
       }
     `;
@@ -178,10 +179,10 @@ export const styles = memoizeStyle({
     `;
   },
 
-  disabledDark22Theme() {
+  disabledDark22Theme(t: Theme) {
     return css`
       .${globalClasses.text} {
-        ${linkUseLineWithoutOpacity()}
+        ${linkUseLineWithoutOpacity(t.linkLineHoverBorderBottomStyle)}
       }
     `;
   },

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -243,7 +243,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
       : cx(
           styles.lineRoot(),
           disabled && styles.disabled(this.theme),
-          disabled && _isTheme2022 && isDarkTheme(this.theme) && styles.disabledDark22Theme(),
+          disabled && _isTheme2022 && isDarkTheme(this.theme) && styles.disabledDark22Theme(this.theme),
           isFocused && use === 'default' && styles.lineFocus(this.theme),
           isFocused && use === 'success' && styles.lineFocusSuccess(this.theme),
           isFocused && use === 'danger' && styles.lineFocusDanger(this.theme),

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -123,7 +123,7 @@ export class DefaultTheme {
     return this.linkLineBorderBottomStyle;
   }
   public static linkLineBorderBottomWidth = '0px';
-  public static linkLineBorderBottomOpacity = '0.5';
+  public static linkLineBorderBottomOpacity = '0.49';
 
   //#endregion
   //#region Token

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -119,7 +119,11 @@ export class DefaultTheme {
   public static linkButtonPaddingX = '10px';
 
   public static linkLineBorderBottomStyle = '';
+  public static get linkLineHoverBorderBottomStyle() {
+    return this.linkLineBorderBottomStyle;
+  }
   public static linkLineBorderBottomWidth = '0px';
+  public static linkLineBorderBottomOpacity = '0.5';
 
   //#endregion
   //#region Token
@@ -484,7 +488,13 @@ export class DefaultTheme {
     return this.linkHoverTextDecoration;
   }
   public static btnLinkLineBorderBottomStyle = '';
+  public static get btnLinkHoverLineBorderBottomStyle() {
+    return this.btnLinkLineBorderBottomStyle;
+  }
   public static btnLinkLineBorderBottomWidth = '0px';
+  public static get btnLinkLineBorderBottomOpacity() {
+    return this.linkLineBorderBottomOpacity;
+  }
 
   public static get btnLinkIconMarginRight() {
     return this.linkIconMarginRight;

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -123,7 +123,7 @@ export class DefaultTheme {
     return this.linkLineBorderBottomStyle;
   }
   public static linkLineBorderBottomWidth = '0px';
-  public static linkLineBorderBottomOpacity = '0.49';
+  public static linkLineBorderBottomOpacity = '0.5';
 
   //#endregion
   //#region Token


### PR DESCRIPTION
## Проблема

После ПР #3185 пропала возможность кастомизировать подчеркивание в 22 теме

## Решение

Изначально просили добавить переменную `linkLineHoverBorderBottomStyle `, чтобы изменять стиль подчеркивания при ховере по аналогии с переменной `linkLineBorderBottomStyle `. Но я также решила добавить переменную `linkLineBorderBottomOpacity `для возможности кастомизации прозрачности.
Добавила аналогичные переменные для кнопки-ссылки: `btnLinkHoverLineBorderBottomStyle`, `btnLinkLineBorderBottomOpacity`

Полная прозрачность достигается при `animation-delay: -0.99s`, а не `-1s`. Пришлось внести корректировку в 1 сотую процента для переменной

## Ссылки

fix IF-1312

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
