### PR TITLE
test(Kebab): add test for aria-describedby

### DIFF
--- a/packages/react-ui/components/Kebab/__tests__/Kebab-test.tsx
+++ b/packages/react-ui/components/Kebab/__tests__/Kebab-test.tsx
@@ -33,4 +33,19 @@ describe('Kebab', () => {
     userEvent.tab();
     expect(kebab).not.toHaveFocus();
   });
+
+  it('passes value to aria-describedby prop', () => {
+    const id = 'id';
+    const description = 'description';
+    render(
+      <>
+        <Kebab aria-describedby={id} />
+        <p id={id}>description</p>
+      </>,
+    );
+
+    const caption = screen.getByTestId(KebabDataTids.caption);
+    expect(caption).toHaveAttribute('aria-describedby', id);
+    expect(caption).toHaveAccessibleDescription(description);
+  });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В рамках #3094 не получилось затащить тест на `aria-describedby` для `Kebab`, так как в нём не было `data-tid`'ов

## Решение

Добавил тест на прокидывание `aria-describedby` в `Kebab`

## Ссылки

IF-1036

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
 ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
