### PR TITLE
chore(ScrollContainer): make `inner` and `hasScrollBar` public

### DIFF
--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -91,6 +91,8 @@ type DefaultProps = Required<
 export class ScrollContainer extends React.Component<ScrollContainerProps> {
   public static __KONTUR_REACT_UI__ = 'ScrollContainer';
 
+  public inner: Nullable<HTMLElement>;
+
   public static propTypes = {
     invert: PropTypes.bool,
     maxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -113,7 +115,6 @@ export class ScrollContainer extends React.Component<ScrollContainerProps> {
 
   private scrollX: Nullable<ScrollBar>;
   private scrollY: Nullable<ScrollBar>;
-  private inner: Nullable<HTMLElement>;
   private setRootNode!: TSetRootNode;
 
   public componentDidMount() {
@@ -230,7 +231,7 @@ export class ScrollContainer extends React.Component<ScrollContainerProps> {
     this.inner.scrollLeft = this.inner.scrollWidth - this.inner.offsetWidth;
   }
 
-  private hasScrollBar(axis: ScrollAxis) {
+  public hasScrollBar(axis: ScrollAxis) {
     if (!this.inner) {
       return false;
     }


### PR DESCRIPTION
## Проблема

`SideMenu` использует приватный `hasScrollBar`. Некоторые пользователи используют приватное поле  `inner`. Это вызывает недовольство у `TypeScript`

## Решение

Сделала их публичными

## Ссылки

fix IF-1111

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
