### PR TITLE
feat(Textarea): add prop size, tests, documentation

### DIFF
--- a/packages/react-ui/.creevey/images/Textarea/size/chrome.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98f6f383a83f3154b46931b73088fad6dca39db9ee9849a4a90955bbb20013c9
+size 7769

--- a/packages/react-ui/.creevey/images/Textarea/size/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:546048f13088a7a8e9345eef3eba978fdfc7df1fb8c012f5e452cfbdc44ed61a
+size 8081

--- a/packages/react-ui/.creevey/images/Textarea/size/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:820d99b85388ad9fb400dbe84df5c67caa264caf4208b7738a95defc588eef57
+size 8053

--- a/packages/react-ui/.creevey/images/Textarea/size/chrome8px.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2089bd85f894ad4d14a4b60be7f14291a2f9e0d8f77455b52b4adadb9e35318f
+size 7907

--- a/packages/react-ui/.creevey/images/Textarea/size/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f1bcb546a9822578d0d7b96dc94c85759ff9348aeba330906add49c3a522ff8
+size 7823

--- a/packages/react-ui/.creevey/images/Textarea/size/chromeFlat8px.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/chromeFlat8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9cc0c06fe0065c40f2d22f4bc870ab110b459dabbf2fcfb541124170338f888
+size 7784

--- a/packages/react-ui/.creevey/images/Textarea/size/firefox.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77e9c3eb751209d3486755d52d3fc8edf7ad602cc56de9b95eac656de6cb9aab
+size 8508

--- a/packages/react-ui/.creevey/images/Textarea/size/firefox2022.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c66724650744bf90b73c74d9736bf0b88836fae72cc405ec793683aa51268a3
+size 8759

--- a/packages/react-ui/.creevey/images/Textarea/size/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09629f204a708e5dadd7cdd98edab308afa7ef5aff3302ac462862f1f2dc6e47
+size 8685

--- a/packages/react-ui/.creevey/images/Textarea/size/firefox8px.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c3baf4cfddcf398172671b7c14084fe45a8c64a17cfd6790d0c7cedeee79f6f
+size 8541

--- a/packages/react-ui/.creevey/images/Textarea/size/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed98f8edbb002d2716ef0028836b4216ff565334d5e6a9492dda85b44c0056ed
+size 8469

--- a/packages/react-ui/.creevey/images/Textarea/size/firefoxFlat8px.png
+++ b/packages/react-ui/.creevey/images/Textarea/size/firefoxFlat8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81a006aed808b2ce39cf64b6732caa56251588d5fac94d60a06d575fbea78b6a
+size 8352

--- a/packages/react-ui/components/Textarea/Textarea.md
+++ b/packages/react-ui/components/Textarea/Textarea.md
@@ -42,3 +42,13 @@ const [value, setValue] = React.useState('');
   counterHelp="Hello 👋"
 />;
 ```
+
+У Textarea есть 3 стандартных размера.
+
+```jsx harmony
+<Gapped vertical>
+  <Textarea size={'small'} value={'Маленький'} autoResize rows={1} />
+  <Textarea size={'medium'} value={'Средний'} autoResize rows={1} />
+  <Textarea size={'large'} value={'Большой'} autoResize rows={1} />
+</Gapped>
+```

--- a/packages/react-ui/components/Textarea/Textarea.mixins.ts
+++ b/packages/react-ui/components/Textarea/Textarea.mixins.ts
@@ -1,0 +1,22 @@
+import { css } from '../../lib/theming/Emotion';
+
+export const rootTextareaSizeMixin = (fontSize: string, lineHeight: string) => {
+  return css`
+    font-size: ${fontSize};
+    line-height: ${lineHeight};
+  `;
+};
+
+export const textareaSizeMixin = (paddingY: string, paddingX: string, minHeight: string) => {
+  return css`
+    min-height: ${minHeight};
+    padding: ${paddingY} ${paddingX};
+  `;
+};
+
+export const counterSizeMixin = (paddingX: string, paddingY: string) => {
+  return css`
+    right: ${paddingY};
+    bottom: ${paddingX};
+  `;
+};

--- a/packages/react-ui/components/Textarea/Textarea.styles.ts
+++ b/packages/react-ui/components/Textarea/Textarea.styles.ts
@@ -1,13 +1,28 @@
 import { css, memoizeStyle } from '../../lib/theming/Emotion';
 import { Theme } from '../../lib/theming/Theme';
 
+import { counterSizeMixin, rootTextareaSizeMixin, textareaSizeMixin } from './Textarea.mixins';
+
 export const styles = memoizeStyle({
-  root(t: Theme) {
+  root() {
     return css`
       display: inline-block;
