### PR TITLE
ci: fix publishing of a specific directory via npm

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -21,7 +21,7 @@
     "build": "run-p build:esm build:cjs && node scripts/build/postbuild",
     "clean": "git clean -fdxqe node_modules",
     "prerelease": "node scripts/publish/prepublish && yarn build",
-    "release": "cd build && npm publish && cd ..",
+    "release": "npm publish ./build --workspaces=false",
     "postrelease": "yarn deploy",
     "predeploy": "rimraf .styleguide/deploy && yarn run styleguide:build",
     "deploy": "gh-pages -a -d .styleguide/deploy -r git@github.com:skbkontur/react-ui.git",


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
Во время релиза react-ui перестала публиковаться директория `build`, несмотря на указание ее в команде:

> npm publish ./build

Опытным путем выяснил, что проблема появилась в [npm@8.5.0](https://github.com/npm/cli/blob/v8.5.0/CHANGELOG.md#v850-2022-02-10), вероятно из-за фичи с воркспейсами.

<!-- Подробно опиши решаемую проблему. -->

## Решение

Проблема лечится отключением воркспейсов опцией [--workspaces=false](https://docs.npmjs.com/cli/v8/commands/npm-publish#workspaces). Проверил в последнем next: [@skbkontur/react-ui@4.16.0-next.5](https://npmfs.com/package/@skbkontur/react-ui/4.16.0-next.5/).

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-1377

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
