### PR TITLE
fix(Select): reject focus of unmounted input

### DIFF
--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, ReactPortal, AriaAttributes } from 'react';
 import invariant from 'invariant';
 import { globalObject } from '@skbkontur/global-object';
+import debounce from 'lodash.debounce';
 
 import {
   isKeyArrowDown,
@@ -488,7 +489,7 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
   private getSearch = () => {
     return (
       <div className={styles.search()} onKeyDown={this.handleKey}>
-        <Input ref={this.focusInput} onValueChange={this.handleSearch} width="100%" />
+        <Input ref={this.debouncedFocusInput} onValueChange={this.handleSearch} width="100%" />
       </div>
     );
   };
@@ -516,7 +517,7 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
       <Input
         autoFocus
         value={this.state.searchPattern}
-        ref={this.focusInput}
+        ref={this.debouncedFocusInput}
         onValueChange={this.handleSearch}
         width="100%"
       />
@@ -569,10 +570,10 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
     return getRootNode(this);
   };
 
-  private focusInput = (input: Input) => {
-    // fix cases when an Input is rendered in portal
-    globalObject.setTimeout(() => input?.focus(), 0);
-  };
+  // fix cases when an Input is rendered in portal
+  // https://github.com/skbkontur/retail-ui/issues/1995
+  private focusInput = (input: Input) => input?.focus();
+  private debouncedFocusInput = debounce(this.focusInput);
 
   private refMenu = (menu: Menu) => {
     this.menu = menu;


### PR DESCRIPTION
## Проблема

Если у `Select` есть поисковая строка (проп `search`), то при открытии выпадашки может выбрасываться ошибка, при попытке фокуса в поисковую строку.

## Решение

Причина проблемы в `setTimeout`, который решает эту проблему https://github.com/skbkontur/retail-ui/issues/1995. Т.е. если быстро размонтировать компонент, то `setTimeout` может вызваться после и спровоцировать ошибку.
Удалось исправить через `debounce`, т.к. при размонтировании ref-функция вызывается с null, следовательно можно прервать текущий отложенный автофокус.

## Ссылки

`IF-1543`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно
  ⚠ Не удалось воспроизвести проблему юнит-тестом. Скриншотный тест решил слишком замороченно будет ради такого редкого сценария.

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
