### PR TITLE
fix(DropdownMenu): fix bgSecondary in THEME_2022_DARK

### DIFF
--- a/packages/react-ui/internal/themes/Theme2022Dark.ts
+++ b/packages/react-ui/internal/themes/Theme2022Dark.ts
@@ -155,7 +155,9 @@ export class Theme2022Dark extends (class {} as typeof Theme2022Internal) {
   //#endregion Textarea
 
   //#region Menu
-  public static menuBgDefault = '#333333';
+  public static get menuBgDefault() {
+    return this.bgSecondary;
+  }
 
   public static menuItemTextColor = 'rgba(255, 255, 255, 0.87)';
   public static menuItemHoverBg = 'rgba(255, 255, 255, 0.1)';


### PR DESCRIPTION
## Проблема

После #3234 в `DropdownMenu` в 22 темной теме перестала работать переменная темы `bgSecondary`. Причина была в том, что раньше `DropdownMenu` использовал внутри себя `InternalMenu`, который использовал переменную `bgSecondary`. Теперь же он использует `Menu`, который использует переменную `menuBgDefault` и в 22 темной теме она не залинкована на `bgSecondary`

## Решение

Залинковала `menuBgDefault` на `bgSecondary` в 22 темной теме 

## Ссылки

fix IF-1583

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
