### PR TITLE
fix(validations): add $ as allowed symbol

### DIFF
--- a/packages/react-ui-validations/src/Validations/PathHelper.ts
+++ b/packages/react-ui-validations/src/Validations/PathHelper.ts
@@ -1,6 +1,6 @@
 const classicFunctionRegEx =
-  /^\s*function\s*\(\s*([A-Za-z0-9_]+)\s*\)\s*\{\s*(?:(?:"use strict"|'use strict');?)?\s*return\s+\1\s*([.[].*?)?\s*;?\s*\}\s*$/;
-const arrowFunctionRegEx = /^\s*\(?\s*([A-Za-z0-9_]+)\s*\)?\s*=>\s*\1\s*([.[].*?)?\s*$/;
+  /^\s*function\s*\(\s*([A-Za-z0-9_$]+)\s*\)\s*\{\s*(?:(?:"use strict"|'use strict');?)?\s*return\s+\1\s*([.[].*?)?\s*;?\s*\}\s*$/;
+const arrowFunctionRegEx = /^\s*\(?\s*([A-Za-z0-9_$]+)\s*\)?\s*=>\s*\1\s*([.[].*?)?\s*$/;
 
 type NonNullableRecursive<T> = {
   [K in keyof T]: T[K] extends Record<string, unknown> ? NonNullable<NonNullableRecursive<T[K]>> : NonNullable<T[K]>;

--- a/packages/react-ui-validations/tests/PathHelper.test.ts
+++ b/packages/react-ui-validations/tests/PathHelper.test.ts
@@ -47,6 +47,9 @@ describe('PathHelper', () => {
         const path = extractPath('function(x) { return  x  [  v djf g" dsd] f[sl dfgj   }  ');
         expect(path).toStrictEqual('[  v djf g" dsd] f[sl dfgj');
       });
+      it('does not throw error for $', () => {
+        expect(() => extractPath('$ => $.somProperty')).not.toThrow();
+      });
     });
     describe('arrow function', () => {
       it('empty path', () => {

--- a/packages/react-ui-validations/tests/PathHelper.test.ts
+++ b/packages/react-ui-validations/tests/PathHelper.test.ts
@@ -48,7 +48,7 @@ describe('PathHelper', () => {
         expect(path).toStrictEqual('[  v djf g" dsd] f[sl dfgj');
       });
       it('does not throw error for $', () => {
-        expect(() => extractPath('$ => $.somProperty')).not.toThrow();
+        expect(() => extractPath('function($) { return  $.someProperty }')).not.toThrow();
       });
     });
     describe('arrow function', () => {
@@ -91,6 +91,9 @@ describe('PathHelper', () => {
       it('do not remove [ for any content', () => {
         const path = extractPath('x => x  [  v djf g" dsd] f[sl dfgj   ');
         expect(path).toStrictEqual('[  v djf g" dsd] f[sl dfgj');
+      });
+      it('does not throw error for $', () => {
+        expect(() => extractPath('$ => $.someProperty')).not.toThrow();
       });
     });
   });


### PR DESCRIPTION
## Проблема

При минификации кода имена переменных могут быть заменены на $ символ.

Например, такая конструкция
`validation.getNode(x => x.SomeProperty)`
преобразуется в `G.getNode($ -> $.SomeProperty)`
и падает с ошибкой `"Not supported or invalid path: $->$.SomeProperty"`

## Решение

Добавила $ в разрешенные символы

## Ссылки

fix IF-1557

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