-      font-size: ${t.textareaFontSize};
-      line-height: ${t.textareaLineHeight};
       position: relative;
+    `;
+  },
+  rootSmall(t: Theme) {
+    return css`
+      ${rootTextareaSizeMixin(t.textareaFontSizeSmall, t.textareaLineHeightSmall)};
+    `;
+  },
+  rootMedium(t: Theme) {
+    return css`
+      ${rootTextareaSizeMixin(t.textareaFontSizeMedium, t.textareaLineHeightMedium)};
+    `;
+  },
+  rootLarge(t: Theme) {
+    return css`
+      ${rootTextareaSizeMixin(t.textareaFontSizeLarge, t.textareaLineHeightLarge)};
     `;
   },
 
@@ -26,9 +41,7 @@ export const styles = memoizeStyle({
       line-height: inherit;
       max-width: 100%;
       min-width: ${t.textareaWidth};
-      min-height: ${t.textareaMinHeight};
       outline: none;
-      padding: ${t.textareaPaddingY} ${t.textareaPaddingX};
       transition: border-color ${t.transitionDuration} ${t.transitionTimingFunction}, height 0.2s ease-out;
       vertical-align: middle;
       width: 100%;
@@ -57,6 +70,21 @@ export const styles = memoizeStyle({
       &::-moz-placeholder {
         color: ${t.textareaPlaceholderColor};
       }
+    `;
+  },
+  textareaSmall(t: Theme) {
+    return css`
+      ${textareaSizeMixin(t.textareaPaddingYSmall, t.textareaPaddingXSmall, t.textareaMinHeightSmall)};
+    `;
+  },
+  textareaMedium(t: Theme) {
+    return css`
+      ${textareaSizeMixin(t.textareaPaddingYMedium, t.textareaPaddingXMedium, t.textareaMinHeightMedium)};
+    `;
+  },
+  textareaLarge(t: Theme) {
+    return css`
+      ${textareaSizeMixin(t.textareaPaddingYLarge, t.textareaPaddingXLarge, t.textareaMinHeightLarge)};
     `;
   },
 
