### PR TITLE
fix(Switcher): export SwitcherItems type

### DIFF
--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -20,7 +20,7 @@ import { mod } from './helpers';
  * @deprecated use SizeProp
  */
 export type SwitcherSize = SizeProp;
-type SwitcherItems = string | SwitcherItem;
+export type SwitcherItems = string | SwitcherItem;
 
 export const SwitcherDataTids = {
   root: 'Switcher__root',


### PR DESCRIPTION
## Проблема

`Switcher` имеет проп `items` с типом `SwitcherItems[]`, но тип `SwitcherItems` не экспоритируется, вынуждая пользователей писать тип самим

## Решение

Добавила экспорт типа `SwitcherItems`

## Ссылки

fix IF-1601

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
