### PR TITLE
fix(Toggle): link toggleContainerBg to toggleBg variables

### DIFF
--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1567,9 +1567,15 @@ export class DefaultTheme {
   }
 
   public static toggleContainerBg = '';
-  public static toggleContainerBgHover = '';
-  public static toggleContainerBgChecked = '';
-  public static toggleContainerBgCheckedHover = '';
+  public static get toggleContainerBgHover() {
+    return this.toggleBgHover;
+  }
+  public static get toggleContainerBgChecked() {
+    return this.toggleBgChecked;
+  }
+  public static get toggleContainerBgCheckedHover() {
+    return this.toggleContainerBgHover;
+  }
   public static toggleContainerBoxShadow = '';
   public static toggleContainerBoxShadowHover = '';
   public static toggleContainerBoxShadowChecked = '';

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -1573,9 +1573,7 @@ export class DefaultTheme {
   public static get toggleContainerBgChecked() {
     return this.toggleBgChecked;
   }
-  public static get toggleContainerBgCheckedHover() {
-    return this.toggleContainerBgHover;
-  }
+  public static toggleContainerBgCheckedHover = '';
   public static toggleContainerBoxShadow = '';
   public static toggleContainerBoxShadowHover = '';
   public static toggleContainerBoxShadowChecked = '';

--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -377,7 +377,7 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static toggleHandleActiveWidthIncrement = '0px';
 
   public static toggleBgChecked = '#3D3D3D';
-  public static toggleBgHover = '#3D3D3D';
+  public static toggleBgHover = '#F0F0F0';
 
   public static toggleCheckedBg = '#fff';
   public static toggleCheckedBgHover = '#fff';
@@ -389,13 +389,17 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static toggleHandleBoxShadow = '0 0 0 1px rgba(0, 0, 0, 0.16)';
 
   // idle :hover
-  public static toggleContainerBgHover = '#F0F0F0';
+  public static get toggleContainerBgHover() {
+    return this.toggleBgHover;
+  }
   public static toggleContainerBoxShadowHover = 'inset 0 0 0 1px rgba(0, 0, 0, 0.16)';
   public static toggleHandleBgHover = '#FFFFFF';
   public static toggleHandleBoxShadowHover = '0 0 0 1px rgba(0, 0, 0, 0.16)';
 
   // checked
-  public static toggleContainerBgChecked = '#3D3D3D';
+  public static get toggleContainerBgChecked() {
+    return this.toggleBgChecked;
+  }
   public static toggleContainerBoxShadowChecked = 'none';
   public static toggleHandleBgChecked = '#FFFFFF';
   public static toggleHandleBoxShadowChecked = 'none';

--- a/packages/react-ui/internal/themes/Theme2022.ts
+++ b/packages/react-ui/internal/themes/Theme2022.ts
@@ -389,17 +389,11 @@ export class Theme2022 extends (class {} as typeof DefaultThemeInternal) {
   public static toggleHandleBoxShadow = '0 0 0 1px rgba(0, 0, 0, 0.16)';
 
   // idle :hover
-  public static get toggleContainerBgHover() {
-    return this.toggleBgHover;
-  }
   public static toggleContainerBoxShadowHover = 'inset 0 0 0 1px rgba(0, 0, 0, 0.16)';
   public static toggleHandleBgHover = '#FFFFFF';
   public static toggleHandleBoxShadowHover = '0 0 0 1px rgba(0, 0, 0, 0.16)';
 
   // checked
-  public static get toggleContainerBgChecked() {
-    return this.toggleBgChecked;
-  }
   public static toggleContainerBoxShadowChecked = 'none';
   public static toggleHandleBgChecked = '#FFFFFF';
   public static toggleHandleBoxShadowChecked = 'none';

--- a/packages/react-ui/internal/themes/Theme2022Dark.ts
+++ b/packages/react-ui/internal/themes/Theme2022Dark.ts
@@ -234,19 +234,27 @@ export class Theme2022Dark extends (class {} as typeof Theme2022Internal) {
   public static toggleHandleBoxShadow = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
 
   // idle :hover
-  public static toggleContainerBgHover = 'rgba(255, 255, 255, 0.16)';
+  public static toggleBgHover = 'rgba(255, 255, 255, 0.16)';
+  public static get toggleContainerBgHover() {
+    return this.toggleBgHover;
+  }
   public static toggleContainerBoxShadowHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgHover = 'rgba(255, 255, 255, 0.32)';
   public static toggleHandleBoxShadowHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
 
   // checked
-  public static toggleContainerBgChecked = 'rgba(255, 255, 255, 0.1)';
+  public static toggleBgChecked = 'rgba(255, 255, 255, 0.1)';
+  public static get toggleContainerBgChecked() {
+    return this.toggleBgChecked;
+  }
   public static toggleContainerBoxShadowChecked = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgChecked = '#EBEBEB';
   public static toggleHandleBoxShadowChecked = 'none';
 
   // checked :hover
-  public static toggleContainerBgCheckedHover = 'rgba(255, 255, 255, 0.16)';
+  public static get toggleContainerBgCheckedHover() {
+    return this.toggleContainerBgHover;
+  }
   public static toggleContainerBoxShadowCheckedHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgCheckedHover = '#FFFFFF';
   public static toggleHandleBoxShadowCheckedHover = 'none';

--- a/packages/react-ui/internal/themes/Theme2022Dark.ts
+++ b/packages/react-ui/internal/themes/Theme2022Dark.ts
@@ -246,6 +246,9 @@ export class Theme2022Dark extends (class {} as typeof Theme2022Internal) {
   public static toggleHandleBoxShadowChecked = 'none';
 
   // checked :hover
+  public static get toggleContainerBgCheckedHover() {
+    return this.toggleContainerBgHover;
+  }
   public static toggleContainerBoxShadowCheckedHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgCheckedHover = '#FFFFFF';
   public static toggleHandleBoxShadowCheckedHover = 'none';

--- a/packages/react-ui/internal/themes/Theme2022Dark.ts
+++ b/packages/react-ui/internal/themes/Theme2022Dark.ts
@@ -235,26 +235,17 @@ export class Theme2022Dark extends (class {} as typeof Theme2022Internal) {
 
   // idle :hover
   public static toggleBgHover = 'rgba(255, 255, 255, 0.16)';
-  public static get toggleContainerBgHover() {
-    return this.toggleBgHover;
-  }
   public static toggleContainerBoxShadowHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgHover = 'rgba(255, 255, 255, 0.32)';
   public static toggleHandleBoxShadowHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
 
   // checked
   public static toggleBgChecked = 'rgba(255, 255, 255, 0.1)';
-  public static get toggleContainerBgChecked() {
-    return this.toggleBgChecked;
-  }
   public static toggleContainerBoxShadowChecked = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgChecked = '#EBEBEB';
   public static toggleHandleBoxShadowChecked = 'none';
 
   // checked :hover
-  public static get toggleContainerBgCheckedHover() {
-    return this.toggleContainerBgHover;
-  }
   public static toggleContainerBoxShadowCheckedHover = 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)';
   public static toggleHandleBgCheckedHover = '#FFFFFF';
   public static toggleHandleBoxShadowCheckedHover = 'none';


### PR DESCRIPTION
## Проблема

В 22 темах пропала обратная совместимость для управления цветом тогла через переменную темы `toggleBgChecked`. 

## Решение

Залинковала новые переменные `toggleContainerBg..` на старые

## Ссылки

fix IF-1520

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
