### PR TITLE
fix(GlobalLoader): repair of call chain done()➔start()➔done()

### DIFF
--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import debounce from 'lodash.debounce';
-import { globalObject, SafeTimer } from '@skbkontur/global-object';
 
 import { isTestEnv } from '../../lib/currentEnvironment';
 import { CommonWrapper } from '../../internal/CommonWrapper';
@@ -78,7 +77,6 @@ type DefaultProps = Required<
 let currentGlobalLoader: GlobalLoader;
 @rootNode
 export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoaderState> {
-  private successAnimationInProgressTimeout: SafeTimer;
   private setRootNode!: TSetRootNode;
   private getProps = createPropsGetter(GlobalLoader.defaultProps);
 
@@ -117,7 +115,6 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
       successAnimationInProgress: false,
       expectedResponseTime: this.getProps().expectedResponseTime,
     };
-    this.successAnimationInProgressTimeout = null;
     currentGlobalLoader?.kill();
     currentGlobalLoader = this;
   }
@@ -137,7 +134,7 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
       this.setState({ expectedResponseTime });
     }
     if (rejected !== prevProps.rejected) {
-      this.setReject(!!rejected);
+      this.setReject(rejected);
     }
     if (active !== prevProps.active) {
       if (active) {
@@ -146,10 +143,6 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
         this.setDone();
       }
     }
-  }
-
-  componentWillUnmount() {
-    this.successAnimationInProgressTimeout && globalObject.clearTimeout(this.successAnimationInProgressTimeout);
   }
 
   public render() {

--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -262,6 +262,7 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
   public kill = () => {
     this.stopTask.cancel();
     this.startTask.cancel();
+    this.resumeTaskAfterSuccessAnimation.cancel();
     this.setState({
       dead: true,
     });

--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -92,6 +92,10 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
     this.props.onDone?.();
   }, this.getProps().delayBeforeHide);
 
+  private readonly resumeTaskAfterSuccessAnimation = debounce(() => {
+    this.setActive();
+  }, this.getProps().delayBeforeHide);
+
   public static defaultProps: DefaultProps = {
     expectedResponseTime: 1000,
     delayBeforeShow: 1000,
@@ -219,15 +223,12 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
   };
 
   public setActive = () => {
-    const { delayBeforeHide, rejected } = this.getProps();
     this.startTask.cancel();
     if (this.state.successAnimationInProgress) {
-      this.successAnimationInProgressTimeout = globalObject.setTimeout(() => {
-        this.setActive();
-      }, delayBeforeHide);
+      this.resumeTaskAfterSuccessAnimation();
     } else {
       this.setState({ visible: false, done: false, rejected: false, accept: false, started: true });
-      if (rejected) {
+      if (this.getProps().rejected) {
         this.setReject(true);
       } else {
         this.stopTask.cancel();
@@ -242,6 +243,7 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
     }
     this.setState({ done: true, successAnimationInProgress: true });
     this.startTask.cancel();
+    this.resumeTaskAfterSuccessAnimation.cancel();
     this.stopTask();
   };
 

--- a/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
+++ b/packages/react-ui/components/GlobalLoader/__tests__/GlobalLoader-test.tsx
@@ -99,6 +99,59 @@ describe('Global Loader', () => {
       await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
     });
+
+    it('should hide in start->done->start->done scenario', async () => {
+      const { rerender } = render(<GlobalLoader expectedResponseTime={2000} ref={refGlobalLoader} />);
+
+      rerender(
+        <GlobalLoader
+          expectedResponseTime={2000}
+          delayBeforeShow={DELAY_BEFORE_GLOBAL_LOADER_SHOW}
+          delayBeforeHide={DELAY_BEFORE_GLOBAL_LOADER_HIDE}
+          ref={refGlobalLoader}
+          active
+        />,
+      );
+
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
+
+      rerender(
+        <GlobalLoader
+          expectedResponseTime={2000}
+          delayBeforeShow={DELAY_BEFORE_GLOBAL_LOADER_SHOW}
+          delayBeforeHide={DELAY_BEFORE_GLOBAL_LOADER_HIDE}
+          ref={refGlobalLoader}
+          active={false}
+        />,
+      );
+
+      await delay(100);
+
+      rerender(
+        <GlobalLoader
+          expectedResponseTime={2000}
+          delayBeforeShow={DELAY_BEFORE_GLOBAL_LOADER_SHOW}
+          delayBeforeHide={DELAY_BEFORE_GLOBAL_LOADER_HIDE}
+          ref={refGlobalLoader}
+          active
+        />,
+      );
+
+      await delay(200);
+
+      rerender(
+        <GlobalLoader
+          expectedResponseTime={2000}
+          delayBeforeShow={DELAY_BEFORE_GLOBAL_LOADER_SHOW}
+          delayBeforeHide={DELAY_BEFORE_GLOBAL_LOADER_HIDE}
+          ref={refGlobalLoader}
+          active={false}
+        />,
+      );
+
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_HIDE);
+      expect(screen.queryByTestId(GlobalLoaderDataTids.root)).not.toBeInTheDocument();
+    });
   });
 
   describe('with static methods', () => {
@@ -154,6 +207,18 @@ describe('Global Loader', () => {
       await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
 
       expect(screen.getByTestId(GlobalLoaderDataTids.root)).toBeInTheDocument();
+    });
+
+    it('should hide in start->done->start->done scenario', async () => {
+      GlobalLoader.start();
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_SHOW);
+      GlobalLoader.done();
+      await delay(100);
+      GlobalLoader.start();
+      await delay(200);
+      GlobalLoader.done();
+      await delay(DELAY_BEFORE_GLOBAL_LOADER_HIDE);
+      expect(screen.queryByTestId(GlobalLoaderDataTids.root)).not.toBeInTheDocument();
     });
 
     it('should not change state unless there was a call to "start" before "done"', async () => {


### PR DESCRIPTION
## Проблема

При быстром вызове статического метода` done()` после цепочки `start()->done()->start()` (либо если менять через проп как ниже) `GlobalLoader` не скрывается

```
  const [active, set] = useState(false);
  useEffect(() => {
    (async function() {
      await delay(1000);
      set(true);
      await delay(6000);
      set(false);
      await delay(100);
      set(true);
      await delay(200);
      set(false);
    })();
  },[])
  console.info(active);
  return (<GlobalLoader active={active} />);
```

Пытались исправить это в #3319

Думаю, что корень проблемы в том, что при `start()`  ГЛ ждет, пока закончится анимация `done()`. Если в этот момент придет придет новый `done()`, то ГЛ его пропустит.

## Решение

Заменила задержку `setTimout` на новую задачу с `debounce`. При вызове `done()` отменяю ее

## Ссылки



## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
