### PR TITLE
chore(SidePage): add FocusLock on featureFlag

### DIFF
--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -19,6 +19,11 @@ import { cx } from '../../lib/theming/Emotion';
 import { isTestEnv } from '../../lib/currentEnvironment';
 import { ResponsiveLayout } from '../ResponsiveLayout';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import {
+  getFullReactUIFlagsContext,
+  ReactUIFeatureFlags,
+  ReactUIFeatureFlagsContext
+} from '../../lib/featureFlagsContext';
 
 import { SidePageBody } from './SidePageBody';
 import { SidePageContainer } from './SidePageContainer';
@@ -163,14 +168,23 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
 
   private getProps = createPropsGetter(SidePage.defaultProps);
 
+  private featureFlags!: ReactUIFeatureFlags;
+
   public render(): JSX.Element {
     return (
-      <ThemeContext.Consumer>
-        {(theme) => {
-          this.theme = theme;
-          return this.renderMain();
+      <ReactUIFeatureFlagsContext.Consumer>
+        {(flags) => {
+          this.featureFlags = getFullReactUIFlagsContext(flags);
+          return (
+            <ThemeContext.Consumer>
+              {(theme) => {
+                this.theme = theme;
+                return this.renderMain();
+              }}
+            </ThemeContext.Consumer>
+          );
         }}
-      </ThemeContext.Consumer>
+      </ReactUIFeatureFlagsContext.Consumer>
     );
   }
 
@@ -239,7 +253,8 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
         }
         wrapperRef={this.rootRef}
       >
-        <FocusLock disabled={disableFocusLock || !blockBackground} autoFocus={false} className={styles.focusLock()}>
+        <FocusLock disabled={this.featureFlags.sidePageAddFocusLockWhenBackgroundBlocked ?
+          !blockBackground : (disableFocusLock || !blockBackground) } autoFocus={false} className={styles.focusLock()}>
           <RenderLayer onClickOutside={this.handleClickOutside} active>
             <div
               data-tid={SidePageDataTids.container}

--- a/packages/react-ui/components/SidePage/__stories__/SidePage.stories.tsx
+++ b/packages/react-ui/components/SidePage/__stories__/SidePage.stories.tsx
@@ -11,6 +11,7 @@ import { Gapped } from '../../Gapped';
 import { Shape } from '../../../typings/utility-types';
 import { delay } from '../../../lib/utils';
 import { ThemeContext } from '../../../lib/theming/ThemeContext';
+import { ReactUIFeatureFlagsContext } from '../../../lib/featureFlagsContext';
 
 const textSample = (
   <p>
@@ -786,6 +787,51 @@ BodyWithoutHeader.parameters = {
           .perform();
         await delay(100);
         await this.expect(await this.browser.takeScreenshot()).to.matchImage('open side-page without header');
+      },
+    },
+  },
+};
+
+export const SidePageWithFocusLockWhenBackgroundBlockedFeatureFlag: Story = () => {
+  return (
+    <ReactUIFeatureFlagsContext.Provider value={{ sidePageAddFocusLockWhenBackgroundBlocked: true }}>
+      <Sample total={1} current={1} blockBackground/>
+    </ReactUIFeatureFlagsContext.Provider>
+  );
+};
+SidePageWithFocusLockWhenBackgroundBlockedFeatureFlag.storyName = 'SidePage with sidePageAddFocusLockWhenBackgroundBlocked feature flag ';
+SidePageWithFocusLockWhenBackgroundBlockedFeatureFlag.parameters = {
+  creevey: {
+    skip: { in: /^(?!\b(chrome2022|firefox2022)\b)/ },
+    tests: {
+      async 'open side-page'() {
+        const pressTab = () => {
+          return this.browser
+            .actions({
+              bridge: true,
+            })
+            .sendKeys(this.keys.TAB);
+        };
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+          .click(this.browser.findElement({css: '[data-tid~="open-side-page"]'}))
+          .perform();
+        await delay(100);
+        pressTab().perform();
+        await delay(100);
+        const firstTimeTabPress = await this.browser.takeScreenshot();
+        pressTab().perform();
+        await delay(100);
+        const secondTimeTabPress = await this.browser.takeScreenshot();
+        pressTab().perform();
+        await delay(100);
+        const thirdTimeTabPress = await this.browser.takeScreenshot();
+        pressTab().perform();
+        await delay(100);
+        const fourthTimeTabPress = await this.browser.takeScreenshot();
+        await this.expect({ firstTimeTabPress, secondTimeTabPress, thirdTimeTabPress, fourthTimeTabPress }).to.matchImages();
       },
     },
   },

--- a/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
+++ b/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
@@ -5,6 +5,7 @@
 ```typescript static
 export interface ReactUIFeatureFlags {
   tokenInputRemoveWhitespaceFromDefaultDelimiters?: boolean;
+  sidePageAddFocusLockWhenBackgroundBlocked?: boolean;
 }
 ```
 
@@ -39,6 +40,56 @@ const getItems = () => {};
     onValueChange={setSelectedItems}
   />
 </ReactUIFeatureFlagsContext.Provider>
+```
+
+### sidePageAddFocusLockWhenBackgroundBlocked
+
+В SidePage FocusLock будет применяться тогда и только тогда, когда проп blockBackground равен true.
+В React UI 5.0 фича будет применена по умолчанию.
+
+```jsx harmony
+import { SidePage, Button, ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
+
+const [opened, setOpened] = React.useState(false);
+
+function renderSidePage() {
+  return (
+    <ReactUIFeatureFlagsContext.Provider value={{ sidePageAddFocusLockWhenBackgroundBlocked: true }}>
+      <SidePage onClose={close} blockBackground>
+        <SidePage.Header>SidePage</SidePage.Header>
+        <SidePage.Body>
+          <div
+            style={{
+              background: `repeating-linear-gradient(60deg, #808080, #808080 20px, #d3d3d3 20px, #d3d3d3 40px)`,
+              height: 600,
+              padding: '20px 0',
+            }}
+          >
+            <SidePage.Container>
+              <p>Content</p>
+            </SidePage.Container>
+          </div>
+        </SidePage.Body>
+        <SidePage.Footer panel>
+          <Button onClick={close}>Close</Button>
+        </SidePage.Footer>
+      </SidePage>
+    </ReactUIFeatureFlagsContext.Provider>
+  );
+}
+
+function open() {
+  setOpened(true);
+}
+
+function close() {
+  setOpened(false);
+}
+
+<div>
+  {opened && renderSidePage()}
+  <Button onClick={open}>Open</Button>
+</div>
 ```
 
 ## Объект со всеми флагами

--- a/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
+++ b/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 export interface ReactUIFeatureFlags {
   tokenInputRemoveWhitespaceFromDefaultDelimiters?: boolean;
+  sidePageAddFocusLockWhenBackgroundBlocked?: boolean;
 }
 
 export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {
   tokenInputRemoveWhitespaceFromDefaultDelimiters: false,
+  sidePageAddFocusLockWhenBackgroundBlocked: false,
 };
 
 export const ReactUIFeatureFlagsContext = React.createContext<ReactUIFeatureFlags>(reactUIFeatureFlagsDefault);


### PR DESCRIPTION
## Проблема

SidePage не ловит фокус в ловушку по умолчанию

## Решение

Добавить FocusLock

## Ссылки

[#1222](https://yt.skbkontur.ru/issue/IF-1222/SidePage-ne-lovit-fokus-v-lovushku-po-umolchaniyu) -- SidePage: не ловит фокус в ловушку по умолчанию

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

3. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

4. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

5. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
