### PR TITLE
fix(PasswordInput): eye icon triggers form submit

### DIFF
--- a/packages/react-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-ui/components/PasswordInput/PasswordInput.tsx
@@ -199,6 +199,7 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
         <span className={cx(styles.toggleVisibility(this.theme), this.getEyeWrapperClassname())}>
           {!this.props.disabled && (
             <button
+              type="button"
               aria-label={this.state.visible ? this.locale.eyeClosedAriaLabel : this.locale.eyeOpenedAriaLabel}
               onClick={this.handleToggleVisibility}
               className={styles.icon()}

--- a/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
+++ b/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
@@ -136,6 +136,12 @@ describe('PasswordInput', () => {
     expect(screen.getByDisplayValue(inputValue)).toHaveAttribute('type', 'password');
   });
 
+  it('button wrapping eye icon should have type="button"', () => {
+    render(<PasswordInput value={'input'} />);
+
+    expect(screen.getByTestId(PasswordInputDataTids.eyeIcon)).toHaveAttribute('type', 'button');
+  });
+
   describe('a11y', () => {
     it('sets value for aria-label attribute', () => {
       const ariaLabel = 'aria-label';


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

При клике на иконку глаза в `<PasswordInput />` происходит отправка формы

## Решение

Это происходило из-за того, что у кнопки по умолчанию задан `type="submit"`
Изменил тип кнопки на `type="button"`

## Ссылки

IF-1580

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)