### PR TITLE
chore(Gapped): unpack ReactFragment base on featureFlag

### DIFF
--- a/packages/react-ui/.creevey/images/Gapped/With React Fragment Child/chrome.png
+++ b/packages/react-ui/.creevey/images/Gapped/With React Fragment Child/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e4ebad690af00c456ef76997f8b7620c78232b189e5ece4fe11f92ef56700a
+size 5804

--- a/packages/react-ui/.creevey/images/Gapped/With React Fragment Child/firefox.png
+++ b/packages/react-ui/.creevey/images/Gapped/With React Fragment Child/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36913dc85afd52a45328e0374b0af6500cf103422eb07a524bc795414853cd0d
+size 4697

--- a/packages/react-ui/components/Gapped/Gapped.tsx
+++ b/packages/react-ui/components/Gapped/Gapped.tsx
@@ -81,9 +81,16 @@ export class Gapped extends React.Component<GappedProps> {
 
   public render() {
     return (
-      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
-        {this.getProps().vertical ? this.renderVertical() : this.renderHorizontal()}
-      </CommonWrapper>
+      <ReactUIFeatureFlagsContext.Consumer>
+        {(flags) => {
+          this.featureFlags = getFullReactUIFlagsContext(flags);
+          return (
+            <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
+              {this.getProps().vertical ? this.renderVertical() : this.renderHorizontal()}
+            </CommonWrapper>
+          );
+        }}
+      </ReactUIFeatureFlagsContext.Consumer>
     );
   }
 
@@ -128,34 +135,27 @@ export class Gapped extends React.Component<GappedProps> {
     const contStyle: React.CSSProperties = wrap ? { marginTop: -gap - 1, marginLeft: -gap } : { whiteSpace: 'nowrap' };
 
     return (
-      <ReactUIFeatureFlagsContext.Consumer>
-        {(flags) => {
-          this.featureFlags = getFullReactUIFlagsContext(flags);
-          return (
-            <div data-tid={GappedDataTids.horizontal} style={rootStyle}>
-              <div style={contStyle}>
-                {React.Children.toArray(children)
-                  .map((child: React.ReactNode) => {
-                    if (this.featureFlags.gappedUnpackReactFragment && ReactIs.isFragment(child)) {
-                      return child.props.children;
-                    }
-                    return child;
-                  })
-                  .reduce((accumulator, value) => accumulator.concat(value), [])
-                  .filter(this.filterChildren)
-                  .map((child: React.ReactNode, index: number) => {
-                    const marginLeft = index === 0 ? undefined : gap;
-                    return (
-                      <span key={index} style={{ marginLeft, ...itemStyle }}>
-                        {child}
-                      </span>
-                    );
-                  })}
-              </div>
-            </div>
-          );
-        }}
-      </ReactUIFeatureFlagsContext.Consumer>
+      <div data-tid={GappedDataTids.horizontal} style={rootStyle}>
+        <div style={contStyle}>
+          {React.Children.toArray(children)
+            .map((child: React.ReactNode) => {
+              if (this.featureFlags.gappedUnpackReactFragment && ReactIs.isFragment(child)) {
+                return child.props.children;
+              }
+              return child;
+            })
+            .reduce((accumulator, value) => accumulator.concat(value), [])
+            .filter(this.filterChildren)
+            .map((child: React.ReactNode, index: number) => {
+              const marginLeft = index === 0 ? undefined : gap;
+              return (
+                <span key={index} style={{ marginLeft, ...itemStyle }}>
+                  {child}
+                </span>
+              );
+            })}
+        </div>
+      </div>
     );
   }
 

--- a/packages/react-ui/components/Gapped/__stories__/Gapped.stories.tsx
+++ b/packages/react-ui/components/Gapped/__stories__/Gapped.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Meta } from '../../../typings/stories';
 import { Gapped, GappedProps } from '../Gapped';
 import { Button } from '../../Button';
+import { ReactUIFeatureFlagsContext } from '../../../lib/featureFlagsContext';
 
 export default {
   title: 'Gapped',
@@ -88,4 +89,31 @@ export const WithFalsyChilds = () => {
       {index + 1 < falsyValues.length && <hr />}
     </>
   ));
+};
+
+export const WithReactFragmentChild = () => (
+  <>
+    <ReactUIFeatureFlagsContext.Provider value={{ gappedUnpackReactFragment: true }}>
+      <Gapped gap={20}>
+        <React.Fragment>
+          <span>with</span>
+          <span>gappedUnpackReactFragment</span>
+          <span>flag</span>
+        </React.Fragment>
+      </Gapped>
+    </ReactUIFeatureFlagsContext.Provider>
+
+    <Gapped gap={20}>
+      <React.Fragment>
+        <span>without</span>
+        <span>gappedUnpackReactFragment</span>
+        <span>flag</span>
+      </React.Fragment>
+    </Gapped>
+  </>
+);
+WithReactFragmentChild.parameters = {
+  creevey: {
+    skip: { in: /^(?!\b(chrome|firefox)\b)/ },
+  },
 };

--- a/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
+++ b/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
@@ -5,6 +5,7 @@
 ```typescript static
 export interface ReactUIFeatureFlags {
   tokenInputRemoveWhitespaceFromDefaultDelimiters?: boolean;
+  gappedUnpackReactFragment?: boolean;
 }
 ```
 
@@ -38,6 +39,25 @@ const getItems = () => {};
     selectedItems={selectedItems}
     onValueChange={setSelectedItems}
   />
+</ReactUIFeatureFlagsContext.Provider>
+```
+
+### gappedUnpackReactFragment
+
+В Gapped при использовании React.Fragment вся работа идет с его дочерними элементами.
+В React UI 5.0 фича будет применена по умолчанию.
+
+```jsx harmony
+import { Gapped, ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
+
+<ReactUIFeatureFlagsContext.Provider value={{ gappedUnpackReactFragment: true }}>
+  <Gapped gap={20}>
+    <React.Fragment>
+      <span>with</span>
+      <span>gappedUnpackReactFragment</span>
+      <span>flag</span>
+    </React.Fragment>
+  </Gapped>
 </ReactUIFeatureFlagsContext.Provider>
 ```
 

--- a/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
+++ b/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 export interface ReactUIFeatureFlags {
   tokenInputRemoveWhitespaceFromDefaultDelimiters?: boolean;
+  gappedUnpackReactFragment?: boolean;
 }
 
 export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {
   tokenInputRemoveWhitespaceFromDefaultDelimiters: false,
+  gappedUnpackReactFragment: false,
 };
 
 export const ReactUIFeatureFlagsContext = React.createContext<ReactUIFeatureFlags>(reactUIFeatureFlagsDefault);


### PR DESCRIPTION
## Проблема

При оборачивании элементов в React.Fragment внутри Gapped отступы между ними не появляются

## Решение

При обработке React.Fragment внутри Gapped необходимо работать с его дочерними элементами.

## Ссылки

[#1268](https://yt.skbkontur.ru/issue/IF-1268/Gapped-nauchit-rabotat-s-React.Fragment) -- Gapped: научить работать с React.Fragment

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

3. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

4. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

5. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
