### PR TITLE
fix(ComboBox): describe all available types returned by `getItems`

### DIFF
--- a/packages/react-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/react-ui/components/ComboBox/ComboBox.tsx
@@ -53,7 +53,7 @@ export interface ComboBoxProps<T>
    * Элементы могут быть любого типа. В этом случае необходимо определить
    * свойства `itemToValue`, `renderValue`, `renderItem`, `valueToString`
    */
-  getItems: (query: string) => Promise<T[]>;
+  getItems: (query: string) => Promise<Array<ComboBoxExtendedItem<T>>>;
 
   /**
    * Необходим для сравнения полученных результатов с `value`
@@ -117,7 +117,7 @@ export interface ComboBoxProps<T>
    *    }
    * }}
    */
-  itemWrapper?: (item?: T) => React.ComponentType<unknown>;
+  itemWrapper?: (item: T) => React.ComponentType<unknown>;
 
   /**
    * Функция для отрисовки сообщения о пустом результате поиска
@@ -186,6 +186,8 @@ export interface ComboBoxItem {
   value: string;
   label: string;
 }
+
+export type ComboBoxExtendedItem<T> = T | (() => React.ReactElement<T>) | React.ReactElement<T>;
 
 type DefaultProps<T> = Required<
   Pick<

--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -7,7 +7,7 @@ import SearchIcon from '@skbkontur/react-icons/Search';
 
 import { Meta, Story } from '../../../typings/stories';
 import { ComboBox, ComboBoxProps } from '../ComboBox';
-import { MenuItem } from '../../MenuItem';
+import { MenuItem, MenuItemState } from '../../MenuItem';
 import { MenuSeparator } from '../../MenuSeparator';
 import { Nullable } from '../../../typings/utility-types';
 import { Toggle } from '../../Toggle';
@@ -1303,3 +1303,67 @@ WithManualPosition.parameters = {
     },
   },
 };
+
+export const WithExtendedItem: Story = () => {
+  const [value, setValue] = React.useState<ValueType>();
+
+  const CustomItem = ({ id, name }: ValueType) => (
+    <span>
+      CustomItem: {id} + {name}
+    </span>
+  );
+
+  const RenderItem = ({ id, name, state = null }: ValueType & { state?: MenuItemState }) => (
+    <span>
+      RenderItem: {id} + {name} (state: {state})
+    </span>
+  );
+
+  const ItemWrapper = ({ id, name }: ValueType) => (
+    <span>
+      ItemWrapper: {id} + {name}
+    </span>
+  );
+
+  return (
+    <>
+      Пример передачи в getItems всех допустимых типов.
+      <br />
+      Должны работать навигация клавишами и выбор пункта.
+      <br />
+      <ComboBox<ValueType>
+        value={value}
+        onValueChange={setValue}
+        itemToValue={(item) => item.id}
+        renderValue={(item) => item.name}
+        valueToString={(item) => item.name}
+        getItems={() =>
+          Promise.resolve([
+            { id: 1, name: 'Paris' },
+            { id: 2, name: 'Madrid' },
+            <MenuSeparator key={2} />,
+            <hr key={3} />,
+            <MenuItem key={1} {...{ id: 3, name: 'London' }}>
+              <CustomItem id={3} name="London" />
+            </MenuItem>,
+            () => (
+              <MenuItem {...{ id: 4, name: 'Berlin' }}>
+                <CustomItem id={4} name="Berlin" />
+              </MenuItem>
+            ),
+            { id: 5, name: 'Rome' },
+            { id: 6, name: 'Amsterdam' },
+          ])
+        }
+        renderItem={(item, state) => <RenderItem {...{ ...item, state }} />}
+        itemWrapper={(item) =>
+          function itemWrapper(props) {
+            const isJust2Items = item.id === 5 || item.id === 6;
+            return <button {...props}>{isJust2Items ? props.children : <ItemWrapper {...item} />}</button>;
+          }
+        }
+      />
+    </>
+  );
+};
+WithExtendedItem.parameters = { creevey: { skip: true } };

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxMenu.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxMenu.tsx
@@ -9,13 +9,14 @@ import { Nullable } from '../../typings/utility-types';
 import { MenuSeparator } from '../../components/MenuSeparator';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { MenuMessage } from '../MenuMessage';
+import { ComboBoxExtendedItem } from '../../components/ComboBox';
 
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { ComboBoxLocale, CustomComboBoxLocaleHelper } from './locale';
 
 export interface ComboBoxMenuProps<T> {
   opened?: boolean;
-  items?: Nullable<T[]>;
+  items?: Nullable<Array<ComboBoxExtendedItem<T>>>;
   totalCount?: number;
   loading?: boolean;
   maxMenuHeight?: number | string;
@@ -23,7 +24,7 @@ export interface ComboBoxMenuProps<T> {
   renderNotFound?: () => React.ReactNode;
   renderTotalCount?: (found: number, total: number) => React.ReactNode;
   renderItem: (item: T, state: MenuItemState) => React.ReactNode;
-  itemWrapper?: (item?: T) => React.ComponentType<unknown>;
+  itemWrapper?: (item: T) => React.ComponentType<unknown>;
   onValueChange: (value: T) => any;
   renderAddButton?: () => React.ReactNode;
   caption?: React.ReactNode;
@@ -170,11 +171,12 @@ export class ComboBoxMenu<T> extends React.Component<ComboBoxMenuProps<T>> {
     );
   }
 
-  private renderItem = (item: T, index: number): React.ReactNode => {
+  private renderItem = (item: ComboBoxExtendedItem<T>, index: number): React.ReactNode => {
     // NOTE this is undesireable feature, better
     // to remove it from further versions
     const { renderItem, onValueChange, itemWrapper } = this.props;
-    if (isFunction(item) || React.isValidElement(item)) {
+
+    if (!isSimpleItem<T>(item)) {
       const element = isFunction(item) ? item() : item;
       const props = Object.assign(
         {
@@ -198,4 +200,8 @@ export class ComboBoxMenu<T> extends React.Component<ComboBoxMenuProps<T>> {
       </MenuItem>
     );
   };
+}
+
+function isSimpleItem<T>(item: ComboBoxExtendedItem<T>): item is T {
+  return !isFunction(item) && !React.isValidElement(item);
 }

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
@@ -19,6 +19,7 @@ import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { LoadingIcon } from '../icons2022/LoadingIcon';
+import { ComboBoxExtendedItem } from '../../components/ComboBox';
 
 import { ArrowDownIcon } from './ArrowDownIcon';
 import { ComboBoxMenu } from './ComboBoxMenu';
@@ -41,7 +42,7 @@ interface ComboBoxViewProps<T>
    * Cостояние валидации при ошибке.
    */
   error?: boolean;
