### PR TITLE
chore: change styleguidist font

### DIFF
--- a/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.styles.ts
+++ b/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.styles.ts
@@ -4,7 +4,6 @@ import { Theme } from '../../../lib/theming/Theme';
 export const styles = memoizeStyle({
   root() {
     return css`
-      font-family: 'Lab Grotesque', Roboto, 'Helvetica Neue', Arial, sans-serif;
       font-weight: 400;
       font-size: 14px;
       padding-left: 300px;
@@ -24,8 +23,6 @@ export const styles = memoizeStyle({
         height: 149px;
         z-index: 999;
         a {
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-            'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
           position: relative;
           right: -37px;
           top: -22px;
@@ -164,8 +161,6 @@ export const styles = memoizeStyle({
       p {
         color: #767676;
         margin: 5px 0 0;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-          'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
         font-size: 15px;
         font-weight: normal;
       }
@@ -183,8 +178,6 @@ export const styles = memoizeStyle({
   },
   footerLink() {
     return css`
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
-        'Droid Sans', 'Helvetica Neue', sans-serif;
       position: relative;
       right: -37px;
       top: -22px;

--- a/packages/react-ui/.styleguide/config/base.config.js
+++ b/packages/react-ui/.styleguide/config/base.config.js
@@ -12,7 +12,6 @@ const { publishVersion } = require('../helpers');
 const styles = {
   StyleGuide: {
     '@global body': {
-      fontFamily: '"Lab Grotesque", Roboto, "Helvetica Neue", Arial, sans-serif',
       fontSize: 14,
     },
     content: {
@@ -243,6 +242,11 @@ module.exports = {
           href: 'https://s.kontur.ru/common-v2/fonts/LabGrotesque/LabGrotesque.css',
         },
       ],
+    },
+  },
+  theme: {
+    fontFamily: {
+      base: '"Lab Grotesque", Roboto, "Helvetica Neue", Arial, sans-serif',
     },
   },
 };


### PR DESCRIPTION
## Проблема

В документации не у всех элементов установлен шрифт `LabGrotesque`

![image](https://github.com/skbkontur/retail-ui/assets/32093844/9e51bc35-ae48-4186-acec-17cf67f2f3ba)


## Решение

Проблема была в том, что в стайлгайдисте есть свои сгенерированные классы и они переписывали цвет некоторых элементов. 

Решила задачнием шрифта через тему стайлгайдиста

## Ссылки

fix IF-1298

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
