### PR TITLE
fix(Select): let _renderButton override aria-label passed to root

### DIFF
--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -693,7 +693,6 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
           'aria-describedby': this.props['aria-describedby'],
           'aria-expanded': this.state.opened ? 'true' : 'false',
           'aria-controls': this.menuId,
-          // TODO: remove condtion (`buttonElement.props['aria-label'] ??`) in 5.0 thus unifying API
           'aria-label': buttonElement.props['aria-label'] ?? this.props['aria-label'],
         })
       : buttonElement;

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -693,7 +693,8 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
           'aria-describedby': this.props['aria-describedby'],
           'aria-expanded': this.state.opened ? 'true' : 'false',
           'aria-controls': this.menuId,
-          'aria-label': this.props['aria-label'],
+          // TODO: remove condtion (`buttonElement.props['aria-label'] ??`) in 5.0 thus unifying API
+          'aria-label': buttonElement.props['aria-label'] ?? this.props['aria-label'],
         })
       : buttonElement;
   };

--- a/packages/react-ui/components/Select/__tests__/Select-test.tsx
+++ b/packages/react-ui/components/Select/__tests__/Select-test.tsx
@@ -283,6 +283,29 @@ describe('Select', () => {
 
       expect(screen.getByRole('button')).toHaveAttribute('aria-label', ariaLabel);
     });
+
+    it('sets value for aria-label attribute when `_renderButton` is passed', () => {
+      const ariaLabel = 'aria-label';
+      render(<Select _renderButton={(params) => <button {...params}>test</button>} aria-label={ariaLabel} />);
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-label', ariaLabel);
+    });
+
+    it('aria-label passed to `_renderButton` overrides aria-label on `Select`', () => {
+      const ariaLabel = 'aria-label';
+      render(
+        <Select
+          _renderButton={(params) => (
+            <button {...params} aria-label={ariaLabel}>
+              test
+            </button>
+          )}
+          aria-label={'test'}
+        />,
+      );
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-label', ariaLabel);
+    });
   });
 
   describe('Locale', () => {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Если пробрасывать `aria-label` в `Select` при использовании пропа `_renderButton`, то `aria-label` проброшенный в `_renderButton` будет перезаписан, что приводит к ломающим изменениям

## Решение

Написал условие для проверки что в `_renderButton` не был проброшен `aria-label`, прежде чем записывать `aria-label` из пропов

Создал задачу IF-1420, чтобы избавиться от этого поведения в мажорной версии, так как остальные пропы перезаписывают значение в `_renderButton`

## Ссылки

IF-1416, IF-1420

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
