### PR TITLE
fix(ComboBox,InputLikeText): use `flushSync` only in React 18

### DIFF
--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -346,10 +346,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       );
     };
 
-    // Auto-batching React@18 creates problems that are fixed with flushSync
-    // https://github.com/skbkontur/retail-ui/pull/3144#issuecomment-1535235366
-    const isReact18 = React.version.search('18') === 0;
-    if (sync && isReact18) {
+    if (sync) {
       return ReactDOM.flushSync(() => {
         updateState(action);
       });

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -1,5 +1,4 @@
 import React, { AriaAttributes } from 'react';
-import ReactDOM from 'react-dom';
 
 import { Nullable } from '../../typings/utility-types';
 import { Input, InputIconType } from '../../components/Input';
@@ -333,20 +332,18 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     let effects: Array<CustomComboBoxEffect<T>>;
     let nextState: Pick<CustomComboBoxState<T>, never>;
 
-    ReactDOM.flushSync(() => {
-      this.setState(
-        (state) => {
-          const stateAndEffect = this.reducer(state, this.props, action);
+    this.setState(
+      (state) => {
+        const stateAndEffect = this.reducer(state, this.props, action);
 
-          [nextState, effects] = stateAndEffect instanceof Array ? stateAndEffect : [stateAndEffect, []];
+        [nextState, effects] = stateAndEffect instanceof Array ? stateAndEffect : [stateAndEffect, []];
 
-          return nextState;
-        },
-        () => {
-          effects.forEach(this.handleEffect);
-        },
-      );
-    });
+        return nextState;
+      },
+      () => {
+        effects.forEach(this.handleEffect);
+      },
+    );
   };
 
   private handleEffect = (effect: CustomComboBoxEffect<T>) => {

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -309,7 +309,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   }
 
   public componentDidMount() {
-    this.dispatch({ type: 'Mount' }, false);
+    this.dispatch({ type: 'Mount' });
     if (this.props.autoFocus) {
       this.focus();
     }
@@ -319,7 +319,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     if (prevState.editing && !this.state.editing) {
       this.handleBlur();
     }
-    this.dispatch({ type: 'DidUpdate', prevProps, prevState }, false);
+    this.dispatch({ type: 'DidUpdate', prevProps, prevState });
   }
 
   /**
@@ -329,30 +329,24 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     this.dispatch({ type: 'Reset' });
   }
 
-  private dispatch = (action: CustomComboBoxAction<T>, sync = true) => {
-    const updateState = (action: CustomComboBoxAction<T>) => {
-      let effects: Array<CustomComboBoxEffect<T>>;
-      let nextState: Pick<CustomComboBoxState<T>, never>;
+  private dispatch = (action: CustomComboBoxAction<T>) => {
+    let effects: Array<CustomComboBoxEffect<T>>;
+    let nextState: Pick<CustomComboBoxState<T>, never>;
 
+    ReactDOM.flushSync(() => {
       this.setState(
         (state) => {
           const stateAndEffect = this.reducer(state, this.props, action);
+
           [nextState, effects] = stateAndEffect instanceof Array ? stateAndEffect : [stateAndEffect, []];
+
           return nextState;
         },
         () => {
           effects.forEach(this.handleEffect);
         },
       );
-    };
-
-    if (sync) {
-      return ReactDOM.flushSync(() => {
-        updateState(action);
-      });
-    }
-
-    return updateState(action);
+    });
   };
 
   private handleEffect = (effect: CustomComboBoxEffect<T>) => {

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -1,7 +1,6 @@
 // TODO: Enable this rule in functional components.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import { isNonNullable } from '../../lib/utils';
 import { isKeyTab, isShortcutPaste } from '../../lib/events/keyboard/identifiers';
@@ -451,9 +450,7 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
       }
     }
 
-    ReactDOM.flushSync(() => {
-      this.setState({ focused: true });
-    });
+    this.setState({ focused: true });
 
     if (this.props.onFocus) {
       this.props.onFocus(e);

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -1,6 +1,7 @@
 // TODO: Enable this rule in functional components.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import { isNonNullable } from '../../lib/utils';
 import { isKeyTab, isShortcutPaste } from '../../lib/events/keyboard/identifiers';
@@ -450,7 +451,13 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
       }
     }
 
-    this.setState({ focused: true });
+    // Auto-batching React@18 creates problems that are fixed with flushSync
+    // https://github.com/skbkontur/retail-ui/pull/3144#issuecomment-1535235366
+    if (React.version.search('18') === 0) {
+      ReactDOM.flushSync(() => this.setState({ focused: true }));
+    } else {
+      this.setState({ focused: true });
+    }
 
     if (this.props.onFocus) {
       this.props.onFocus(e);


### PR DESCRIPTION
## Проблема

Фикс в `ComboBox` для React 18 #3144 создал 2 проблемы:
1. В React 17 в консоль сыпалась ошибка #3189
2. В React 16 эта же ошибка крашила приложение #3202 

## Решение

Решили https://github.com/skbkontur/retail-ui/pull/3202#issuecomment-1632494470 использовать исходный фикс из #3144 исключительно под React 18.
Для этого последовательно откатил предыдущие комиты, и затем "скрестил" код из этих комитов в один.

> Если мест использования `flushSync` с проверкой на `React18` получается больше одного, то уже стоит вынести их в переиспользуемую функцию, наподобие тех, что у нас в `SSRSafe`. Так будет меньше вероятность наступить на ту же граблю в будущем.
© https://github.com/skbkontur/retail-ui/pull/3202#issuecomment-1632494470

Предлагаю пока не выносить это решение в хелперы. Сейчас это жуткий костыль для логики одного компонента.
При этом не до конца понятно почему именно в этих местах использование `flushSync` помогает решить проблему.

Мне кажется будет лучше поднять приоритет рефакторингу `ComboBox`.

## Ссылки

Версия для тестов `4.15.2-flushSync-React18-only`
`IF1334`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

4. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

5. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
