### PR TITLE
chore(Button): delete pointer-events style

### DIFF
--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -331,7 +331,6 @@ export const styles = memoizeStyle({
   linkDisabled(t: Theme) {
     return css`
       cursor: default;
-      pointer-events: none;
 
       &,
       &:hover:enabled,
@@ -359,7 +358,6 @@ export const styles = memoizeStyle({
   disabled(t: Theme) {
     return css`
       cursor: default;
-      pointer-events: none;
       box-shadow: 0 0 0 ${t.btnBorderWidth} ${t.btnDisabledBorderColor};
 
       background-image: none;


### PR DESCRIPTION
## Проблема

[Песочница](https://codesandbox.io/s/falling-currying-3ty3ky?file=/src/App.js:117-1131)
Кнопка находится внутри кликабельного блока. Если кнопка `disabled`, то при клике по ней происходит редирект, что отличается от нативного поведения. Решили исправить

## Решение

Обнаружила, что проблема в свойстве `pointer-events: none`:
1. Нативной кнопке пробрасывается состояние `disabled`, что само по себе отключает события мыши, поэтому дополнительно указывать `pointer-events: none` не нужно
2. Если в песочнице для нативной заблокированной кнопки добавить это свойство, то при клике на нее тоже будет происходить редирект

Удалила это свойство. Тесты добавлять не вижу необходимости

## Ссылки

fix IF-1433

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

4. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

5. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
