### PR TITLE
fix(Button): use=link prevents action of parent link

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -473,7 +473,14 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
     if (_isTheme2022 && isLink && !loading) {
       captionNode = (
         <ThemeContext.Provider value={getInnerLinkTheme(this.theme)}>
-          <Link focused={isFocused} disabled={disabled} icon={this.renderIcon2022(icon)} as="span" tabIndex={-1}>
+          <Link
+            _enableEventsWithoutHref
+            focused={isFocused}
+            disabled={disabled}
+            icon={this.renderIcon2022(icon)}
+            as="span"
+            tabIndex={-1}
+          >
             {children}
           </Link>
         </ThemeContext.Provider>

--- a/packages/react-ui/components/Button/__tests__/Button-test.tsx
+++ b/packages/react-ui/components/Button/__tests__/Button-test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { useState } from 'react';
 
@@ -207,5 +207,22 @@ describe('Button', () => {
     );
 
     expect(screen.getByTestId(ButtonDataTids.spinner)).toBeInTheDocument();
+  });
+
+  it('use="link" in THEME_2022 does not prevent default action of parent link', () => {
+    render(
+      <ThemeContext.Provider value={THEME_2022}>
+        <a href="">
+          <Button use="link">text</Button>
+        </a>
+      </ThemeContext.Provider>,
+    );
+
+    const link = screen.getByRole('link');
+    const keyDownEvent = createEvent.keyDown(link);
+
+    fireEvent(link, keyDownEvent);
+
+    expect(keyDownEvent.defaultPrevented).toBe(false);
   });
 });

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -75,6 +75,11 @@ export interface LinkProps
          * @ignore
          */
         focused?: boolean;
+        /**
+         * Снимает ограничение на предотвращение событий при клике по ссылке без заданного `href`
+         * @ignore
+         */
+        _enableEventsWithoutHref?: boolean;
       }
     > {}
 
@@ -86,7 +91,7 @@ export const LinkDataTids = {
   root: 'Link__root',
 } as const;
 
-type DefaultProps = Required<Pick<LinkProps, 'href' | 'use' | 'as'>>;
+type DefaultProps = Required<Pick<LinkProps, 'href' | 'use' | 'as' | '_enableEventsWithoutHref'>>;
 type DefaultizedLinkProps = DefaultizedProps<LinkProps, DefaultProps>;
 
 /**
@@ -110,6 +115,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
     href: '',
     use: 'default',
     as: 'a',
+    _enableEventsWithoutHref: false,
   };
 
   private getProps = createPropsGetter(Link.defaultProps);
@@ -239,7 +245,7 @@ export class Link extends React.Component<LinkProps, LinkState> {
   private handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     const { onClick, disabled, loading } = this.props;
     const href = this.getProps().href;
-    if (!href) {
+    if (!href && !this.getProps()._enableEventsWithoutHref) {
       event.preventDefault();
     }
     if (onClick && !disabled && !loading) {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

При оборачивании кнопки `<Button use="link" />` в тег `<a>` переход по ссылке не срабатывал, поведение воспроизводилось только в `THEME_2022`

## Решение

Проблема был в том, что в `THEME_2022` состояние `<Button use="link">` под капотом использует наш компонент `<Link>` у которого сброшена семантика. При этом внутри `<Link>` есть условие, которое вызывает `e.preventDefault()` при клике, если в компонент не передан проп `href`.

Добавил дополнительный, скрытый проп `_enableEventsWithoutHref` в `<Link>`, который позволяет отключить это поведение и прокинул его в `<Button use="link">` в `THEME_2022`.

В тестах тестирую, что для этого случая поведение по умолчанию не отключено.

## Ссылки

IF-1574

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)