### PR TITLE
feat(Link): add transition on underline

### DIFF
--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -28,6 +28,8 @@ const oldLineText = function (t: Theme) {
   `;
 };
 
+const linkLineBorderBottomColor = 'color-mix(in srgb, currentColor ${t.linkLineBorderBottomOpacity}, transparent)';
+
 export const styles = memoizeStyle({
   root(t: Theme) {
     return css`
@@ -52,7 +54,7 @@ export const styles = memoizeStyle({
     // Планировалось добавить transition и color-mix(in srgb, currentColor 50%, transparent) в lineText.
     // Однако, в chrome и edge сочетание transition, color-mix и currentColor вызывает моргание при transition.
     return css`
-      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
+      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
@@ -66,12 +68,12 @@ export const styles = memoizeStyle({
 
   lineText(t: Theme) {
     return css`
-      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
+      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
-        border-bottom-color: ${t.linkLineBorderBottomColor};
+        border-bottom-color: ${linkLineBorderBottomColor};
       }
-      else {
+      @supports not (border-bottom-color: ${linkLineBorderBottomColor}) {
         ${oldLineText(t)};
       }
     `;

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -28,8 +28,8 @@ const oldLineText = function (t: Theme) {
   `;
 };
 
-const linkLineBorderBottomColor = 'color-mix(in srgb, currentColor ${t.linkLineBorderBottomOpacity}, transparent)';
-
+// const linkLineBorderBottomColor = 'color-mix(in srgb, currentColor ${t.linkLineBorderBottomOpacity}, transparent)';
+//
 export const styles = memoizeStyle({
   root(t: Theme) {
     return css`
@@ -54,7 +54,7 @@ export const styles = memoizeStyle({
     // Планировалось добавить transition и color-mix(in srgb, currentColor 50%, transparent) в lineText.
     // Однако, в chrome и edge сочетание transition, color-mix и currentColor вызывает моргание при transition.
     return css`
-      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
+      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
@@ -68,12 +68,12 @@ export const styles = memoizeStyle({
 
   lineText(t: Theme) {
     return css`
-      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
+      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
-        border-bottom-color: ${linkLineBorderBottomColor};
+        border-bottom-color: ${t.linkLineBorderBottomColor};
       }
-      @supports not (border-bottom-color: ${linkLineBorderBottomColor}) {
+      @supports not (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         ${oldLineText(t)};
       }
     `;

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -28,8 +28,6 @@ const oldLineText = function (t: Theme) {
   `;
 };
 
-// const linkLineBorderBottomColor = 'color-mix(in srgb, currentColor ${t.linkLineBorderBottomOpacity}, transparent)';
-//
 export const styles = memoizeStyle({
   root(t: Theme) {
     return css`

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -16,6 +16,18 @@ const line = keyframes`
   }
 `;
 
+const oldLineText = function (t: Theme) {
+  const delay = parseFloat(t.linkLineBorderBottomOpacity) - 1;
+  return css`
+    border-bottom-style: ${t.linkLineBorderBottomStyle};
+    border-bottom-width: ${t.linkLineBorderBottomWidth};
+    animation: ${line} 1s linear !important; // override creevey
+    animation-play-state: paused !important;
+    animation-delay: ${delay}s !important;
+    animation-fill-mode: forwards !important;
+  `;
+};
+
 export const styles = memoizeStyle({
   root(t: Theme) {
     return css`
@@ -32,15 +44,40 @@ export const styles = memoizeStyle({
     `;
   },
 
-  lineText(t: Theme) {
-    const delay = parseFloat(t.linkLineBorderBottomOpacity) - 1;
+  lineTextWrapper(t: Theme) {
+    // При hover'е выполняется подчеркивание из прозрачного переходит в currentColor.
+    // За счет наложения этого цвета на подчеркивание lineText (currentColor с половинной прозрачностью)
+    // достигается эффект перехода currentColor с половинной прозрачностью до currentColor.
     return css`
-      border-bottom-style: ${t.linkLineBorderBottomStyle};
-      border-bottom-width: ${t.linkLineBorderBottomWidth};
-      animation: ${line} 1s linear !important; // override creevey
-      animation-play-state: paused !important;
-      animation-delay: ${delay}s !important;
-      animation-fill-mode: forwards !important;
+      display: inline;
+      @supports (border-bottom-color: color-mix(in srgb, currentColor 50%, transparent)) {
+        transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
+        border-bottom-style: ${t.linkLineBorderBottomStyle};
+        border-bottom-width: ${t.linkLineBorderBottomWidth};
+        border-bottom-color: transparent;
+        &:hover {
+          border-bottom-color: currentColor;
+        }
+      }
+    `;
+  },
+
+  lineText(t: Theme) {
+    return css`
+      @supports (border-bottom-color: color-mix(in srgb, currentColor 50%, transparent)) {
+        border-bottom-style: ${t.linkLineBorderBottomStyle};
+        border-bottom-width: ${t.linkLineBorderBottomWidth};
+        border-bottom-color: color-mix(in srgb, currentColor 50%, transparent);
+      }
+      @supports not (border-bottom-color: color-mix(in srgb, currentColor 50%, transparent)) {
+        ${oldLineText(t)};
+      }
+    `;
+  },
+
+  lineTextIE11(t: Theme) {
+    return css`
+      ${oldLineText(t)};
     `;
   },
 

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -50,6 +50,9 @@ export const styles = memoizeStyle({
     // При hover'е подчеркивание из прозрачного переходит в currentColor.
     // За счет наложения этого цвета на подчеркивание lineText (currentColor с половинной прозрачностью)
     // достигается эффект перехода currentColor с половинной прозрачностью до currentColor.
+
+    // Планировалось добавить transition и color-mix(in srgb, currentColor 50%, transparent) в lineText.
+    // Однако, в chrome и edge сочетание transition, color-mix и currentColor вызывает моргание при transition.
     return css`
       @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -28,8 +28,6 @@ const oldLineText = function (t: Theme) {
   `;
 };
 
-const linkLineBorderBottomColor = 'color-mix(in srgb, currentColor ${t.linkLineBorderBottomOpacity}, transparent)';
-
 export const styles = memoizeStyle({
   root(t: Theme) {
     return css`
@@ -54,7 +52,7 @@ export const styles = memoizeStyle({
     // Планировалось добавить transition и color-mix(in srgb, currentColor 50%, transparent) в lineText.
     // Однако, в chrome и edge сочетание transition, color-mix и currentColor вызывает моргание при transition.
     return css`
-      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
+      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
@@ -68,12 +66,12 @@ export const styles = memoizeStyle({
 
   lineText(t: Theme) {
     return css`
-      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
+      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
-        border-bottom-color: ${linkLineBorderBottomColor};
+        border-bottom-color: ${t.linkLineBorderBottomColor};
       }
-      @supports not (border-bottom-color: ${linkLineBorderBottomColor}) {
+      else {
         ${oldLineText(t)};
       }
     `;

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -28,6 +28,8 @@ const oldLineText = function (t: Theme) {
   `;
 };
 
+const linkLineBorderBottomColor = 'color-mix(in srgb, currentColor ${t.linkLineBorderBottomOpacity}, transparent)';
+
 export const styles = memoizeStyle({
   root(t: Theme) {
     return css`
@@ -45,12 +47,11 @@ export const styles = memoizeStyle({
   },
 
   lineTextWrapper(t: Theme) {
-    // При hover'е выполняется подчеркивание из прозрачного переходит в currentColor.
+    // При hover'е подчеркивание из прозрачного переходит в currentColor.
     // За счет наложения этого цвета на подчеркивание lineText (currentColor с половинной прозрачностью)
     // достигается эффект перехода currentColor с половинной прозрачностью до currentColor.
     return css`
-      display: inline;
-      @supports (border-bottom-color: color-mix(in srgb, currentColor 50%, transparent)) {
+      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
@@ -64,12 +65,12 @@ export const styles = memoizeStyle({
 
   lineText(t: Theme) {
     return css`
-      @supports (border-bottom-color: color-mix(in srgb, currentColor 50%, transparent)) {
+      @supports (border-bottom-color: ${linkLineBorderBottomColor}) {
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
-        border-bottom-color: color-mix(in srgb, currentColor 50%, transparent);
+        border-bottom-color: ${linkLineBorderBottomColor};
       }
-      @supports not (border-bottom-color: color-mix(in srgb, currentColor 50%, transparent)) {
+      @supports not (border-bottom-color: ${linkLineBorderBottomColor}) {
         ${oldLineText(t)};
       }
     `;

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -192,7 +192,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
     if (_isTheme2022) {
       // lineTextWrapper нужен для реализации transition у подчеркивания
       child = (
-        <div className={cx(styles.lineTextWrapper(this.theme))}>
+        <span className={cx(styles.lineTextWrapper(this.theme))}>
           <span
             className={cx(globalClasses.text, {
               [styles.lineText(this.theme)]: !isIE11,
@@ -201,7 +201,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
           >
             {this.props.children}
           </span>
-        </div>
+        </span>
       );
     }
 

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -13,6 +13,7 @@ import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter, DefaultizedProps } from '../../lib/createPropsGetter';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
 import { isDarkTheme, isTheme2022 } from '../../lib/theming/ThemeHelpers';
+import { isIE11 } from '../../lib/client';
 
 import { globalClasses, styles } from './Link.styles';
 
@@ -189,7 +190,19 @@ export class Link extends React.Component<LinkProps, LinkState> {
 
     let child = this.props.children;
     if (_isTheme2022) {
-      child = <span className={cx(globalClasses.text, styles.lineText(this.theme))}>{this.props.children}</span>;
+      // lineTextWrapper нужен для реализации transition у подчеркивания
+      child = (
+        <div className={cx(styles.lineTextWrapper(this.theme))}>
+          <span
+            className={cx(globalClasses.text, {
+              [styles.lineText(this.theme)]: !isIE11,
+              [styles.lineTextIE11(this.theme)]: isIE11,
+            })}
+          >
+            {this.props.children}
+          </span>
+        </div>
+      );
     }
 
     return (

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -127,9 +127,6 @@ export class DefaultTheme {
   }
   public static linkLineBorderBottomWidth = '0px';
   public static linkLineBorderBottomOpacity = '0.5';
-  public static linkLineBorderBottomColor = `color-mix(in srgb, currentColor ${
-    parseFloat(this.linkLineBorderBottomOpacity) * 100
-  }%, transparent)`;
 
   //#endregion
   //#region Token

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -131,7 +131,6 @@ export class DefaultTheme {
     parseFloat(this.linkLineBorderBottomOpacity) * 100
   }%, transparent)`;
 
-
   //#endregion
   //#region Token
   public static tokenDisabledBg = 'rgba(0, 0, 0, 0.05)';

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -127,6 +127,10 @@ export class DefaultTheme {
   }
   public static linkLineBorderBottomWidth = '0px';
   public static linkLineBorderBottomOpacity = '0.5';
+  public static linkLineBorderBottomColor = `color-mix(in srgb, currentColor ${
+    parseFloat(this.linkLineBorderBottomOpacity) * 100
+  }%, transparent)`;
+
 
   //#endregion
   //#region Token

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -127,6 +127,9 @@ export class DefaultTheme {
   }
   public static linkLineBorderBottomWidth = '0px';
   public static linkLineBorderBottomOpacity = '0.5';
+  public static linkLineBorderBottomColor = `color-mix(in srgb, currentColor ${
+    parseFloat(this.linkLineBorderBottomOpacity) * 100
+  }%, transparent)`;
 
   //#endregion
   //#region Token


### PR DESCRIPTION
## Проблема

Отсутствует transition на подчеркивании в 2022 теме. 

## Решение
Изначально планировалось добавить стили:
`transition: border-bottom-color 1000ms cubic-bezier(0.5, 1, 0.89, 1);
border-bottom-color: color-mix(in srgb, currentColor 50%, transparent);`
Однако, в chrome и edge сочетание transition, color-mix и currentColor вызывает моргание при применении transition.

Чтобы избежать этого - добавила lineTextWrapper с прозрачным подчеркиванием, при hover'е меняющимся на currentColor, а у lineText оставила подчеркивание currentColor с половинной прозрачностью.
При hover'е выполняется подчеркивание из прозрачного переходит в currentColor. За счет наложения этого цвета на подчеркивание lineText (currentColor с половинной прозрачностью) достигается эффект перехода currentColor с половинной прозрачностью до currentColor.

Однако в chrome<111, edge<111, firefox<113 color-mix не поддерживается. Для поддержки старых и новых версий браузеров используется @supports not с решением через color-mix и @supports not со старым решением соответственно.

## Ссылки

https://yt.skbkontur.ru/issue/IF-1376
https://yt.skbkontur.ru/issue/IF-1308

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
