### PR TITLE
feat(Button): add data-tid for spinner icon

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -422,7 +422,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
     if (loading && !icon) {
       const loadingIcon = _isTheme2022 ? <LoadingIcon size={size} /> : <Spinner caption={null} dimmed type="mini" />;
       loadingNode = (
-        <div data-tid={_isTheme2022 ? ButtonDataTids.spinner : undefined} className={styles.loading()}>
+        <div data-tid={ButtonDataTids.spinner} className={styles.loading()}>
           {loadingIcon}
         </div>
       );

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -187,6 +187,7 @@ export interface ButtonState {
 
 export const ButtonDataTids = {
   root: 'Button__root',
+  spinner: 'Button__spinner',
 } as const;
 
 type DefaultProps = Required<Pick<ButtonProps, 'use' | 'size' | 'type'>>;
@@ -420,7 +421,11 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
     let loadingNode = null;
     if (loading && !icon) {
       const loadingIcon = _isTheme2022 ? <LoadingIcon size={size} /> : <Spinner caption={null} dimmed type="mini" />;
-      loadingNode = <div className={styles.loading()}>{loadingIcon}</div>;
+      loadingNode = (
+        <div data-tid={_isTheme2022 ? ButtonDataTids.spinner : undefined} className={styles.loading()}>
+          {loadingIcon}
+        </div>
+      );
     }
 
     // Force disable all props and features, that cannot be use with Link

--- a/packages/react-ui/components/Button/__tests__/Button-test.tsx
+++ b/packages/react-ui/components/Button/__tests__/Button-test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { useState } from 'react';
 
-import { Button, ButtonType } from '../Button';
+import { ThemeContext } from '../../../lib/theming/ThemeContext';
+import { THEME_2022 } from '../../../lib/theming/themes/Theme2022';
+import { Button, ButtonDataTids, ButtonType } from '../Button';
 
 describe('Button', () => {
   it('has correct label', () => {
@@ -195,5 +197,15 @@ describe('Button', () => {
 
     expect(onMouseDown).toHaveBeenCalledTimes(1);
     expect(onMouseUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('has data-tid `Button__spinner` when component in loading state (THEME_2022)', () => {
+    render(
+      <ThemeContext.Provider value={THEME_2022}>
+        <Button loading />
+      </ThemeContext.Provider>,
+    );
+
+    expect(screen.getByTestId(ButtonDataTids.spinner)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В теме 2022 нельзя получить доступ к иконке кнопки в состоянии `loading`

## Решение

Добавил на обёртку иконки `data-tid`

## Ссылки

IF-1457

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
