### PR TITLE
fix(Toggle): disable animations for `THEME_2022`

### DIFF
--- a/packages/react-ui/.creevey/images/ZIndex/Loader and SidePage/SidePage shadow cover Loader/chrome2022Dark/SidePage shadow cover Loader.png
+++ b/packages/react-ui/.creevey/images/ZIndex/Loader and SidePage/SidePage shadow cover Loader/chrome2022Dark/SidePage shadow cover Loader.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5151cf9efefb6f828ad875190c6599de7114df40f3f3b4d538d3262d9bfe23f1
-size 13995
+oid sha256:d6cf99f63c2220fa45733eb48ef31d565280d030bdeb1151ead74e6d39c80450
+size 13979

--- a/packages/react-ui/components/Toggle/Toggle.styles.ts
+++ b/packages/react-ui/components/Toggle/Toggle.styles.ts
@@ -127,7 +127,7 @@ export const styles = memoizeStyle({
     return css`
       &:enabled {
         ~ .${globalClasses.container}, ~ .${globalClasses.handle} {
-          transition: 0.2s ease-in !important;
+          transition: 0.2s ease-in;
         }
         :not(:checked) {
           ~ .${globalClasses.container} {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В теме `THEME_2022` не работает проп `disableAnimations`.
Из-за чего невозможно стабильно воспроизводить результат в скриншотном тестировании.

| ![image](https://github.com/skbkontur/retail-ui/assets/2708211/8e5d07a5-a6e7-4518-8adb-e1c690c78dad) |
| --- | 


## Решение

Удалил лишний `!important`.

Дело в альтернативной вёрстке для темы `THEME_2022`.
В ней отдельно задаются стили для анимации. И почему-то был добавлен флаг `!important`.
Вкупе с селектором, их специфичность не мог перебить стиль, отключающий анимации.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
