### PR TITLE
fix(DateInput): use `flushSync` in React@18

### DIFF
--- a/packages/react-ui/components/DateInput/DateInput.tsx
+++ b/packages/react-ui/components/DateInput/DateInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import { ConditionalHandler } from '../../lib/ConditionalHandler';
 import { LENGTH_FULLDATE, MAX_FULLDATE, MIN_FULLDATE } from '../../lib/date/constants';
@@ -140,7 +141,7 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
       prevProps.maxDate !== maxDate ||
       this.iDateMediator.isChangedLocale(this.locale)
     ) {
-      this.updateFromProps();
+      this.updateFromProps(false);
     }
     this.selectNode();
   }
@@ -162,7 +163,7 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
   };
 
   public componentDidMount(): void {
-    this.updateFromProps();
+    this.updateFromProps(false);
     if (this.props.autoFocus) {
       this.focus();
     }
@@ -352,16 +353,22 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
     this.setState({ selected, inputMode: false });
   };
 
-  private updateValue = (state: Partial<DateInputState> = {}): void => {
+  private updateValue = (state: Partial<DateInputState> = {}, sync = true): void => {
     const valueFormatted = this.iDateMediator.getString();
 
-    this.setState({ ...state, valueFormatted } as DateInputState, this.emitChange);
+    const update = () => this.setState({ ...state, valueFormatted } as DateInputState, this.emitChange);
+
+    if (sync && React.version.search('18') === 0) {
+      ReactDOM.flushSync(update);
+    } else {
+      update();
+    }
   };
 
-  private updateFromProps = (): void => {
+  private updateFromProps = (sync: boolean): void => {
     this.iDateMediator.update(this.props, this.locale);
 
-    this.updateValue();
+    this.updateValue({}, sync);
   };
 
   private fullSelection = (): void => {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Проблема с батчингом в Реакт18, который под строгим режимом автоматически пакетирует изменения в стейт, из-за чего цепочка изменений отличается от Реакт17, и это сказывается уже на визуальном отображении контрола.

## Решение

Исправляется так же, использованием flushSync в проблемном месте.
Это самое место находится в `DateInput`.
 
Релиз для теста `4.16.0-DateInput-flushSync.1` (✅ проверен на проекте).

## Ссылки

- `IF-1477`
- https://github.com/skbkontur/retail-ui/pull/3144#issuecomment-1535235366

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
