### PR TITLE
chore(Link): change text decoration on hover in 22 theme

### DIFF
--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -13,6 +13,7 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static linkColor = '#222222';
   public static linkHoverColor = '#222222';
   public static linkActiveColor = '#141414';
+  public static linkHoverTextDecoration = 'none';
 
   public static linkSuccessColor = '#538A1B';
   public static linkSuccessHoverColor = '#477916';

--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -106,8 +106,6 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static btnWithIconPaddingLeftMedium = '10px';
   public static btnWithIconPaddingLeftLarge = '12px';
 
-  public static btnLinkHoverTextDecoration = 'none';
-
   public static get btnLinkLineBorderBottomStyle() {
     return this.linkLineBorderBottomStyle;
   }

--- a/packages/react-ui/internal/themes/Theme2022Dark.ts
+++ b/packages/react-ui/internal/themes/Theme2022Dark.ts
@@ -97,6 +97,7 @@ export class Theme2022Dark extends (class {} as typeof Theme2022Internal) {
   public static linkColor = 'rgba(255, 255, 255, 0.87)';
   public static linkHoverColor = '#ffffff';
   public static linkActiveColor = '#c2c2c2';
+  public static linkHoverTextDecoration = 'none';
 
   public static linkSuccessColor = '#78BF2B';
   public static linkSuccessHoverColor = '#B9E96E';


### PR DESCRIPTION
## Проблема

В 22 теме подчеркивание в кнопках-ссылках и ссылках реализовано через `border-bottom`, а не `text-decoratoion`. Но иногда пользователям необходимо реализовать подчеркивание через `text-decoratoion` для однородности с другими элементами. [Пример](https://codesandbox.io/s/withered-leaf-sdxtv4?file=/src/index.js). Они отключают подчеркивание через  `border-bottom` и ожидают, что и в ссылке и в кнопке-ссылке заработает подчеркивание через  `text-decoratoion`. Проблема в том, что в кнопке оно не работает, а в ссылке работает.

## Решение

Считаю что при отключении подчеркивания через `border-bottom`, `text-decoratoion` не должен автоматически включаться. Это касается и кнопки-ссылки и ссылки

Установила `linkHoverTextDecoration`  = `'none'` в 22х темах. 

Объяснить пользователям, что это правильное поведение и в случае необходимости им самим нужно переопределять эту переменную. 

Возможно завести проп, который переключает стили подчеркивания между  `border-bottom` и `text-decoratoion`

Либо избавиться от `border-bottom` и использовать `text-underline-offset` - заведена задача IF-1490

## Ссылки

fix IF-1472

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

4. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

5. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
