### PR TITLE
chore: add missing export

### DIFF
--- a/packages/react-ui-validations/src/index.tsx
+++ b/packages/react-ui-validations/src/index.tsx
@@ -1,13 +1,27 @@
 import { text, tooltip } from './ErrorRenderer';
-import { ValidationContainer, ValidationContainerProps } from './ValidationContainer';
+import {
+  ValidationContainer,
+  ValidationContainerProps,
+  FocusMode,
+  ValidationSettings,
+  ValidateArgumentType,
+  ScrollOffset,
+} from './ValidationContainer';
 import { TooltipPosition, ValidationTooltip, ValidationTooltipProps } from './ValidationTooltip';
-import { RenderErrorMessage, Validation, ValidationBehaviour } from './ValidationWrapperInternal';
+import {
+  RenderErrorMessage,
+  Validation,
+  ValidationBehaviour,
+  ValidationLevel,
+  TextPosition,
+} from './ValidationWrapperInternal';
 import { ValidationWrapper, ValidationInfo, ValidationWrapperProps } from './ValidationWrapper';
 import {
   ValidationContext,
   ValidationContextType,
   ValidationContextWrapper,
   ValidationContextWrapperProps,
+  ValidationContextSettings,
 } from './ValidationContextWrapper';
 
 export {
@@ -30,6 +44,13 @@ export {
   TooltipPosition,
   tooltip,
   text,
+  FocusMode,
+  ValidationSettings,
+  ValidateArgumentType,
+  ValidationContextSettings,
+  ScrollOffset,
+  ValidationLevel,
+  TextPosition,
 };
 
 export * from './Validations';


### PR DESCRIPTION
## Проблема

Из пакета react-ui-validations yе получается импортировать `ValidationSettings` и `FocusMode`. Стоит проверить и другие типы

## Решение

Добавила остутствующие экспорты

## Ссылки

fix F-1371

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
