### PR TITLE
fix(GlobalLoader): fix warning in strict mode

### DIFF
--- a/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
+++ b/packages/react-ui/components/GlobalLoader/GlobalLoader.tsx
@@ -116,9 +116,9 @@ export class GlobalLoader extends React.Component<GlobalLoaderProps, GlobalLoade
       expectedResponseTime: this.getProps().expectedResponseTime,
     };
     currentGlobalLoader?.kill();
-    currentGlobalLoader = this;
   }
   componentDidMount() {
+    currentGlobalLoader = this;
     const { active, rejected } = this.getProps();
     if (active) {
       this.setActive();


### PR DESCRIPTION
## Проблема

При использовании `GlobalLoader` в `StrictMode` в консоли появляется варнинг: `Warning: Can't call setState on a component that is not yet mounted. `

## Решение

Происходило это из-за особенности реализации `singleton` (`GlobalLoader` может быть только один на странице): в конструкторе вызывался метод `kill` на существующем компоненте и сразу же присваивался текущему экземпляру (который еще не замаунтился). И на нем вызывался `setState`. Перенесла присваивание в `componentDidMount`

## Ссылки

fix IF-1594

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
