### PR TITLE
fix(SidePage): fix overlay when changing desktop->mobile->desktop

### DIFF
--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -184,7 +184,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
             <ResponsiveLayout>
               {({ isMobile }) => (
                 <>
-                  {!isMobile && blockBackground && this.renderShadow()}
+                  {blockBackground && this.renderShadow(isMobile)}
                   <CSSTransition
                     in
                     classNames={this.getTransitionNames()}
@@ -283,17 +283,21 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     return this.layout.clientWidth;
   };
 
-  private renderShadow(): JSX.Element {
+  private renderShadow(isMobile: boolean): JSX.Element {
     return (
       <ZIndex priority={'Sidepage'} className={styles.overlay()} onScroll={LayoutEvents.emit}>
-        <HideBodyVerticalScroll key="hbvs" />
-        <div
-          key="overlay"
-          className={cx({
-            [styles.background()]: true,
-            [styles.backgroundGray(this.theme)]: this.state.hasBackground,
-          })}
-        />
+        {!isMobile && (
+          <>
+            <HideBodyVerticalScroll key="hbvs" />
+            <div
+              key="overlay"
+              className={cx({
+                [styles.background()]: true,
+                [styles.backgroundGray(this.theme)]: this.state.hasBackground,
+              })}
+            />
+          </>
+        )}
       </ZIndex>
     );
   }


### PR DESCRIPTION
## Проблема

При переключении адаптива компонент с вуалью перемонтировался, из-за чего инкрементил z-index в рамках своей "группы".

--- 

Вуаль и SidePage находятся в одной группе приоритетности z-index'ов - `Sidepage: 9`.
`ZIndex` вычисляет для нового объекта `z-index` так: `последний z-index в группе` + `delta`.

При первом рендере как desktop, `SidePage` сначала монтирует вуаль и затем основной контент. Оба элемента обёрнуты в ZIndex.
Следовательно, вуаль всегда находится **под** основным контентом.

Затем, при срабатывании условия `isMobile`, вуаль удаляется, и грубо говоря забывает про свой предыдущий `z-index`.
А когда, возвращается десктопное отображение, вуаль монтируется заново, и теперь уже она **над** основным контентом.

Основной контент не удаляется, а просто меняет стиль отображение. Поэтому он помнит свой `z-index`.

## Решение

Проще всего переверстать так, чтобы вуаль тоже не удалялась при смене отображения.

## Ссылки

`IF-1487`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