-  items?: Nullable<T[]>;
+  items?: Nullable<Array<ComboBoxExtendedItem<T>>>;
   loading?: boolean;
   menuAlign?: 'left' | 'right';
   opened?: boolean;
@@ -75,7 +76,7 @@ interface ComboBoxViewProps<T>
   onMouseOver?: (e: React.MouseEvent) => void;
   onMouseLeave?: (e: React.MouseEvent) => void;
   renderItem?: (item: T, state: MenuItemState) => React.ReactNode;
-  itemWrapper?: (item?: T) => React.ComponentType<unknown>;
+  itemWrapper?: (item: T) => React.ComponentType<unknown>;
   renderNotFound?: () => React.ReactNode;
   renderTotalCount?: (found: number, total: number) => React.ReactNode;
   renderValue?: (item: T) => React.ReactNode;

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -12,6 +12,7 @@ import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { responsiveLayout } from '../../components/ResponsiveLayout/decorator';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { DropdownContainerProps } from '../DropdownContainer';
+import { ComboBoxExtendedItem } from '../../components/ComboBox';
 
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { CustomComboBoxAction, CustomComboBoxEffect, reducer } from './CustomComboBoxReducer';
@@ -58,12 +59,12 @@ export interface CustomComboBoxProps<T>
   renderNotFound?: () => React.ReactNode;
   renderTotalCount?: (found: number, total: number) => React.ReactNode;
   renderItem: (item: T, state?: MenuItemState) => React.ReactNode;
-  itemWrapper?: (item?: T) => React.ComponentType<unknown>;
+  itemWrapper?: (item: T) => React.ComponentType<unknown>;
   renderValue: (value: T) => React.ReactNode;
   renderAddButton?: (query?: string) => React.ReactNode;
   valueToString: (value: T) => string;
   itemToValue: (item: T) => string | number;
-  getItems: (query: string) => Promise<T[]>;
+  getItems: (query: string) => Promise<Array<ComboBoxExtendedItem<T>>>;
   inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
 }
 
@@ -72,7 +73,7 @@ export interface CustomComboBoxState<T> {
   loading: boolean;
   opened: boolean;
   textValue: string;
-  items: Nullable<T[]>;
+  items: Nullable<Array<ComboBoxExtendedItem<T>>>;
   inputChanged: boolean;
   focused: boolean;
   repeatRequest: () => void;

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBoxReducer.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBoxReducer.tsx
@@ -6,6 +6,7 @@ import { isNonNullable } from '../../lib/utils';
 import { isKeyArrowUp, isKeyArrowVertical, isKeyEnter, isKeyEscape } from '../../lib/events/keyboard/identifiers';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { Nullable } from '../../typings/utility-types';
+import { ComboBoxExtendedItem } from '../../components/ComboBox';
 
 import { CustomComboBox, CustomComboBoxProps, CustomComboBoxState, DefaultState } from './CustomComboBox';
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
@@ -28,7 +29,7 @@ export type CustomComboBoxAction<T> =
   | { type: 'Close' }
   | { type: 'Search'; query: string }
   | { type: 'RequestItems' }
-  | { type: 'ReceiveItems'; items: T[] }
+  | { type: 'ReceiveItems'; items: Array<ComboBoxExtendedItem<T>> }
   | { type: 'RequestFailure'; repeatRequest: () => void }
   | { type: 'CancelRequest' };
 


### PR DESCRIPTION
## Проблема

Указанный тип пропа `getItems` не соответствует реальности:
```js
// Интерфейсе
getItems: (query: string) => Promise<T[]>;

// Фактические возможности
getItems: (query: string) => Promise<Array<T | (() => React.ReactElement<T>) | React.ReactElement<T>>>;
```

## Решение

Описал реальный тип `getItems`.

Также исправил типа пропа `itemWrapper`. Изначальный тип предполагал, что `item` может быть `undefined`.
Хотя по логике кода такого происходить не должно.
```js
// Было
itemWrapper?: (item?: T) => React.ComponentType<unknown>;

// Стало
itemWrapper?: (item: T) => React.ComponentType<unknown>;
```

## Ссылки

`IF-1425`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ ❗ В качестве теста добавил стори с `getItems` и другими пропами использующими `item`.
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
