### PR TITLE
fix(CurrencyInput): remove `findDOMNode` console warning in `THEME_2022`

### DIFF
--- a/packages/react-ui/components/Input/InputLayout/InputLayout.tsx
+++ b/packages/react-ui/components/Input/InputLayout/InputLayout.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+import { forwardRefAndName } from '../../../lib/forwardRefAndName';
 import { InputDataTids, InputProps } from '../Input';
-import { CommonWrapper } from '../../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper } from '../../../internal/CommonWrapper';
 
 import { InputLayoutAside } from './InputLayoutAside';
 import { InputLayoutContext, InputLayoutContextDefault, InputLayoutContextProps } from './InputLayoutContext';
@@ -9,19 +10,19 @@ import { stylesLayout } from './InputLayout.styles';
 
 type InputLayoutRootFromInputProps = Pick<InputProps, 'leftIcon' | 'rightIcon' | 'prefix' | 'suffix'>;
 
-export interface InputLayoutRootProps extends InputLayoutRootFromInputProps {
+export interface InputLayoutRootProps extends InputLayoutRootFromInputProps, CommonProps {
   labelProps: React.LabelHTMLAttributes<HTMLLabelElement>;
   context: Partial<InputLayoutContextProps>;
 }
 
-export const InputLayout: React.FunctionComponent<InputLayoutRootProps> = (props) => {
+export const InputLayout = forwardRefAndName<HTMLLabelElement, InputLayoutRootProps>('InputLayout', (props, ref) => {
   const { leftIcon, rightIcon, prefix, suffix, labelProps, context, children } = props;
   const _context: InputLayoutContextProps = { ...InputLayoutContextDefault, ...context };
 
   return (
     <InputLayoutContext.Provider value={_context}>
       <CommonWrapper {...props}>
-        <label data-tid={InputDataTids.root} {...labelProps}>
+        <label ref={ref} data-tid={InputDataTids.root} {...labelProps}>
           <InputLayoutAside icon={leftIcon} text={prefix} side="left" />
           <span className={stylesLayout.input()}>{children}</span>
           <InputLayoutAside icon={rightIcon} text={suffix} side="right" />
@@ -29,4 +30,4 @@ export const InputLayout: React.FunctionComponent<InputLayoutRootProps> = (props
       </CommonWrapper>
     </InputLayoutContext.Provider>
   );
-};
+});


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

При использовании `<CurrencyInput />` в `THEME_2022` с включенным `StrictMode` `React` выдавал ошибку о использовании `findDOMNode`.

## Решение

При реализации `THEME_2022` в `<Input />` добавился новый функциональный компонент - `<InputLayout />`, который не умел работать с `ref`. Для того, чтобы исправить проблему научил его работать с `ref`.

Песочница в которой воспроизводится проблема: https://codesandbox.io/s/competent-bas-2lkvpy
Песочница с исправлениями из пулл-реквеста: https://codesandbox.io/s/amazing-rhodes-lv8hkx?file=/src/index.js

## Ссылки

IF-1459

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
