### PR TITLE
fix(Sticky): fix width calc in fixed state on page resize

### DIFF
--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -180,6 +180,7 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
     }
 
     if (fixed) {
+      this.setState({ width });
       const stop = getStop && getStop();
       if (stop) {
         const deltaHeight = prevHeight - height;
@@ -196,7 +197,7 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
           relativeTop = stopRect.bottom - top;
         }
 
-        this.setState({ relativeTop, deltaHeight, stopped, width });
+        this.setState({ relativeTop, deltaHeight, stopped });
       }
     }
   };

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -166,8 +166,8 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
     if (!this.wrapper || !this.inner) {
       return;
     }
-    const { top, bottom, left } = getDOMRect(this.wrapper);
-    const { width, height } = getDOMRect(this.inner);
+    const { top, bottom, left, width } = getDOMRect(this.wrapper);
+    const { height } = getDOMRect(this.inner);
     const { getStop, side } = this.props;
     const { fixed: prevFixed, height: prevHeight = height } = this.state;
     const offset = this.getProps().offset;
@@ -196,7 +196,7 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
           relativeTop = stopRect.bottom - top;
         }
 
-        this.setState({ relativeTop, deltaHeight, stopped });
+        this.setState({ relativeTop, deltaHeight, stopped, width });
       }
     }
   };


### PR DESCRIPTION
## Проблема

При ресайзе страницы со `Sticky` в фиксированном состоянии не пересчитывается ширина 

## Решение

Поправила расчет ширины

## Ссылки

fix IF-1470

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
