### PR TITLE
fix(InputLikeText): use debounce to control async content selection

### DIFF
--- a/packages/react-ui/components/DateInput/__stories__/DateInput.stories.tsx
+++ b/packages/react-ui/components/DateInput/__stories__/DateInput.stories.tsx
@@ -9,6 +9,7 @@ import { Select } from '../../Select';
 import { DateInput, DateInputProps } from '../DateInput';
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { defaultLangCode } from '../../../lib/locale/constants';
+import { InternalDateGetter } from '../../../lib/date/InternalDateGetter';
 
 interface DateInputFormattingState {
   order: InternalDateOrder;
@@ -239,11 +240,21 @@ class DateInputSimple extends React.Component<DateInputSimpleProps> {
 }
 
 class DateInputLastEvent extends React.Component {
+  private getTodayComponents = InternalDateGetter.getTodayComponents;
   public state = {
     lastEvent: 'none',
   };
 
+  public handleFocus = () => {
+    InternalDateGetter.getTodayComponents = () => ({
+      date: 1,
+      month: 1,
+      year: 2000,
+    });
+  };
+
   public handleBlur = () => {
+    InternalDateGetter.getTodayComponents = this.getTodayComponents;
     this.setState({ lastEvent: 'blur' });
   };
 
@@ -254,7 +265,12 @@ class DateInputLastEvent extends React.Component {
   public render() {
     return (
       <Gapped>
-        <DateInputSimple onValueChange={this.handleChange} onBlur={this.handleBlur} defaultValue="21.12.2012" />
+        <DateInputSimple
+          onValueChange={this.handleChange}
+          onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
+          defaultValue="21.12.2012"
+        />
         <div>{this.state.lastEvent}</div>
       </Gapped>
     );
@@ -380,15 +396,6 @@ BlurAlwaysAfterChange.parameters = {
       },
       async 'value restored'() {
         await this.browser.executeScript(function () {
-          // @ts-expect-error: `window` object doesn't expose types by default. See: https://github.com/microsoft/TypeScript/issues/19816.
-          window.OldDate = window.Date;
-          // @ts-expect-error: Read the comment above.
-          window.Date = function () {
-            // @ts-expect-error: Read the comment above.
-            return new window.OldDate(2000, 0, 1);
-          };
-        });
-        await this.browser.executeScript(function () {
           const input = window.document.querySelector("[data-comp-name~='DateInput']");
           if (input instanceof HTMLElement) {
             input.focus();
@@ -402,10 +409,9 @@ BlurAlwaysAfterChange.parameters = {
           .click(this.browser.findElement({ css: 'body' }))
           .perform();
         await this.browser.executeScript(function () {
-          // @ts-expect-error: `window` object doesn't expose types by default. See: https://github.com/microsoft/TypeScript/issues/19816.
-          if (window.OldDate) {
-            // @ts-expect-error: Read the comment above.
-            window.Date = window.OldDate;
+          const input = window.document.querySelector("[data-comp-name~='DateInput']");
+          if (input instanceof HTMLElement) {
+            input.blur();
           }
         });
         await this.expect(await this.takeScreenshot()).to.matchImage('value restored');

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import ReactDOM from 'react-dom';
+import debounce from 'lodash.debounce';
 
 import { isNonNullable } from '../../lib/utils';
 import { isKeyTab, isShortcutPaste } from '../../lib/events/keyboard/identifiers';
@@ -100,6 +101,9 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
     return this.node;
   }
 
+  // Async call required for Firefox
+  private selectNodeContentsDebounced = debounce(selectNodeContents, 0);
+
   public selectInnerNode = (node: HTMLElement | null, start = 0, end = 1) => {
     if (this.dragging || !node) {
       return;
@@ -112,7 +116,8 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
     this.frozenBlur = true;
 
     this.lastSelectedInnerNode = [node, start, end];
-    setTimeout(() => selectNodeContents(node, start, end), 0);
+    this.selectNodeContentsDebounced(node, start, end);
+
     if (this.focusTimeout) {
       clearInterval(this.focusTimeout);
     }
@@ -465,6 +470,7 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
   };
 
   private handleBlur = (e: React.FocusEvent<HTMLElement>) => {
+    this.selectNodeContentsDebounced.cancel();
     if (isMobile) {
       e.target.removeAttribute('contenteditable');
     }


### PR DESCRIPTION
Черипик из https://github.com/skbkontur/retail-ui/pull/3218 для релиза мастера.