### PR TITLE
chore(ComboBox): fix example

### DIFF
--- a/packages/react-ui/components/ComboBox/ComboBox.md
+++ b/packages/react-ui/components/ComboBox/ComboBox.md
@@ -163,7 +163,7 @@ const getItems = q =>
       { approved: false, value: 3, label: 'Розенкранц Харитонов', email: 'third@skbkontur.ru' },
       { approved: false, value: 4, label: 'Надежда Дубова', email: 'fourth@skbkontur.ru' },
       { approved: true, value: 5, label: 'Владислав Сташкеевич', email: 'fifth@skbkontur.ru' },
-      { approved: true, value: 6, label: 'Василиса Поволоцкая', email: 'sixth@skbkontur.ru' },
+      { approved: true, value: 6, label: 'Василиса Александровна Поволоцкая', email: 'sixth@skbkontur.ru' },
     ].filter(x => x.label.toLowerCase().includes(q.toLowerCase()) || x.value.toString(10) === q),
   ).then(delay(500));
 
@@ -195,7 +195,7 @@ const customRenderItem = item => (
   >
     <div
       style={{
-        minWidth: '55%',
+        width: '55%',
         display: 'flex',
       }}
     >
@@ -242,7 +242,9 @@ const customRenderValue = item => (
   >
     <div
       style={{
-        minWidth: '55%',
+        width: '55%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis'
       }}
     >
       {item.label}


### PR DESCRIPTION
## Проблема

В примере "_Переопределение renderValue, renderItem и itemWrapper_" некорректно отображались длинные имена: 

![image](https://github.com/skbkontur/retail-ui/assets/32093844/79c7c910-b85e-458b-a88c-4dd4a6592eab)

![image](https://github.com/skbkontur/retail-ui/assets/32093844/773f3adf-e311-46ab-be59-86831af9a3e5)

## Решение

исправила пример

## Ссылки

fix IF-1375

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
