### PR TITLE
fix(ScrollContainer): stretch small content to size of container

### DIFF
--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.styles.ts
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.styles.ts
@@ -22,8 +22,8 @@ export const styles = memoizeStyle({
     return css`
       position: relative;
       overflow: scroll;
-      max-height: 100%;
-      max-width: 100%;
+      height: 100%;
+      width: 100%;
 
       /* Hide scrobars without losing functionality */
       scrollbar-width: none;


### PR DESCRIPTION
## Проблема

В [документации](https://tech.skbkontur.ru/react-ui/#/Components/ScrollContainer) в первом примере с горизонтальным скроллом если навести курсор на пустое пространство под контеном и зажать shift - не сработает скролл. Проблема в том, что внутренний скролл контейнер сжимается до высоты контента и получается пустое пространство между внешним и внутренним контейнерм, в котором скролл не работает

## Решение

Заменила `max-height` на `height` и  `max-width` на `width`. При этом у пользователей останется возможность применить их через пропы `maxHeight` и `maxWidth`

## Ссылки

fix IF-1573

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