@@ -147,8 +175,21 @@ export const styles = memoizeStyle({
       background: ${t.textareaCounterBg};
       color: ${t.textareaCounterColor};
       border-radius: 2px;
-      right: ${t.textareaPaddingX};
-      bottom: ${t.textareaPaddingY};
+    `;
+  },
+  counterSmall(t: Theme) {
+    return css`
+      ${counterSizeMixin(t.textareaPaddingYSmall, t.textareaPaddingXSmall)};
+    `;
+  },
+  counterMedium(t: Theme) {
+    return css`
+      ${counterSizeMixin(t.textareaPaddingYMedium, t.textareaPaddingXMedium)};
+    `;
+  },
+  counterLarge(t: Theme) {
+    return css`
+      ${counterSizeMixin(t.textareaPaddingYLarge, t.textareaPaddingXLarge)};
     `;
   },
 

--- a/packages/react-ui/components/Textarea/Textarea.tsx
+++ b/packages/react-ui/components/Textarea/Textarea.tsx
@@ -24,6 +24,8 @@ import { getTextAreaHeight } from './TextareaHelpers';
 import { styles } from './Textarea.styles';
 import { TextareaCounter, TextareaCounterRef } from './TextareaCounter';
 
+export type TextareaSize = 'small' | 'medium' | 'large';
+
 const DEFAULT_WIDTH = 250;
 const AUTORESIZE_THROTTLE_DEFAULT_WAIT = 100;
 
@@ -42,7 +44,8 @@ export interface TextareaProps
         warning?: boolean;
         /** Не активное состояние */
         disabled?: boolean;
-
+        /** Размер */
+        size?: TextareaSize;
         /**
          * Автоматический ресайз
          * в зависимости от содержимого
@@ -120,7 +123,7 @@ export const TextareaDataTids = {
   helpIcon: 'TextareaCounter__helpIcon',
 } as const;
 
-type DefaultProps = Required<Pick<TextareaProps, 'rows' | 'maxRows' | 'extraRow' | 'disableAnimations'>>;
+type DefaultProps = Required<Pick<TextareaProps, 'rows' | 'maxRows' | 'extraRow' | 'disableAnimations' | 'size'>>;
 
 /**
  * Компонент для ввода многострочного текста.
@@ -191,10 +194,35 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
     rows: 3,
     maxRows: 15,
     extraRow: true,
+    size: 'small',
     disableAnimations: isTestEnv,
   };
 
   private getProps = createPropsGetter(Textarea.defaultProps);
+
+  private getRootSizeClassName() {
+    switch (this.getProps().size) {
+      case 'large':
+        return styles.rootLarge(this.theme);
+      case 'medium':
+        return styles.rootMedium(this.theme);
+      case 'small':
+      default:
+        return styles.rootSmall(this.theme);
+    }
+  }
+
+  private getTextareaSizeClassName() {
+    switch (this.getProps().size) {
+      case 'large':
+        return styles.textareaLarge(this.theme);
+      case 'medium':
+        return styles.textareaMedium(this.theme);
+      case 'small':
+      default:
+        return styles.textareaSmall(this.theme);
+    }
+  }
 
   public state = {
     needsPolyfillPlaceholder,
@@ -331,6 +359,7 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
       width = DEFAULT_WIDTH,
       error,
       warning,
+      size,
       autoResize,
       resize,
       onCut,
@@ -357,7 +386,7 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
       },
     };
 
-    const textareaClassNames = cx({
+    const textareaClassNames = cx(this.getTextareaSizeClassName(), {
       [styles.textarea(this.theme)]: true,
       [styles.hovering(this.theme)]: !error && !warning,
       [styles.disabled(this.theme)]: disabled,
@@ -390,6 +419,7 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
     const counter = showLengthCounter && isCounterVisible && this.node && (
       <TextareaCounter
         textarea={this.node}
+        size={this.getProps().size}
         help={counterHelp}
         value={textareaProps.value}
         length={textareaProps.maxLength ?? lengthCounter ?? 0}
@@ -404,7 +434,13 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
         onClickOutside={this.handleCloseCounterHelp}
         active={this.state.isCounterVisible}
       >
-        <label data-tid={TextareaDataTids.root} {...rootProps} className={styles.root(this.theme)}>
+        <label
+          data-tid={TextareaDataTids.root}
+          {...rootProps}
+          className={cx(this.getRootSizeClassName(), {
+            [styles.root()]: true,
+          })}
+        >
           {placeholderPolyfill}
           <ResizeDetector onResize={this.reflowCounter}>
             <textarea

--- a/packages/react-ui/components/Textarea/TextareaCounter.tsx
+++ b/packages/react-ui/components/Textarea/TextareaCounter.tsx
@@ -11,7 +11,7 @@ import { cx } from '../../lib/theming/Emotion';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { QuestionCircleIcon16Solid } from '../../internal/icons2022/QuestionCircleIcon/QuestionCircleIcon16Solid';
 
-import { TextareaDataTids, TextareaProps } from './Textarea';
+import { TextareaDataTids, TextareaProps, TextareaSize } from './Textarea';
 import { styles } from './Textarea.styles';
 
 export interface TextareaCounterProps {
@@ -20,6 +20,7 @@ export interface TextareaCounterProps {
   help: TextareaProps['counterHelp'];
   onCloseHelp: () => void;
   textarea: HTMLTextAreaElement;
+  size: TextareaSize;
 }
 
 export interface TextareaCounterRef {
@@ -30,7 +31,7 @@ const handleHelpMouseDown = (e: SyntheticEvent) => e.preventDefault();
 
 export const TextareaCounter = forwardRefAndName<TextareaCounterRef, TextareaCounterProps>(
   'TextareaCounter',
-  ({ length, value, help, onCloseHelp, textarea }, ref) => {
+  ({ length, value, help, onCloseHelp, textarea, size }, ref) => {
     const theme = useContext(ThemeContext);
     const [width, setWidth] = useState(textarea.clientWidth);
     const [height, setHeight] = useState(textarea.clientHeight);
@@ -62,10 +63,22 @@ export const TextareaCounter = forwardRefAndName<TextareaCounterRef, TextareaCou
       </Tooltip>
     );
 
+    const getCounterSizeClassName = () => {
+      switch (size) {
+        case 'large':
+          return styles.counterLarge(theme);
+        case 'medium':
+          return styles.counterMedium(theme);
+        case 'small':
+        default:
+          return styles.counterSmall(theme);
+      }
+    };
+
     return (
-      <div data-tid={TextareaDataTids.counter} className={styles.counterContainer(theme)} style={{ width, height }}>
+      <div data-tid={TextareaDataTids.counter} className={cx(styles.counterContainer(theme))} style={{ width, height }}>
         <span
-          className={cx(styles.counter(theme), {
+          className={cx(getCounterSizeClassName(), styles.counter(theme), {
             [styles.counterError(theme)]: counterValue < 0,
           })}
         >

--- a/packages/react-ui/components/Textarea/__stories__/Textarea.stories.tsx
+++ b/packages/react-ui/components/Textarea/__stories__/Textarea.stories.tsx
@@ -459,3 +459,15 @@ export const TextareaWithDisabledExtraRow: Story = () => {
   return <Textarea width={400} autoResize spellCheck={false} extraRow={false} value={value} />;
 };
 TextareaWithDisabledExtraRow.storyName = 'Textarea with disabled extra row';
+
+export const DifferentSizes: Story = () => {
+  return (
+    <Gapped vertical>
+      <Textarea value={'Size: no size choosen'} autoResize rows={1} />
+      <Textarea size={'small'} value={'Size: small'} autoResize rows={1} />
+      <Textarea size={'medium'} value={'Size: medium'} autoResize rows={1} />
+      <Textarea size={'large'} value={'Size: large'} autoResize rows={1} />
+    </Gapped>
+  );
+};
+DifferentSizes.storyName = 'size';

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1528,7 +1528,7 @@ export class DefaultTheme {
   //#endregion
   //#region Checkbox
   /**
-   * @ deprecated use checkboxFontSizeSmall
+   * @deprecated use checkboxFontSizeSmall
    */
   public static get checkboxFontSize() {
     return this.fontSizeSmall;
@@ -1544,7 +1544,7 @@ export class DefaultTheme {
   }
 
   /**
-   * @ deprecated use checkboxLineHeightSmall
+   * @deprecated use checkboxLineHeightSmall
    */
   public static get checkboxLineHeight() {
     return this.controlLineHeightSmall;
@@ -1559,7 +1559,7 @@ export class DefaultTheme {
     return this.controlLineHeightLarge;
   }
   /**
-   * @ deprecated use checkboxBoxSizeSmall
+   * @deprecated use checkboxBoxSizeSmall
    */
   public static checkboxBoxSize = '16px';
   public static checkboxBoxSizeSmall = '16px';
@@ -1568,7 +1568,7 @@ export class DefaultTheme {
   public static checkboxCaptionGap = '8px';
 
   /**
-   * @ deprecated use checkboxPaddingYSmall
+   * @deprecated use checkboxPaddingYSmall
    */
   public static get checkboxPaddingY() {
     const controlHeight = parseInt(this.controlHeightSmall, 10) || 0;
@@ -1679,7 +1679,7 @@ export class DefaultTheme {
   public static textareaShadow = 'none';
   public static textareaBackgroundClip = 'border-box';
   /**
-   * @ deprecated use textareaFontSizeSmall
+   * @deprecated use textareaFontSizeSmall
    */
   public static get textareaFontSize() {
     return this.fontSizeSmall;
@@ -1694,7 +1694,7 @@ export class DefaultTheme {
     return this.fontSizeLarge;
   }
   /**
-   * @ deprecated use textareaLineHeightSmall
+   * @deprecated use textareaLineHeightSmall
    */
   public static get textareaLineHeight() {
     return this.controlLineHeightSmall;
@@ -1718,7 +1718,7 @@ export class DefaultTheme {
     return `${outlineWidth - borderWidth}px`;
   }
   /**
-   * @ deprecated use textareaMinHeightSmall
+   * @deprecated use textareaMinHeightSmall
    */
   public static get textareaMinHeight() {
     const lineHeight = parseInt(this.textareaLineHeightSmall, 10) || 0;
@@ -1744,7 +1744,7 @@ export class DefaultTheme {
 
   public static textareaWidth = '250px';
   /**
-   * @ deprecated use textareaPaddingXSmall
+   * @deprecated use textareaPaddingXSmall
    */
   public static textareaPaddingX = '7px';
   static get textareaPaddingXSmall() {
@@ -1754,7 +1754,7 @@ export class DefaultTheme {
   public static textareaPaddingXLarge = '15px';
 
   /**
-   * @ deprecated use textareaPaddingYSmall
+   * @deprecated use textareaPaddingYSmall
    */
   public static get textareaPaddingY() {
     return this.controlPaddingYSmall;

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1678,11 +1678,35 @@ export class DefaultTheme {
   }
   public static textareaShadow = 'none';
   public static textareaBackgroundClip = 'border-box';
+  /**
+   * @ deprecated use textareaFontSizeSmall
+   */
   public static get textareaFontSize() {
     return this.fontSizeSmall;
   }
+  public static get textareaFontSizeSmall() {
+    return this.textareaFontSize;
+  }
+  public static get textareaFontSizeMedium() {
+    return this.fontSizeMedium;
+  }
+  public static get textareaFontSizeLarge() {
+    return this.fontSizeLarge;
+  }
+  /**
+   * @ deprecated use textareaLineHeightSmall
+   */
   public static get textareaLineHeight() {
     return this.controlLineHeightSmall;
+  }
+  public static get textareaLineHeightSmall() {
+    return this.textareaLineHeight;
+  }
+  public static get textareaLineHeightMedium() {
+    return this.controlLineHeightMedium;
+  }
+  public static get textareaLineHeightLarge() {
+    return this.controlLineHeightLarge;
   }
   public static textareaBorderRadius = '0px';
   public static get textareaBorderWidth() {
@@ -1693,18 +1717,58 @@ export class DefaultTheme {
     const borderWidth = parseInt(this.textareaBorderWidth, 10) || 0;
     return `${outlineWidth - borderWidth}px`;
   }
+  /**
+   * @ deprecated use textareaMinHeightSmall
+   */
   public static get textareaMinHeight() {
-    const lineHeight = parseInt(this.textareaLineHeight, 10) || 0;
-    const paddingY = parseInt(this.textareaPaddingY, 10) || 0;
+    const lineHeight = parseInt(this.textareaLineHeightSmall, 10) || 0;
+    const paddingY = parseInt(this.textareaPaddingYSmall, 10) || 0;
     const borderWidth = parseInt(this.textareaBorderWidth, 10) || 0;
-
     return `${lineHeight + paddingY * 2 + borderWidth * 2}px`;
   }
+  public static get textareaMinHeightSmall() {
+    return this.textareaMinHeight;
+  }
+  public static get textareaMinHeightMedium() {
+    const lineHeight = parseInt(this.textareaLineHeightMedium, 10) || 0;
+    const paddingY = parseInt(this.textareaPaddingYMedium, 10) || 0;
+    const borderWidth = parseInt(this.textareaBorderWidth, 10) || 0;
+    return `${lineHeight + paddingY * 2 + borderWidth * 2}px`;
+  }
+  public static get textareaMinHeightLarge() {
+    const lineHeight = parseInt(this.textareaLineHeightLarge, 10) || 0;
+    const paddingY = parseInt(this.textareaPaddingYLarge, 10) || 0;
+    const borderWidth = parseInt(this.textareaBorderWidth, 10) || 0;
+    return `${lineHeight + paddingY * 2 + borderWidth * 2}px`;
+  }
+
   public static textareaWidth = '250px';
+  /**
+   * @ deprecated use textareaPaddingXSmall
+   */
   public static textareaPaddingX = '7px';
+  static get textareaPaddingXSmall() {
+    return this.textareaPaddingX;
+  }
+  public static textareaPaddingXMedium = '11px';
+  public static textareaPaddingXLarge = '15px';
+
+  /**
+   * @ deprecated use textareaPaddingYSmall
+   */
   public static get textareaPaddingY() {
     return this.controlPaddingYSmall;
   }
+  public static get textareaPaddingYSmall() {
+    return this.textareaPaddingY;
+  }
+  public static get textareaPaddingYMedium() {
+    return this.controlPaddingYMedium;
+  }
+  public static get textareaPaddingYLarge() {
+    return this.controlPaddingYLarge;
+  }
+
   public static get textareaBorderColor() {
     return this.borderColorGrayLight;
   }


### PR DESCRIPTION
## Проблема

Добавить проп size для Textarea

## Ссылки
https://yt.skbkontur.ru/issue/IF-1357/Dobavit-prop-Size-dlya-Textarea
https://yt.skbkontur.ru/issue/IF-807/Dobavit-propy-size-dlya-vseh-komponentov

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)