### PR TITLE
fix(Link): fix link underline on focus

### DIFF
--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -56,10 +56,25 @@ export const styles = memoizeStyle({
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
+      }
+    `;
+  },
+
+  lineTextWrapperNotFocused(t: Theme) {
+    return css`
+      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         border-bottom-color: transparent;
         &:hover {
           border-bottom-color: currentColor;
         }
+      }
+    `;
+  },
+
+  lineTextWrapperFocused(t: Theme) {
+    return css`
+      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
+        border-bottom-color: currentColor;
       }
     `;
   },

--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -56,13 +56,6 @@ export const styles = memoizeStyle({
         transition: border-bottom-color ${t.transitionDuration} ${t.transitionTimingFunction};
         border-bottom-style: ${t.linkLineBorderBottomStyle};
         border-bottom-width: ${t.linkLineBorderBottomWidth};
-      }
-    `;
-  },
-
-  lineTextWrapperNotFocused(t: Theme) {
-    return css`
-      @supports (border-bottom-color: ${t.linkLineBorderBottomColor}) {
         border-bottom-color: transparent;
         &:hover {
           border-bottom-color: currentColor;

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -194,7 +194,12 @@ export class Link extends React.Component<LinkProps, LinkState> {
     if (_isTheme2022) {
       // lineTextWrapper нужен для реализации transition у подчеркивания
       child = (
-        <span className={cx(styles.lineTextWrapper(this.theme))}>
+        <span
+          className={cx(styles.lineTextWrapper(this.theme), {
+            [styles.lineTextWrapperNotFocused(this.theme)]: !this.state.focusedByTab,
+            [styles.lineTextWrapperFocused(this.theme)]: this.state.focusedByTab,
+          })}
+        >
           <span
             className={cx(globalClasses.text, {
               [styles.lineText(this.theme)]: !isIE11,

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -196,8 +196,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
       child = (
         <span
           className={cx(styles.lineTextWrapper(this.theme), {
-            [styles.lineTextWrapperNotFocused(this.theme)]: !this.state.focusedByTab,
-            [styles.lineTextWrapperFocused(this.theme)]: this.state.focusedByTab,
+            [styles.lineTextWrapperFocused(this.theme)]: isFocused,
           })}
         >
           <span


### PR DESCRIPTION
## Проблема

После #3254 в 22 темах перестало работать подчеркивание ссылки при фокусе. Проблема была в том, что создавалась дополнительная обертка, которая не изменялась при фокусе. Считаю, что это дополнительный аргумент в пользу отказа от `border-bottom` (IF-1490)


## Решение

Добавила на обертку стили для фокуса. В creevey  невозможно это протестировать, так как он применяет стили из `oldLineText`

## Ссылки

fix IF-1528

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
