### PR TITLE
docs(Tab): add information about <Tabs.Tab /> visual states

### DIFF
--- a/packages/react-ui/.styleguide/helpers.js
+++ b/packages/react-ui/.styleguide/helpers.js
@@ -28,15 +28,13 @@ const findComponentsInSection = (dirPath, name) => {
   // Looks for entries like `ParentCompChildComp.tsx`
   // In `ModalClose` the word `Modal` represents parent component and the word `Close` child component
   const surnamePattern = new RegExp(`${name}[a-zA-Z]*\.tsx`);
-  // Looks for entries like `Parents.tsx`
-  // In `Tabs` the word `Tabs` represents parent component and the word `Tab` child component
-  const substringPattern = name.slice(0, -1) + '.tsx';
+  // Component `<Tabs />` utilizes it's own pattern, where deleting the last letter forms child component `<Tab />`
+  const tabPattern = 'Tab.tsx';
   const components = fs
     .readdirSync(dirPath)
     .filter(
       (item) =>
-        (surnamePattern.test(item) || substringPattern === item) &&
-        !excludedComponents.includes(path.basename(item, '.tsx')),
+        (surnamePattern.test(item) || tabPattern === item) && !excludedComponents.includes(path.basename(item, '.tsx')),
     )
     .map((item) => path.join(dirPath, item));
   return {

--- a/packages/react-ui/.styleguide/helpers.js
+++ b/packages/react-ui/.styleguide/helpers.js
@@ -22,13 +22,22 @@ const excludedComponents = [
   'SidePageContext',
 ];
 
-const sectionComponents = ['Modal', 'SidePage'];
+const sectionComponents = ['Modal', 'SidePage', 'Tabs'];
 
 const findComponentsInSection = (dirPath, name) => {
-  const reg = new RegExp(`${name}[a-zA-Z]*\.tsx`);
+  // Looks for entries like `ParentCompChildComp.tsx`
+  // In `ModalClose` the word `Modal` represents parent component and the word `Close` child component
+  const surnamePattern = new RegExp(`${name}[a-zA-Z]*\.tsx`);
+  // Looks for entries like `Parents.tsx`
+  // In `Tabs` the word `Tabs` represents parent component and the word `Tab` child component
+  const substringPattern = name.slice(0, -1) + '.tsx';
   const components = fs
     .readdirSync(dirPath)
-    .filter((item) => reg.test(item) && !excludedComponents.includes(path.basename(item, '.tsx')))
+    .filter(
+      (item) =>
+        (surnamePattern.test(item) || substringPattern === item) &&
+        !excludedComponents.includes(path.basename(item, '.tsx')),
+    )
     .map((item) => path.join(dirPath, item));
   return {
     name,
@@ -58,13 +67,13 @@ const findComponentsRecursively = (dirPath) => {
   return components.filter(Boolean);
 };
 
-const findInComponents = (dir) => {
+const findInComponents = (parentDirName) => {
   const sections = [];
   const components = [];
-  fs.readdirSync(dir).forEach((name) => {
-    const dirPath = path.join(dir, name);
-    if (sectionComponents.includes(name)) {
-      sections.push(findComponentsInSection(dirPath, name));
+  fs.readdirSync(parentDirName).forEach((childDirName) => {
+    const dirPath = path.join(parentDirName, childDirName);
+    if (sectionComponents.includes(childDirName)) {
+      sections.push(findComponentsInSection(dirPath, childDirName));
     } else {
       components.push(...findComponentsRecursively(dirPath));
     }

--- a/packages/react-ui/components/Tabs/Tab.md
+++ b/packages/react-ui/components/Tabs/Tab.md
@@ -1,0 +1,71 @@
+У компонента `<Tabs.Tab />` есть несколько визуальных состояний, в которых компонент может находиться: `primary`, `success`, `warning` и `error`. Чтобы перевести контрол в нужное состояние передайте компоненту булевый проп с соответсвующим названием.
+
+Используя переменные `tabColorPrimary`, `tabColorSuccess`, `tabColorWarning` и `tabColorError` можно изменить активный цвет состояния, а библиотека автоматически подберёт цвет подчёркивания при наведении.
+```jsx harmony
+import { ThemeContext, ThemeFactory, Button, Tabs } from '@skbkontur/react-ui';
+
+const getRandomColor = () => '#' + Math.random().toString(16).substr(-6);
+const updateColors = () => {
+  return {
+    tabColorPrimary: getRandomColor(),
+    tabColorSuccess: getRandomColor(),
+    tabColorWarning: getRandomColor(),
+    tabColorError: getRandomColor(),
+  }
+};
+
+const [activeBase, setActiveBase] = React.useState('error');
+const [activeRandom, setActiveRandom] = React.useState('error');
+const [colors, setColors] = React.useState(updateColors());
+
+<>
+  <p style={{ fontSize: '17px' }}>C цветами по умолчанию</p>
+  <Tabs value={activeBase} onValueChange={setActiveBase}>
+    <Tabs.Tab primary id="primary">Primary</Tabs.Tab>
+    <Tabs.Tab success id="success">Success</Tabs.Tab>
+    <Tabs.Tab warning id="warning">Warning</Tabs.Tab>
+    <Tabs.Tab error id="error">Error</Tabs.Tab>
+  </Tabs>
+
+  <p style={{ fontSize: '17px' }}>Со случайным основным цветом</p>
+  <div style={{ display: 'inline-flex', flexDirection: 'column', justifyContent: 'space-between', height: '100px' }}>
+    <ThemeContext.Consumer>
+      {(theme) => {
+        return (
+          <ThemeContext.Provider
+            value={ThemeFactory.create(colors,theme)}
+          >
+            <Tabs value={activeRandom} onValueChange={setActiveRandom}>
+            <Tabs.Tab primary id="primary">Primary</Tabs.Tab>
+            <Tabs.Tab success id="success">Success</Tabs.Tab>
+            <Tabs.Tab warning id="warning">Warning</Tabs.Tab>
+            <Tabs.Tab error id="error">Error</Tabs.Tab>
+          </Tabs>
+          </ThemeContext.Provider>
+        );
+      }}
+    </ThemeContext.Consumer>
+    <Button onClick={() => setColors(updateColors)}>Получить новый набор цветов</Button>
+  </div>
+</>
+```
+
+С помощью пропа `component` можно изменять корневой элемент `<Tab />`.
+
+Проп может принимать: компоненты, функции и строки.
+```jsx harmony
+import { Tabs } from '@skbkontur/react-ui';
+
+const [active, setActive] = React.useState('/fuji');
+
+const NavLink = props => <a {...props} />;
+
+<Tabs value={active} onValueChange={setActive}>
+  {/** Кастомный компонент **/}
+  <Tabs.Tab  component={(props) => <NavLink {...props} />} id="/fuji">🌋 Fuji</Tabs.Tab>
+  {/** Функция **/}
+  <Tabs.Tab component={(props) => <a {...props} />} id="/tahat">⛰ Tahat</Tabs.Tab>
+  {/** Строка **/}
+  <Tabs.Tab component="a" id="/alps">🗻 Alps</Tabs.Tab>
+</Tabs>;
+```

--- a/packages/react-ui/components/Tabs/Tab.tsx
+++ b/packages/react-ui/components/Tabs/Tab.tsx
@@ -34,64 +34,54 @@ export interface TabProps<T extends string = string>
   extends Pick<AriaAttributes, 'aria-label' | 'aria-describedby'>,
     CommonProps {
   /**
-   * Tab content
-   */
-  children?: React.ReactNode;
-
-  /**
-   * Component to use as a tab
+   * Позволяет передавать свой компонент, строку или функцию, которая заменит собой элемент используемый в компоненте по умолчанию. Реализует паттерн [render prop](https://www.patterns.dev/posts/render-props-pattern).
    */
   component?: React.ComponentType<any> | string;
 
   /**
-   * Link href
+   * `HTML`-аттрибут `href`.
    */
   href?: string;
 
   /**
-   * Tab identifier
+   * Уникальный идентификатор таба. По нему компонент `<Tabs />` определяет какой `<Tab />` сейчас выбран.
    */
   id?: T;
 
   /**
-   * Click event
+   * `HTML`-событие `onclick`.
    */
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
 
   /**
-   * Click event
+   * `HTML`-событие `onkeydown`.
    */
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
 
   /**
-   * Disabled indicator
+   * Переводит компонент в отключенное состояние.
    */
   disabled?: boolean;
 
   /**
-   * Состояние валидации при ошибке.
+   * Визуальное состояние ошибки.
    */
   error?: boolean;
 
   /**
-   * Состояние валидации при предупреждении.
+   * Визуальное состояние предупреждения.
    */
   warning?: boolean;
 
   /**
-   * Success indicator
+   * Визуальное состояние успеха.
    */
   success?: boolean;
 
   /**
-   * Primary indicator
+   * Визуальное состояние главного элемента.
    */
   primary?: boolean;
-
-  /**
-   * Style property
-   */
-  style?: React.CSSProperties;
 }
 
 export interface TabState {
@@ -101,19 +91,7 @@ export interface TabState {
 type DefaultProps = Required<Pick<TabProps, 'component' | 'href'>>;
 
 /**
- * Tab element of Tabs component
- *
- * Can be used for creating custom tabs
- * ```js
- *
- * const RouteTab = (props) => (
- *   <Tab id={props.to} component={RouteLink} {...props}/>
- * )
- *
- * const MyAwesomeTab = (props) => <Tab id={props.id}>8) {props.children}</Tab>
- * ```
- *
- * Works only inside Tabs component, otherwise throws
+ * Вложенный элемент компонента `<Tabs />`.
  */
 @rootNode
 export class Tab<T extends string = string> extends React.Component<TabProps<T>, TabState> {

--- a/packages/react-ui/components/Tabs/Tabs.md
+++ b/packages/react-ui/components/Tabs/Tabs.md
@@ -1,12 +1,57 @@
-```jsx harmony
-const [active, setActive] = React.useState('fuji');
+У `<Tabs.Tab />` есть несколько визуальных состояний, в которых компонент может находиться: `primary`, `success`, `warning` и `error`. Чтобы перевести контрол в нужное состояние передайте компоненту булевый проп с соответсвующим названием.
 
-<Tabs value={active} onValueChange={setActive}>
-  <Tabs.Tab id="fuji">🌋 Fuji</Tabs.Tab>
-  <Tabs.Tab id="tahat">⛰ Tahat</Tabs.Tab>
-  <Tabs.Tab id="alps">🗻 Alps</Tabs.Tab>
-</Tabs>;
+Используя переменные `tabColorPrimary`, `tabColorSuccess`, `tabColorWarning` и `tabColorError` можно изменить активный цвет состояния, а библиотека автоматически подберёт цвет подчёркивания при наведении.
+
+```jsx harmony
+import { ThemeContext, ThemeFactory, Button } from '@skbkontur/react-ui';
+
+const getRandomColor = () => '#' + Math.random().toString(16).substr(-6);
+const updateColors = () => {
+  return {
+    tabColorPrimary: getRandomColor(),
+    tabColorSuccess: getRandomColor(),
+    tabColorWarning: getRandomColor(),
+    tabColorError: getRandomColor(),
+  }
+};
+
+const [activeBase, setActiveBase] = React.useState('error');
+const [activeRandom, setActiveRandom] = React.useState('error');
+const [colors, setColors] = React.useState(updateColors());
+
+<>
+  <p style={{ fontSize: '17px' }}>C цветами по умолчанию</p>
+  <Tabs value={activeBase} onValueChange={setActiveBase}>
+    <Tabs.Tab primary id="primary">Primary</Tabs.Tab>
+    <Tabs.Tab success id="success">Success</Tabs.Tab>
+    <Tabs.Tab warning id="warning">Warning</Tabs.Tab>
+    <Tabs.Tab error id="error">Error</Tabs.Tab>
+  </Tabs>
+
+  <p style={{ fontSize: '17px' }}>Со случайным основным цветом</p>
+  <div style={{ display: 'inline-flex', flexDirection: 'column', justifyContent: 'space-between', height: '100px' }}>
+    <ThemeContext.Consumer>
+      {(theme) => {
+        return (
+          <ThemeContext.Provider
+            value={ThemeFactory.create(colors,theme)}
+          >
+            <Tabs value={activeRandom} onValueChange={setActiveRandom}>
+            <Tabs.Tab primary id="primary">Primary</Tabs.Tab>
+            <Tabs.Tab success id="success">Success</Tabs.Tab>
+            <Tabs.Tab warning id="warning">Warning</Tabs.Tab>
+            <Tabs.Tab error id="error">Error</Tabs.Tab>
+          </Tabs>
+          </ThemeContext.Provider>
+        );
+      }}
+    </ThemeContext.Consumer>
+    <Button onClick={() => setColors(updateColors)}>Получить новый набор цветов</Button>
+  </div>
+</>
 ```
+
+
 
 Можно передавать свои компоненты в качестве табов, например `NavLink` из `react-router`
 

--- a/packages/react-ui/components/Tabs/Tabs.md
+++ b/packages/react-ui/components/Tabs/Tabs.md
@@ -1,82 +1,22 @@
-У `<Tabs.Tab />` есть несколько визуальных состояний, в которых компонент может находиться: `primary`, `success`, `warning` и `error`. Чтобы перевести контрол в нужное состояние передайте компоненту булевый проп с соответсвующим названием.
-
-Используя переменные `tabColorPrimary`, `tabColorSuccess`, `tabColorWarning` и `tabColorError` можно изменить активный цвет состояния, а библиотека автоматически подберёт цвет подчёркивания при наведении.
-
+Базовый пример использования компонента.
 ```jsx harmony
-import { ThemeContext, ThemeFactory, Button } from '@skbkontur/react-ui';
-
-const getRandomColor = () => '#' + Math.random().toString(16).substr(-6);
-const updateColors = () => {
-  return {
-    tabColorPrimary: getRandomColor(),
-    tabColorSuccess: getRandomColor(),
-    tabColorWarning: getRandomColor(),
-    tabColorError: getRandomColor(),
-  }
-};
-
-const [activeBase, setActiveBase] = React.useState('error');
-const [activeRandom, setActiveRandom] = React.useState('error');
-const [colors, setColors] = React.useState(updateColors());
-
-<>
-  <p style={{ fontSize: '17px' }}>C цветами по умолчанию</p>
-  <Tabs value={activeBase} onValueChange={setActiveBase}>
-    <Tabs.Tab primary id="primary">Primary</Tabs.Tab>
-    <Tabs.Tab success id="success">Success</Tabs.Tab>
-    <Tabs.Tab warning id="warning">Warning</Tabs.Tab>
-    <Tabs.Tab error id="error">Error</Tabs.Tab>
-  </Tabs>
-
-  <p style={{ fontSize: '17px' }}>Со случайным основным цветом</p>
-  <div style={{ display: 'inline-flex', flexDirection: 'column', justifyContent: 'space-between', height: '100px' }}>
-    <ThemeContext.Consumer>
-      {(theme) => {
-        return (
-          <ThemeContext.Provider
-            value={ThemeFactory.create(colors,theme)}
-          >
-            <Tabs value={activeRandom} onValueChange={setActiveRandom}>
-            <Tabs.Tab primary id="primary">Primary</Tabs.Tab>
-            <Tabs.Tab success id="success">Success</Tabs.Tab>
-            <Tabs.Tab warning id="warning">Warning</Tabs.Tab>
-            <Tabs.Tab error id="error">Error</Tabs.Tab>
-          </Tabs>
-          </ThemeContext.Provider>
-        );
-      }}
-    </ThemeContext.Consumer>
-    <Button onClick={() => setColors(updateColors)}>Получить новый набор цветов</Button>
-  </div>
-</>
-```
-
-
-
-Можно передавать свои компоненты в качестве табов, например `NavLink` из `react-router`
-
-```jsx harmony
-const [active, setActive] = React.useState('/fuji');
-
-const NavLink = props => (
-  <a
-    {...props}
-    onClick={e => {
-      e.preventDefault();
-      props.onClick(e);
-    }}
-  />
-);
-const TabLink = ({ id, children }) => (
-  <Tabs.Tab id={id} component={props => <NavLink {...props} to={props.id} />}>
-    {children}
-  </Tabs.Tab>
-);
+const [active, setActive] = React.useState('fuji');
 
 <Tabs value={active} onValueChange={setActive}>
-  <TabLink id="/fuji">🌋 Fuji</TabLink>
-  <TabLink id="/tahat">⛰ Tahat</TabLink>
-  <TabLink id="/alps">🗻 Alps</TabLink>
+  <Tabs.Tab id="fuji">🌋 Fuji</Tabs.Tab>
+  <Tabs.Tab id="tahat">⛰ Tahat</Tabs.Tab>
+  <Tabs.Tab id="alps">🗻 Alps</Tabs.Tab>
+</Tabs>;
+```
+
+Компонент может отображать табы двумя способами: горизонтально (по умолчанию) и вертикально.
+```jsx harmony
+const [active, setActive] = React.useState('fuji');
+
+<Tabs vertical value={active} onValueChange={setActive}>
+  <Tabs.Tab id="fuji">🌋 Fuji</Tabs.Tab>
+  <Tabs.Tab id="tahat">⛰ Tahat</Tabs.Tab>
+  <Tabs.Tab id="alps">🗻 Alps</Tabs.Tab>
 </Tabs>;
 ```
 

--- a/packages/react-ui/components/Tabs/Tabs.tsx
+++ b/packages/react-ui/components/Tabs/Tabs.tsx
@@ -22,19 +22,9 @@ interface TabType<T extends ValueBaseType> {
 
 export interface TabsProps<T extends ValueBaseType = string> extends CommonProps {
   /**
-   * Tab component should be child of Tabs component
-   */
-  children?: React.ReactNode;
-
-  /**
-   * Classname of indicator
+   * Позволяет задать кастомный класс подчёркиванию таба.
    */
   indicatorClassName?: string;
-
-  /**
-   * Tabs change event
-   */
-  onValueChange?: (value: T) => void;
 
   /**
    * Задаёт размер контрола.
@@ -44,23 +34,28 @@ export interface TabsProps<T extends ValueBaseType = string> extends CommonProps
   size?: TabSize;
 
   /**
-   * Active tab identifier
+   * Задаёт текущий активный `<Tab />`. Принимает `id` таба.
    */
   value: T;
 
   /**
-   * Vertical indicator
+   * Функция, позволяющая изменить текущий активный `<Tab />`.
+   */
+  onValueChange?: (value: T) => void;
+
+  /**
+   * Переводит компонент в режим вертикального отображения.
    * @default false
    */
   vertical?: boolean;
 
   /**
-   * Width of tabs container
+   * `CSS`-свойство `width`.
    */
   width?: number | string;
 
   /**
-   * Атрибут для указания id элемента(-ов), описывающих его
+   * Атрибут для указания id элемента(-ов), описывающих его.
    */
   'aria-describedby'?: AriaAttributes['aria-describedby'];
 }
@@ -73,9 +68,7 @@ export const TabsDataTids = {
 type DefaultProps = Required<Pick<TabsProps, 'vertical' | 'size'>>;
 
 /**
- * Tabs wrapper
- *
- * contains static property `Tab`
+ * Родитель компонента `<Tab />`. Связывает `Tab`'ы в группу и позволяет управлять их состоянием.
  */
 @rootNode
 export class Tabs<T extends string = string> extends React.Component<TabsProps<T>> {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В документации нет ни слова о визуальных состояниях `<Tabs.Tab />`. Хотя визуальные состояния компонента - часть публичного `API`.

## Решение

Добавил описание визуальных состояний, с примерами и объяснениями о работе фичи с автоматическим подбором цвета подчёркивания при наведении.

## Ссылки

IF-1451

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
