### PR TITLE
Sticky: fix max update depth error

### DIFF
--- a/packages/react-ui/components/SidePage/SidePageHeader.tsx
+++ b/packages/react-ui/components/SidePage/SidePageHeader.tsx
@@ -59,6 +59,7 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
   private sticky: Sticky | null = null;
   private lastRegularHeight = 0;
   private setRootNode!: TSetRootNode;
+  private closeIcon = (<SidePageCloseButton />);
 
   public get regularHeight(): number {
     const { isReadyToFix } = this.state;
@@ -180,10 +181,10 @@ export class SidePageHeader extends React.Component<SidePageHeaderProps, SidePag
         })}
       >
         {this.isMobileLayout ? (
-          <SidePageCloseButton />
+          this.closeIcon
         ) : (
           <Sticky side="top" offset={stickyOffset}>
-            <SidePageCloseButton />
+            {this.closeIcon}
           </Sticky>
         )}
       </div>

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -99,8 +99,9 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
         this.reflowCounter += 1;
         return;
       }
+    } else {
+      this.reflowCounter = 0;
     }
-    this.reflowCounter = 0;
   }
 
   public render() {

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -99,7 +99,6 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
         this.reflowCounter += 1;
         return;
       }
-    } else {
       this.reflowCounter = 0;
     }
   }

--- a/packages/react-ui/components/Sticky/Sticky.tsx
+++ b/packages/react-ui/components/Sticky/Sticky.tsx
@@ -99,8 +99,8 @@ export class Sticky extends React.Component<StickyProps, StickyState> {
         this.reflowCounter += 1;
         return;
       }
-      this.reflowCounter = 0;
     }
+    this.reflowCounter = 0;
   }
 
   public render() {


### PR DESCRIPTION
## Проблема

[песочница](https://codesandbox.io/s/small-shadow-nycmjd)

При открытии `SidePage` первого уровня скроллинг в низ не приводит к ошибке, но при открытии вложенного `SidePage` при проскролировании в самый низ сайдпейджа получаем ошибку бесконечного обновления
Проблема возникла после [коммита](https://github.com/skbkontur/retail-ui/commit/5603ef6eedec2786a68bb86a8b1131b609aea25c), когда мы вынесли крестик в отдельный компонент.
 
## Решение

Проблема оказалась в компоненте `Sticky`: раньше в SidePage мы рендерили 
```
 <Sticky side="top" offset={stickyOffset}>
            {this.closeIcon}
</Sticky>
```
что не вызывало перерендера Sticky:
```
 public componentDidUpdate(prevProps: StickyProps, prevState: StickyState) {
    if (!shallowEqual(prevProps, this.props) ...
```

Но после того, как мы заменили на 
```
<Sticky side="top" offset={stickyOffset}>
            <SidePageCloseButton />
</Sticky>
```
Sticky стал обновляться гораздо чаще.

Но корень проблемы был в том, что в `Sticky` `this.reflowCounter` обнулялся каждый раз! Поэтому это условие  `this.reflowCounter < MAX_REFLOW_RETRIES` фактически не срабатывало, что и приводило к очень большому количеству ререндеров

Добавила обнуление `this.reflowCounter` по условию

## Ссылки

fix IF-1494

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
