### PR TITLE
chore: add export of type `InstanceWithRootNode` to use rootNode API

### DIFF
--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -105,6 +105,22 @@ export const WithClassChildren = () => (
 
 Подробнее в [пулл-реквесте](https://github.com/skbkontur/retail-ui/pull/2518)
 
+### Получение корневого элемента через ref
+
+Библиотека эскпортирует тип `InstanceWithRootNode`, который позволяет получить доступ к корневому элементу в классовых компонентах, используя `ref`, вместо `findDOMNode`.
+
+```js static
+import { Button } from '@skbkontur/react-ui';
+
+const ref = React.useRef<Button & InstanceWithRootNode>(null);
+
+React.useEffect(() => {
+  ref.current?.getRootNode();
+}, []);
+
+<Button ref={ref}>Кнопка</Button>
+```
+
 ## FAQ
 
 ### Отключение анимаций во время тестирования

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -105,22 +105,6 @@ export const WithClassChildren = () => (
 
 Подробнее в [пулл-реквесте](https://github.com/skbkontur/retail-ui/pull/2518)
 
-### Получение корневого элемента через ref
-
-Библиотека эскпортирует тип `InstanceWithRootNode`, который позволяет получить доступ к корневому элементу в классовых компонентах, используя `ref`, вместо `findDOMNode`.
-
-```js static
-import { Button } from '@skbkontur/react-ui';
-
-const ref = React.useRef<Button & InstanceWithRootNode>(null);
-
-React.useEffect(() => {
-  ref.current?.getRootNode();
-}, []);
-
-<Button ref={ref}>Кнопка</Button>
-```
-
 ## FAQ
 
 ### Отключение анимаций во время тестирования

--- a/packages/react-ui/index.ts
+++ b/packages/react-ui/index.ts
@@ -55,3 +55,4 @@ export * from './lib/theming/themes/Theme2022Dark';
 export * from './internal/Popup/types';
 export * as ColorFunctions from './lib/styles/ColorFunctions';
 export * as DimensionFunctions from './lib/styles/DimensionFunctions';
+export type { InstanceWithRootNode } from './lib/rootNode/rootNodeDecorator';


### PR DESCRIPTION
## Проблема

Пользователи хотят получать доступ к корневым элементам из классовых компонентов

## Решение

Добавил экспорт `InstanceWithRootNode` и описал как им пользоваться в документации

## Ссылки

IF-1452

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
