### PR TITLE
fix(Button): not render arrow when prop arrow is false

### DIFF
--- a/packages/react-ui/components/Button/ButtonArrow.tsx
+++ b/packages/react-ui/components/Button/ButtonArrow.tsx
@@ -72,7 +72,7 @@ const ButtonArrow: React.FunctionComponent<ButtonArrowProps> = ({
 export function useButtonArrow(props: ButtonArrowProps, theme: Theme): [string, string, React.ReactNode] {
   const { arrow, size, use } = props;
   const _isTheme2022 = isTheme2022(theme);
-  const canRender = use !== 'link' && typeof arrow !== 'undefined';
+  const canRender = use !== 'link' && (arrow === true || arrow === 'left');
 
   const rootClassName =
     !_isTheme2022 && canRender


### PR DESCRIPTION
## Проблема

При передаче в Button пропа arrow={false} стрелка появляется поверх теста. Необходимо устранить такое поведение. 
Стрелка должна быть отрисована только если проп arrow  = 'left' или true.
![image](https://github.com/skbkontur/retail-ui/assets/67754964/0249030d-8da5-4b45-a2e9-b6e72dfafafa)

## Ссылки
https://yt.skbkontur.ru/issue/IF-1536

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)