### PR TITLE
fix(ComboBox): fix key down logic in closed state

### DIFF
--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -138,6 +138,25 @@ describe('ComboBox', () => {
     expect(onValueChange).toHaveBeenCalledTimes(1);
   });
 
+  it('opens menu on arrow down', async () => {
+    const items = ['one', 'two', 'three'];
+    const [search] = searchFactory(Promise.resolve(items));
+    render(<ComboBox getItems={search} renderItem={(x) => x} value={'one'} />);
+    userEvent.click(screen.getByTestId(InputLikeTextDataTids.root));
+
+    await delay(0);
+
+    userEvent.keyboard('{enter}');
+
+    await delay(0);
+
+    userEvent.keyboard('{arrowdown}');
+
+    await delay(0);
+
+    expect(screen.queryAllByTestId(ComboBoxMenuDataTids.item)).toHaveLength(items.length);
+  });
+
   it('retries request on Enter if rejected', async () => {
     const [search, promise] = searchFactory(Promise.reject());
     render(<ComboBox getItems={search} renderItem={(x) => x} />);

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -162,7 +162,7 @@ describe('ComboBox', () => {
     };
     render(
       <form onSubmit={handleSubmit}>
-        <ComboBox getItems={getItems} renderItem={(x) => x} value={'one'} />
+        <ComboBox getItems={getItems} value={'one'} />
       </form>,
     );
 

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -154,6 +154,29 @@ describe('ComboBox', () => {
     expect(search).toHaveBeenCalledTimes(2);
   });
 
+  it('does not submit the form on the first Enter key press but submits on the second', async () => {
+    const handleSubmit = jest.fn();
+
+    const getItems = () => {
+      return Promise.resolve(['one', 'two', 'three']);
+    };
+    render(
+      <form onSubmit={handleSubmit}>
+        <ComboBox getItems={getItems} renderItem={(x) => x} value={'one'} />
+      </form>,
+    );
+
+    const input = screen.getByTestId(InputLikeTextDataTids.root);
+    fireEvent.click(input);
+    fireEvent.keyPress(input, { key: 'Enter', code: 'Enter' });
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    fireEvent.submit(input);
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps focus after a click on the refresh button', async () => {
     const [search, promise] = searchFactory(Promise.reject());
     render(<ComboBox getItems={search} renderItem={(x) => x} />);

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -140,19 +140,12 @@ describe('ComboBox', () => {
 
   it('opens menu on arrow down', async () => {
     const items = ['one', 'two', 'three'];
-    const [search] = searchFactory(Promise.resolve(items));
+    const [search, promise] = searchFactory(Promise.resolve(items));
     render(<ComboBox getItems={search} renderItem={(x) => x} value={'one'} />);
     userEvent.click(screen.getByTestId(InputLikeTextDataTids.root));
-
-    await delay(0);
-
     userEvent.keyboard('{enter}');
-
-    await delay(0);
-
     userEvent.keyboard('{arrowdown}');
-
-    await delay(0);
+    await promise;
 
     expect(screen.queryAllByTestId(ComboBoxMenuDataTids.item)).toHaveLength(items.length);
   });

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -280,7 +280,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       onInputClick: this.handleInputClick,
       onInputKeyDown: (event: React.KeyboardEvent) => {
         event.persist();
-        this.state.opened && this.dispatch({ type: 'KeyPress', event });
+        this.dispatch({ type: 'KeyPress', event });
       },
       onMouseEnter: this.props.onMouseEnter,
       onMouseOver: this.props.onMouseOver,

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -280,7 +280,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       onInputClick: this.handleInputClick,
       onInputKeyDown: (event: React.KeyboardEvent) => {
         event.persist();
-        this.dispatch({ type: 'KeyPress', event });
+        this.state.opened && this.dispatch({ type: 'KeyPress', event });
       },
       onMouseEnter: this.props.onMouseEnter,
       onMouseOver: this.props.onMouseOver,

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBoxReducer.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBoxReducer.tsx
@@ -262,6 +262,9 @@ export function reducer<T>(
 
       switch (true) {
         case isKeyEnter(e):
+          if (!state.opened) {
+            break;
+          }
           e.preventDefault();
           effects.push(Effect.selectMenuItem(e));
           break;


### PR DESCRIPTION
## Проблема

Когда `ComboBox` находится внутри формы, при нажатии на `enter` не происходит сабмит

Ожидаемое поведение при нажатии на `enter`:
При открытом результате поиска в комбобоксе - выбор элемента
Когда выбран элемент и просто инпут в фокусе - сабмит

## Решение

При закрытом меню не вызываю обработчик события. Следовательно, не происходит вызов `preventDefault` и форма засабмитится

## Ссылки

fix IF-1436

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
