### PR TITLE
fix(GlobalLoader): repair of call chain done()➔start()➔done()

### DIFF
--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -246,9 +246,6 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
   };
 
   public setReject = (reject: boolean) => {
-    if (!this.state.started) {
-      return;
-    }
     if (!this.state.visible && (this.state.started || this.getProps().active)) {
       this.setState({ visible: true });
     }

--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -241,12 +241,18 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
   };
 
   public setDone = () => {
+    if (!this.state.started) {
+      return;
+    }
     this.setState({ done: true, successAnimationInProgress: true });
     this.startTask.cancel();
     this.stopTask();
   };
 
   public setReject = (reject: boolean) => {
+    if (!this.state.started) {
+      return;
+    }
     if (!this.state.visible && (this.state.started || this.getProps().active)) {
       this.setState({ visible: true });
     }

--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -150,14 +150,11 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
 
   public render() {
     let status: GlobalLoaderViewProps['status'] = 'standard';
-    let dataState: GlobalLoaderViewProps['dataState'];
 
     if (this.state.done) {
       status = 'success';
-      dataState = 'done';
     } else if (this.state.rejected) {
       status = 'error';
-      dataState = 'rejected';
     } else if (this.state.accept) {
       status = 'accept';
     }
@@ -172,7 +169,6 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
             status={status}
             data-tid={GlobalLoaderDataTids.root}
             disableAnimations={disableAnimations}
-            dataState={dataState}
           />
         </CommonWrapper>
       )

--- a/packages/react-ui/components/GlobalLoader/GlobalLoaderView.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoaderView.tsx
@@ -13,7 +13,6 @@ export interface GlobalLoaderViewProps extends Pick<CommonProps, 'data-tid'> {
   delayBeforeHide: number;
   status?: 'success' | 'error' | 'standard' | 'accept';
   disableAnimations: boolean;
-  dataState?: 'done' | 'rejected';
 }
 
 export interface GlobalLoaderViewRef {
@@ -26,7 +25,6 @@ export const GlobalLoaderView = ({
   delayBeforeHide,
   status,
   disableAnimations,
-  dataState,
   ...rest
 }: GlobalLoaderViewProps) => {
   const ref = useRef<GlobalLoaderViewRef['element']>(null);
@@ -66,7 +64,7 @@ export const GlobalLoaderView = ({
   };
 
   return (
-    <CommonWrapper {...rest} data-state={dataState}>
+    <CommonWrapper {...rest} data-status={status}>
       <ZIndex priority="GlobalLoader" className={styles.outer(theme)}>
         <div ref={ref} className={cx(styles.inner(theme), getAnimationClass(status))} />
       </ZIndex>

--- a/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
+++ b/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
@@ -47,7 +47,7 @@ describe('Global Loader', () => {
 
       rerender(<GlobalLoader expectedResponseTime={2000} active ref={refGlobalLoader} rejected />);
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(GlobalLoaderDataTids.root)).toHaveAttribute('data-state', 'rejected');
+      expect(screen.getByTestId(GlobalLoaderDataTids.root)).toHaveAttribute('data-status', 'error');
     });
 
     it('should set success', async () => {
@@ -128,7 +128,7 @@ describe('Global Loader', () => {
 
       GlobalLoader.reject();
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(GlobalLoaderDataTids.root)).toHaveAttribute('data-state', 'rejected');
+      expect(screen.getByTestId(GlobalLoaderDataTids.root)).toHaveAttribute('data-status', 'error');
     });
 
     it('should set success', async () => {
@@ -137,7 +137,7 @@ describe('Global Loader', () => {
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
 
       GlobalLoader.done();
-      expect(screen.getByTestId(GlobalLoaderDataTids.root)).toHaveAttribute('data-state', 'done');
+      expect(screen.getByTestId(GlobalLoaderDataTids.root)).toHaveAttribute('data-status', 'success');
 
       await delay(DELAY_BEFORE_GLOBAL_LOADER_HIDE);
       expect(screen.queryByTestId(GlobalLoaderDataTids.root)).not.toBeInTheDocument();

--- a/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
+++ b/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
@@ -156,18 +156,10 @@ describe('Global Loader', () => {
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
     });
 
-    it('should not change state unless there was a call to "start" before "done", "reject", "accept"', async () => {
+    it('should not change state unless there was a call to "start" before "done"', async () => {
       const defaultState = refGlobalLoader.current?.state || {};
 
       GlobalLoader.done();
-      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
-      expect(defaultState).toEqual(refGlobalLoader.current?.state);
-
-      GlobalLoader.reject();
-      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
-      expect(defaultState).toEqual(refGlobalLoader.current?.state);
-
-      GlobalLoader.accept();
       await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
       expect(defaultState).toEqual(refGlobalLoader.current?.state);
     });

--- a/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
+++ b/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
@@ -155,5 +155,21 @@ describe('Global Loader', () => {
 
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
     });
+
+    it('should not change state unless there was a call to "start" before "done", "reject", "accept"', async () => {
+      const defaultState = refGlobalLoader.current?.state || {};
+
+      GlobalLoader.done();
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
+      expect(defaultState).toEqual(refGlobalLoader.current?.state);
+
+      GlobalLoader.reject();
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
+      expect(defaultState).toEqual(refGlobalLoader.current?.state);
+
+      GlobalLoader.accept();
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
+      expect(defaultState).toEqual(refGlobalLoader.current?.state);
+    });
   });
 });


### PR DESCRIPTION
## Проблема

Если вызвать методы в такой последовательности, не дождавшись появления лоадера
— ⚫ start ➔ 🟢 done
то всё норм, лоадер так и не появится.

А если же вызвать в такой последовательности
— 🟢 done ➔ ⚫ start ➔ 🟢 done
то лоадер появится, и понадобиться второй раз вызывать done.

## Решение

Метод done ожидает определённого состояние контрола, чтобы "сбросить" это состояние. Делается это без проверок, ожидая, что это будет делать пользователь.
Добавил такую проверку вначале метода, чтобы состояние не сбрасывалось, если сбрасывать нечего.

## Ссылки

`IF-1540`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
