### PR TITLE
fix: globalObject.isInstanceOf in IE 11

### DIFF
--- a/packages/react-ui/components/Calendar/Calendar.tsx
+++ b/packages/react-ui/components/Calendar/Calendar.tsx
@@ -4,7 +4,7 @@ import throttle from 'lodash.throttle';
 import shallowEqual from 'shallowequal';
 import { globalObject, SafeTimer } from '@skbkontur/global-object';
 
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import { InternalDate } from '../../lib/date/InternalDate';
 import { InternalDateTransformer } from '../../lib/date/InternalDateTransformer';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
@@ -397,7 +397,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   };
 
   private handleTouchStart = (event: Event) => {
-    if (!isInstanceOfForIE11(event, globalObject.TouchEvent)) {
+    if (!isInstanceOf(event, globalObject.TouchEvent)) {
       return;
     }
 
@@ -406,7 +406,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   };
 
   private handleTouchMove = (event: Event) => {
-    if (!isInstanceOfForIE11(event, globalObject.TouchEvent)) {
+    if (!isInstanceOf(event, globalObject.TouchEvent)) {
       return;
     }
 
@@ -421,7 +421,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   private throttledHandleTouchMove = throttle(this.handleTouchMove, 10);
 
   private handleWheel = (event: Event) => {
-    if (!isInstanceOfForIE11(event, globalObject.WheelEvent)) {
+    if (!isInstanceOf(event, globalObject.WheelEvent)) {
       return;
     }
     event.preventDefault();

--- a/packages/react-ui/components/Calendar/Calendar.tsx
+++ b/packages/react-ui/components/Calendar/Calendar.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import normalizeWheel from 'normalize-wheel';
 import throttle from 'lodash.throttle';
 import shallowEqual from 'shallowequal';
-import { globalObject, isInstanceOf, SafeTimer } from '@skbkontur/global-object';
+import { globalObject, SafeTimer } from '@skbkontur/global-object';
 
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import { InternalDate } from '../../lib/date/InternalDate';
 import { InternalDateTransformer } from '../../lib/date/InternalDateTransformer';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
@@ -396,7 +397,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   };
 
   private handleTouchStart = (event: Event) => {
-    if (!isInstanceOf(event, globalObject.TouchEvent)) {
+    if (!isInstanceOfForIE11(event, globalObject.TouchEvent)) {
       return;
     }
 
@@ -405,7 +406,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   };
 
   private handleTouchMove = (event: Event) => {
-    if (!isInstanceOf(event, globalObject.TouchEvent)) {
+    if (!isInstanceOfForIE11(event, globalObject.TouchEvent)) {
       return;
     }
 
@@ -420,7 +421,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   private throttledHandleTouchMove = throttle(this.handleTouchMove, 10);
 
   private handleWheel = (event: Event) => {
-    if (!isInstanceOf(event, globalObject.WheelEvent)) {
+    if (!isInstanceOfForIE11(event, globalObject.WheelEvent)) {
       return;
     }
     event.preventDefault();

--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -4,7 +4,7 @@ import React, { AriaAttributes } from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
 import debounce from 'lodash.debounce';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { isNonNullable, isNullable } from '../../lib/utils';
 import { isIE11 } from '../../lib/client';
@@ -13,6 +13,7 @@ import { Nullable, Override } from '../../typings/utility-types';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 import { TSetRootNode, rootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { MAX_SAFE_DIGITS } from './constants';
 import { Selection, SelectionDirection, SelectionHelper } from './SelectionHelper';
@@ -471,7 +472,7 @@ export class CurrencyInput extends React.PureComponent<CurrencyInputProps, Curre
 }
 
 function getInputSelectionFromEvent(input: EventTarget): Selection {
-  if (!isInstanceOf(input, globalObject.HTMLInputElement)) {
+  if (!isInstanceOfForIE11(input, globalObject.HTMLInputElement)) {
     throw new Error('input is not HTMLInputElement');
   }
 

--- a/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/react-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -13,7 +13,7 @@ import { Nullable, Override } from '../../typings/utility-types';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 import { TSetRootNode, rootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { MAX_SAFE_DIGITS } from './constants';
 import { Selection, SelectionDirection, SelectionHelper } from './SelectionHelper';
@@ -472,7 +472,7 @@ export class CurrencyInput extends React.PureComponent<CurrencyInputProps, Curre
 }
 
 function getInputSelectionFromEvent(input: EventTarget): Selection {
-  if (!isInstanceOfForIE11(input, globalObject.HTMLInputElement)) {
+  if (!isInstanceOf(input, globalObject.HTMLInputElement)) {
     throw new Error('input is not HTMLInputElement');
   }
 

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { func, number } from 'prop-types';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import { isKeyArrowLeft, isKeyArrowRight, isKeyEnter } from '../../lib/events/keyboard/identifiers';
 import { locale } from '../../lib/locale/decorators';
 import { Nullable } from '../../typings/utility-types';
@@ -333,7 +334,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
     const isArrowRight = isKeyArrowRight(e);
 
     if (
-      isInstanceOf(target, globalObject.Element) &&
+      isInstanceOfForIE11(target, globalObject.Element) &&
       (IGNORE_EVENT_TAGS.includes(target.tagName.toLowerCase()) || (target as HTMLElement).isContentEditable)
     ) {
       return;

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { func, number } from 'prop-types';
 import { globalObject } from '@skbkontur/global-object';
 
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import { isKeyArrowLeft, isKeyArrowRight, isKeyEnter } from '../../lib/events/keyboard/identifiers';
 import { locale } from '../../lib/locale/decorators';
 import { Nullable } from '../../typings/utility-types';
@@ -334,7 +334,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
     const isArrowRight = isKeyArrowRight(e);
 
     if (
-      isInstanceOfForIE11(target, globalObject.Element) &&
+      isInstanceOf(target, globalObject.Element) &&
       (IGNORE_EVENT_TAGS.includes(target.tagName.toLowerCase()) || (target as HTMLElement).isContentEditable)
     ) {
       return;

--- a/packages/react-ui/components/ScrollContainer/ScrollBar.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollBar.tsx
@@ -5,7 +5,7 @@ import { Nullable } from '../../typings/utility-types';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { cx } from '../../lib/theming/Emotion';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { defaultScrollbarState, scrollSizeParametersNames } from './ScrollContainer.constants';
 import { styles, globalClasses } from './ScrollContainer.styles';
@@ -234,7 +234,7 @@ export class ScrollBar extends React.Component<ScrollBarProps, ScrollBarState> {
   };
 
   private handleScrollWheel = (event: Event, axis: ScrollAxis) => {
-    if (!this.inner || !isInstanceOfForIE11(event, globalObject.WheelEvent) || (axis === 'x' && !event.shiftKey)) {
+    if (!this.inner || !isInstanceOf(event, globalObject.WheelEvent) || (axis === 'x' && !event.shiftKey)) {
       return;
     }
 

--- a/packages/react-ui/components/ScrollContainer/ScrollBar.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollBar.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { Nullable } from '../../typings/utility-types';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { cx } from '../../lib/theming/Emotion';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { defaultScrollbarState, scrollSizeParametersNames } from './ScrollContainer.constants';
 import { styles, globalClasses } from './ScrollContainer.styles';
@@ -233,7 +234,7 @@ export class ScrollBar extends React.Component<ScrollBarProps, ScrollBarState> {
   };
 
   private handleScrollWheel = (event: Event, axis: ScrollAxis) => {
-    if (!this.inner || !isInstanceOf(event, globalObject.WheelEvent) || (axis === 'x' && !event.shiftKey)) {
+    if (!this.inner || !isInstanceOfForIE11(event, globalObject.WheelEvent) || (axis === 'x' && !event.shiftKey)) {
       return;
     }
 

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 import debounce from 'lodash.debounce';
 
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { Nullable } from '../../typings/utility-types';
@@ -375,7 +376,7 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
   }, this.getProps().hideScrollBarDelay);
 
   private handleInnerScrollWheel = (event: Event) => {
-    if (!this.inner || !isInstanceOf(event, globalObject.WheelEvent)) {
+    if (!this.inner || !isInstanceOfForIE11(event, globalObject.WheelEvent)) {
       return;
     }
 

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { globalObject } from '@skbkontur/global-object';
 import debounce from 'lodash.debounce';
 
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { Nullable } from '../../typings/utility-types';
@@ -376,7 +376,7 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
   }, this.getProps().hideScrollBarDelay);
 
   private handleInnerScrollWheel = (event: Event) => {
-    if (!this.inner || !isInstanceOfForIE11(event, globalObject.WheelEvent)) {
+    if (!this.inner || !isInstanceOf(event, globalObject.WheelEvent)) {
       return;
     }
 

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -1,7 +1,7 @@
 import React, { AriaAttributes, HTMLAttributes } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import FocusLock from 'react-focus-lock';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { isNonNullable } from '../../lib/utils';
 import { isKeyEscape } from '../../lib/events/keyboard/identifiers';
@@ -19,6 +19,7 @@ import { cx } from '../../lib/theming/Emotion';
 import { isTestEnv } from '../../lib/currentEnvironment';
 import { ResponsiveLayout } from '../ResponsiveLayout';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { SidePageBody } from './SidePageBody';
 import { SidePageContainer } from './SidePageContainer';
@@ -336,7 +337,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     if (this.state.stackPosition === 0 && !this.props.ignoreBackgroundClick) {
       // ignore mousedown on window scrollbar
       if (
-        isInstanceOf(e, globalObject.MouseEvent) &&
+        isInstanceOfForIE11(e, globalObject.MouseEvent) &&
         globalObject.document &&
         e.clientX > globalObject.document.documentElement.clientWidth
       ) {

--- a/packages/react-ui/components/SidePage/SidePage.tsx
+++ b/packages/react-ui/components/SidePage/SidePage.tsx
@@ -19,7 +19,7 @@ import { cx } from '../../lib/theming/Emotion';
 import { isTestEnv } from '../../lib/currentEnvironment';
 import { ResponsiveLayout } from '../ResponsiveLayout';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { SidePageBody } from './SidePageBody';
 import { SidePageContainer } from './SidePageContainer';
@@ -337,7 +337,7 @@ export class SidePage extends React.Component<SidePageProps, SidePageState> {
     if (this.state.stackPosition === 0 && !this.props.ignoreBackgroundClick) {
       // ignore mousedown on window scrollbar
       if (
-        isInstanceOfForIE11(e, globalObject.MouseEvent) &&
+        isInstanceOf(e, globalObject.MouseEvent) &&
         globalObject.document &&
         e.clientX > globalObject.document.documentElement.clientWidth
       ) {

--- a/packages/react-ui/components/Tabs/Indicator.tsx
+++ b/packages/react-ui/components/Tabs/Indicator.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import throttle from 'lodash.throttle';
 import { globalObject } from '@skbkontur/global-object';
 
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { Nullable } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -120,7 +120,7 @@ export class Indicator extends React.Component<IndicatorProps, IndicatorState> {
   private getStyles(node: any): React.CSSProperties {
     const htmlNode = getRootNode(node);
 
-    if (isInstanceOfForIE11(htmlNode, globalObject.HTMLElement)) {
+    if (isInstanceOf(htmlNode, globalObject.HTMLElement)) {
       const rect = getDOMRect(htmlNode);
       if (this.props.vertical) {
         return {

--- a/packages/react-ui/components/Tabs/Indicator.tsx
+++ b/packages/react-ui/components/Tabs/Indicator.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import throttle from 'lodash.throttle';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { Nullable } from '../../typings/utility-types';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -119,7 +120,7 @@ export class Indicator extends React.Component<IndicatorProps, IndicatorState> {
   private getStyles(node: any): React.CSSProperties {
     const htmlNode = getRootNode(node);
 
-    if (isInstanceOf(htmlNode, globalObject.HTMLElement)) {
+    if (isInstanceOfForIE11(htmlNode, globalObject.HTMLElement)) {
       const rect = getDOMRect(htmlNode);
       if (this.props.vertical) {
         return {

--- a/packages/react-ui/components/Tabs/Tabs.tsx
+++ b/packages/react-ui/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import React, { AriaAttributes } from 'react';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { emptyHandler } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -10,6 +10,7 @@ import { getRootNode } from '../../lib/rootNode/getRootNode';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { SizeProp } from '../../lib/types/props';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { Indicator } from './Indicator';
 import { styles } from './Tabs.styles';
@@ -158,7 +159,7 @@ export class Tabs<T extends string = string> extends React.Component<TabsProps<T
     const tabNode = tab.getNode();
     const htmlNode = getRootNode(tabNode);
 
-    if (isInstanceOf(htmlNode, globalObject.HTMLElement) && typeof htmlNode.focus === 'function') {
+    if (isInstanceOfForIE11(htmlNode, globalObject.HTMLElement) && typeof htmlNode.focus === 'function') {
       htmlNode.focus();
     }
   };

--- a/packages/react-ui/components/Tabs/Tabs.tsx
+++ b/packages/react-ui/components/Tabs/Tabs.tsx
@@ -10,7 +10,7 @@ import { getRootNode } from '../../lib/rootNode/getRootNode';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { SizeProp } from '../../lib/types/props';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { Indicator } from './Indicator';
 import { styles } from './Tabs.styles';
@@ -159,7 +159,7 @@ export class Tabs<T extends string = string> extends React.Component<TabsProps<T
     const tabNode = tab.getNode();
     const htmlNode = getRootNode(tabNode);
 
-    if (isInstanceOfForIE11(htmlNode, globalObject.HTMLElement) && typeof htmlNode.focus === 'function') {
+    if (isInstanceOf(htmlNode, globalObject.HTMLElement) && typeof htmlNode.focus === 'function') {
       htmlNode.focus();
     }
   };

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ import { InstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { CloseButtonIcon } from '../../internal/CloseButtonIcon/CloseButtonIcon';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { styles } from './Tooltip.styles';
 
@@ -533,7 +533,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
   };
 
   private isClickOutsideContent(event: Event) {
-    if (this.contentElement && isInstanceOfForIE11(event.target, globalObject.Element)) {
+    if (this.contentElement && isInstanceOf(event.target, globalObject.Element)) {
       return !containsTargetOrRenderContainer(event.target)(this.contentElement);
     }
 

--- a/packages/react-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/react-ui/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import warning from 'warning';
 import isEqual from 'lodash.isequal';
-import { globalObject, isInstanceOf, SafeTimer } from '@skbkontur/global-object';
+import { globalObject, SafeTimer } from '@skbkontur/global-object';
 
 import { isNullable } from '../../lib/utils';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
@@ -20,6 +20,7 @@ import { InstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { CloseButtonIcon } from '../../internal/CloseButtonIcon/CloseButtonIcon';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { styles } from './Tooltip.styles';
 
@@ -532,7 +533,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, TooltipState> imp
   };
 
   private isClickOutsideContent(event: Event) {
-    if (this.contentElement && isInstanceOf(event.target, globalObject.Element)) {
+    if (this.contentElement && isInstanceOfForIE11(event.target, globalObject.Element)) {
       return !containsTargetOrRenderContainer(event.target)(this.contentElement);
     }
 

--- a/packages/react-ui/internal/DateSelect/DateSelect.tsx
+++ b/packages/react-ui/internal/DateSelect/DateSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { globalObject, isBrowser, isInstanceOf, SafeTimer } from '@skbkontur/global-object';
+import { globalObject, isBrowser, SafeTimer } from '@skbkontur/global-object';
 
 import { getRandomID, isNonNullable } from '../../lib/utils';
 import { isKeyEscape } from '../../lib/events/keyboard/identifiers';
@@ -21,6 +21,7 @@ import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { ArrowCollapseCVOpenIcon16Regular } from '../icons2022/ArrowCollapseCVOpenIcon/ArrowCollapseCVOpenIcon16Regular';
 import { ArrowCUpIcon16Regular } from '../icons2022/ArrowCUpIcon/ArrowCUpIcon16Regular';
 import { ArrowCDownIcon16Regular } from '../icons2022/ArrowCDownIcon/ArrowCDownIcon16Regular';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { globalClasses, styles } from './DateSelect.styles';
 
@@ -462,7 +463,7 @@ export class DateSelect extends React.PureComponent<DateSelectProps, DateSelectS
   private getAnchor = () => this.root;
 
   private handleWheel = (event: Event) => {
-    if (!isInstanceOf(event, globalObject.WheelEvent)) {
+    if (!isInstanceOfForIE11(event, globalObject.WheelEvent)) {
       return;
     }
     event.preventDefault();
@@ -479,7 +480,7 @@ export class DateSelect extends React.PureComponent<DateSelectProps, DateSelectS
   };
 
   private handleTouchStart = (event: Event) => {
-    if (!isInstanceOf(event, globalObject.TouchEvent)) {
+    if (!isInstanceOfForIE11(event, globalObject.TouchEvent)) {
       return;
     }
 
@@ -487,7 +488,7 @@ export class DateSelect extends React.PureComponent<DateSelectProps, DateSelectS
   };
 
   private handleTouchMove = (event: Event) => {
-    if (!isInstanceOf(event, globalObject.TouchEvent) || !isBrowser(globalObject)) {
+    if (!isInstanceOfForIE11(event, globalObject.TouchEvent) || !isBrowser(globalObject)) {
       return;
     }
 

--- a/packages/react-ui/internal/DateSelect/DateSelect.tsx
+++ b/packages/react-ui/internal/DateSelect/DateSelect.tsx
@@ -21,7 +21,7 @@ import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { ArrowCollapseCVOpenIcon16Regular } from '../icons2022/ArrowCollapseCVOpenIcon/ArrowCollapseCVOpenIcon16Regular';
 import { ArrowCUpIcon16Regular } from '../icons2022/ArrowCUpIcon/ArrowCUpIcon16Regular';
 import { ArrowCDownIcon16Regular } from '../icons2022/ArrowCDownIcon/ArrowCDownIcon16Regular';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { globalClasses, styles } from './DateSelect.styles';
 
@@ -463,7 +463,7 @@ export class DateSelect extends React.PureComponent<DateSelectProps, DateSelectS
   private getAnchor = () => this.root;
 
   private handleWheel = (event: Event) => {
-    if (!isInstanceOfForIE11(event, globalObject.WheelEvent)) {
+    if (!isInstanceOf(event, globalObject.WheelEvent)) {
       return;
     }
     event.preventDefault();
@@ -480,7 +480,7 @@ export class DateSelect extends React.PureComponent<DateSelectProps, DateSelectS
   };
 
   private handleTouchStart = (event: Event) => {
-    if (!isInstanceOfForIE11(event, globalObject.TouchEvent)) {
+    if (!isInstanceOf(event, globalObject.TouchEvent)) {
       return;
     }
 
@@ -488,7 +488,7 @@ export class DateSelect extends React.PureComponent<DateSelectProps, DateSelectS
   };
 
   private handleTouchMove = (event: Event) => {
-    if (!isInstanceOfForIE11(event, globalObject.TouchEvent) || !isBrowser(globalObject)) {
+    if (!isInstanceOf(event, globalObject.TouchEvent) || !isBrowser(globalObject)) {
       return;
     }
 

--- a/packages/react-ui/internal/DropdownContainer/DropdownContainer.tsx
+++ b/packages/react-ui/internal/DropdownContainer/DropdownContainer.tsx
@@ -1,6 +1,7 @@
 import React, { HTMLAttributes } from 'react';
-import { globalObject, isBrowser, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject, isBrowser } from '@skbkontur/global-object';
 
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { RenderContainer } from '../RenderContainer';
 import { ZIndex } from '../ZIndex';
@@ -121,7 +122,7 @@ export class DropdownContainer extends React.PureComponent<DropdownContainerProp
     const target = this.props.getParent();
     const dom = this.dom;
 
-    if (target && isInstanceOf(target, globalObject.Element) && dom && isBrowser(globalObject)) {
+    if (target && isInstanceOfForIE11(target, globalObject.Element) && dom && isBrowser(globalObject)) {
       const targetRect = getDOMRect(target);
       const { body, documentElement: docEl } = globalObject.document;
 
@@ -171,7 +172,7 @@ export class DropdownContainer extends React.PureComponent<DropdownContainerProp
   };
 
   private getHeight = () => {
-    if (!isInstanceOf(this.dom, globalObject.Element)) {
+    if (!isInstanceOfForIE11(this.dom, globalObject.Element)) {
       return 0;
     }
     const child = this.dom.children.item(0);
@@ -188,7 +189,7 @@ export class DropdownContainer extends React.PureComponent<DropdownContainerProp
     const offsetX = this.getProps().offsetX || 0;
     const offsetY = this.getProps().offsetY || 0;
     const { top, bottom, left, right } = position;
-    if (isInstanceOf(target, globalObject.Element)) {
+    if (isInstanceOfForIE11(target, globalObject.Element)) {
       const targetHeight = getDOMRect(target).height;
       return {
         top: top !== null ? targetHeight + offsetY : null,

--- a/packages/react-ui/internal/DropdownContainer/DropdownContainer.tsx
+++ b/packages/react-ui/internal/DropdownContainer/DropdownContainer.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 import { globalObject, isBrowser } from '@skbkontur/global-object';
 
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { RenderContainer } from '../RenderContainer';
 import { ZIndex } from '../ZIndex';
@@ -122,7 +122,7 @@ export class DropdownContainer extends React.PureComponent<DropdownContainerProp
     const target = this.props.getParent();
     const dom = this.dom;
 
-    if (target && isInstanceOfForIE11(target, globalObject.Element) && dom && isBrowser(globalObject)) {
+    if (target && isInstanceOf(target, globalObject.Element) && dom && isBrowser(globalObject)) {
       const targetRect = getDOMRect(target);
       const { body, documentElement: docEl } = globalObject.document;
 
@@ -172,7 +172,7 @@ export class DropdownContainer extends React.PureComponent<DropdownContainerProp
   };
 
   private getHeight = () => {
-    if (!isInstanceOfForIE11(this.dom, globalObject.Element)) {
+    if (!isInstanceOf(this.dom, globalObject.Element)) {
       return 0;
     }
     const child = this.dom.children.item(0);
@@ -189,7 +189,7 @@ export class DropdownContainer extends React.PureComponent<DropdownContainerProp
     const offsetX = this.getProps().offsetX || 0;
     const offsetY = this.getProps().offsetY || 0;
     const { top, bottom, left, right } = position;
-    if (isInstanceOfForIE11(target, globalObject.Element)) {
+    if (isInstanceOf(target, globalObject.Element)) {
       const targetHeight = getDOMRect(target).height;
       return {
         top: top !== null ? targetHeight + offsetY : null,

--- a/packages/react-ui/internal/FocusTrap/FocusTrap.tsx
+++ b/packages/react-ui/internal/FocusTrap/FocusTrap.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { listen as listenFocusOutside, containsTargetOrRenderContainer } from '../../lib/listenFocusOutside';
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 export interface FocusTrapProps extends CommonProps {
   children: React.ReactElement<any>;
@@ -78,7 +79,7 @@ export class FocusTrap extends React.PureComponent<FocusTrapProps> {
     const target = event.target || event.srcElement;
     const node = getRootNode(this);
 
-    if (node && isInstanceOf(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node)) {
+    if (node && isInstanceOfForIE11(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node)) {
       return;
     }
 

--- a/packages/react-ui/internal/FocusTrap/FocusTrap.tsx
+++ b/packages/react-ui/internal/FocusTrap/FocusTrap.tsx
@@ -4,7 +4,7 @@ import { globalObject } from '@skbkontur/global-object';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { listen as listenFocusOutside, containsTargetOrRenderContainer } from '../../lib/listenFocusOutside';
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 export interface FocusTrapProps extends CommonProps {
   children: React.ReactElement<any>;
@@ -79,7 +79,7 @@ export class FocusTrap extends React.PureComponent<FocusTrapProps> {
     const target = event.target || event.srcElement;
     const node = getRootNode(this);
 
-    if (node && isInstanceOfForIE11(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node)) {
+    if (node && isInstanceOf(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node)) {
       return;
     }
 

--- a/packages/react-ui/internal/IgnoreLayerClick/IgnoreLayerClick.tsx
+++ b/packages/react-ui/internal/IgnoreLayerClick/IgnoreLayerClick.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { globalObject } from '@skbkontur/global-object';
 
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import { CommonWrapper } from '../CommonWrapper';
 
 export interface IgnoreLayerClickProps {
@@ -31,7 +31,7 @@ class IgnoreLayerClickWrapper extends React.Component<WrapperProps> {
 
   public componentDidMount() {
     const element = getRootNode(this);
-    if (isInstanceOfForIE11(element, globalObject.Element)) {
+    if (isInstanceOf(element, globalObject.Element)) {
       element.addEventListener('mousedown', this.handleMouseDown);
       this.element = element;
     }

--- a/packages/react-ui/internal/IgnoreLayerClick/IgnoreLayerClick.tsx
+++ b/packages/react-ui/internal/IgnoreLayerClick/IgnoreLayerClick.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import { CommonWrapper } from '../CommonWrapper';
 
 export interface IgnoreLayerClickProps {
@@ -30,7 +31,7 @@ class IgnoreLayerClickWrapper extends React.Component<WrapperProps> {
 
   public componentDidMount() {
     const element = getRootNode(this);
-    if (isInstanceOf(element, globalObject.Element)) {
+    if (isInstanceOfForIE11(element, globalObject.Element)) {
       element.addEventListener('mousedown', this.handleMouseDown);
       this.element = element;
     }

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -22,7 +22,7 @@ import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { InputLayoutAside } from '../../components/Input/InputLayout/InputLayoutAside';
 import { InputLayoutContext, InputLayoutContextDefault } from '../../components/Input/InputLayout/InputLayoutContext';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { HiddenInput } from './HiddenInput';
 import { styles } from './InputLikeText.styles';
@@ -378,12 +378,7 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
   };
 
   private handleDocumentMouseDown = (e: MouseEvent) => {
-    if (
-      this.state.focused &&
-      this.node &&
-      isInstanceOfForIE11(e.target, globalObject.Node) &&
-      !this.node.contains(e.target)
-    ) {
+    if (this.state.focused && this.node && isInstanceOf(e.target, globalObject.Node) && !this.node.contains(e.target)) {
       this.defrost();
     }
   };

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
-import { globalObject, isInstanceOf, SafeTimer } from '@skbkontur/global-object';
+import { globalObject, SafeTimer } from '@skbkontur/global-object';
 
 import { isFunction, isNonNullable } from '../../lib/utils';
 import { isKeyTab, isShortcutPaste } from '../../lib/events/keyboard/identifiers';
@@ -22,6 +22,7 @@ import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { InputLayoutAside } from '../../components/Input/InputLayout/InputLayoutAside';
 import { InputLayoutContext, InputLayoutContextDefault } from '../../components/Input/InputLayout/InputLayoutContext';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { HiddenInput } from './HiddenInput';
 import { styles } from './InputLikeText.styles';
@@ -377,7 +378,12 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
   };
 
   private handleDocumentMouseDown = (e: MouseEvent) => {
-    if (this.state.focused && this.node && isInstanceOf(e.target, globalObject.Node) && !this.node.contains(e.target)) {
+    if (
+      this.state.focused &&
+      this.node &&
+      isInstanceOfForIE11(e.target, globalObject.Node) &&
+      !this.node.contains(e.target)
+    ) {
       this.defrost();
     }
   };

--- a/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
+++ b/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
@@ -15,7 +15,7 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { getDOMRect } from '../../lib/dom/getDOMRect';
 import { MenuSeparator } from '../../components/MenuSeparator';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { styles } from './InternalMenu.styles';
 import { isActiveElement } from './isActiveElement';
@@ -251,7 +251,7 @@ export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuSta
 
   private focusOnRootElement = (): void => {
     const rootNode = getRootNode(this);
-    if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
+    if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
       rootNode?.focus();
     }
   };
@@ -329,7 +329,7 @@ export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuSta
     if (this.scrollContainer && this.highlighted) {
       const rootNode = getRootNode(this.highlighted);
       // TODO: Remove this check once IF-647 is resolved
-      if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
+      if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
         this.scrollContainer.scrollTo(rootNode);
       }
     }
@@ -361,7 +361,7 @@ export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuSta
     this.setState({ highlightedIndex: index });
 
     const rootNode = getRootNode(this);
-    if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
+    if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
       rootNode?.focus();
     }
   };

--- a/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
+++ b/packages/react-ui/internal/InternalMenu/InternalMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { globalObject, isInstanceOf, isBrowser } from '@skbkontur/global-object';
+import { globalObject, isBrowser } from '@skbkontur/global-object';
 
 import { responsiveLayout } from '../../components/ResponsiveLayout/decorator';
 import { isNonNullable, isNullable } from '../../lib/utils';
@@ -15,6 +15,7 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { getDOMRect } from '../../lib/dom/getDOMRect';
 import { MenuSeparator } from '../../components/MenuSeparator';
 import { ThemeFactory } from '../../lib/theming/ThemeFactory';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { styles } from './InternalMenu.styles';
 import { isActiveElement } from './isActiveElement';
@@ -250,7 +251,7 @@ export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuSta
 
   private focusOnRootElement = (): void => {
     const rootNode = getRootNode(this);
-    if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
+    if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
       rootNode?.focus();
     }
   };
@@ -328,7 +329,7 @@ export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuSta
     if (this.scrollContainer && this.highlighted) {
       const rootNode = getRootNode(this.highlighted);
       // TODO: Remove this check once IF-647 is resolved
-      if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
+      if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
         this.scrollContainer.scrollTo(rootNode);
       }
     }
@@ -360,7 +361,7 @@ export class InternalMenu extends React.PureComponent<InternalMenuProps, MenuSta
     this.setState({ highlightedIndex: index });
 
     const rootNode = getRootNode(this);
-    if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
+    if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
       rootNode?.focus();
     }
   };

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, HTMLAttributes } from 'react';
-import { globalObject, isBrowser, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject, isBrowser } from '@skbkontur/global-object';
 
 import { isKeyArrowDown, isKeyArrowUp, isKeyEnter } from '../../lib/events/keyboard/identifiers';
 import { MenuSeparator } from '../../components/MenuSeparator';
@@ -19,6 +19,7 @@ import { isIE11 } from '../../lib/client';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { isIconPaddingEnabled } from '../InternalMenu/isIconPaddingEnabled';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { styles } from './Menu.styles';
 import { isActiveElement } from './isActiveElement';
@@ -138,7 +139,7 @@ export class Menu extends React.PureComponent<MenuProps, MenuState> {
 
   private focusOnRootElement = (): void => {
     const rootNode = getRootNode(this);
-    if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
+    if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
       rootNode?.focus();
     }
   };
@@ -384,7 +385,7 @@ export class Menu extends React.PureComponent<MenuProps, MenuState> {
     if (this.scrollContainer && this.highlighted) {
       const rootNode = getRootNode(this.highlighted);
       // TODO: Remove this check once IF-647 is resolved
-      if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
+      if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
         this.scrollContainer.scrollTo(rootNode);
       }
     }

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -346,7 +346,7 @@ export class Menu extends React.PureComponent<MenuProps, MenuState> {
     let parsedMaxHeight = maxHeight;
     const rootNode = getRootNode(this);
 
-    if (typeof maxHeight === 'string' && isBrowser && rootNode) {
+    if (typeof maxHeight === 'string' && isBrowser(globalObject) && rootNode) {
       const rootElementMaxHeight = globalObject.getComputedStyle?.(rootNode).maxHeight;
 
       if (rootElementMaxHeight) {

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -19,7 +19,7 @@ import { isIE11 } from '../../lib/client';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { isIconPaddingEnabled } from '../InternalMenu/isIconPaddingEnabled';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { styles } from './Menu.styles';
 import { isActiveElement } from './isActiveElement';
@@ -139,7 +139,7 @@ export class Menu extends React.PureComponent<MenuProps, MenuState> {
 
   private focusOnRootElement = (): void => {
     const rootNode = getRootNode(this);
-    if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
+    if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
       rootNode?.focus();
     }
   };
@@ -385,7 +385,7 @@ export class Menu extends React.PureComponent<MenuProps, MenuState> {
     if (this.scrollContainer && this.highlighted) {
       const rootNode = getRootNode(this.highlighted);
       // TODO: Remove this check once IF-647 is resolved
-      if (isInstanceOfForIE11(rootNode, globalObject.HTMLElement)) {
+      if (isInstanceOf(rootNode, globalObject.HTMLElement)) {
         this.scrollContainer.scrollTo(rootNode);
       }
     }

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import warning from 'warning';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { getDOMRect } from '../../lib/dom/getDOMRect';
 import { Nullable } from '../../typings/utility-types';
@@ -24,6 +24,7 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { callChildRef } from '../../lib/callChildRef/callChildRef';
 import { isInstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 import { PopupPin } from './PopupPin';
 import { Offset, PopupHelper, PositionObject, Rect } from './PopupHelper';
@@ -320,7 +321,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     const useWrapper = this.getProps().useWrapper;
 
     let anchor: Nullable<React.ReactNode> = null;
-    if (isInstanceOf(anchorElement, globalObject.Element)) {
+    if (isInstanceOfForIE11(anchorElement, globalObject.Element)) {
       this.updateAnchorElement(anchorElement);
     } else if (React.isValidElement(anchorElement)) {
       anchor = useWrapper ? <span>{anchorElement}</span> : anchorElement;
@@ -345,7 +346,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     // which should be called within updateAnchorElement
     // in the case when the anchor is not refable
 
-    const canGetAnchorNode = !!anchorWithRef || isInstanceOf(anchorElement, globalObject.Element);
+    const canGetAnchorNode = !!anchorWithRef || isInstanceOfForIE11(anchorElement, globalObject.Element);
 
     return (
       <RenderContainer anchor={anchorWithRef || anchor} ref={canGetAnchorNode ? null : this.updateAnchorElement}>
@@ -368,7 +369,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   };
 
   private addEventListeners(element: Nullable<Element>) {
-    if (element && isInstanceOf(element, globalObject.Element)) {
+    if (element && isInstanceOfForIE11(element, globalObject.Element)) {
       // @ts-expect-error: Type ElementEventMap is missing events: https://github.com/skbkontur/retail-ui/pull/2946#discussion_r931072657
       element.addEventListener('mouseenter', this.handleMouseEnter);
       // @ts-expect-error: See the comment above
@@ -383,7 +384,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   }
 
   private removeEventListeners(element: Nullable<Element>) {
-    if (element && isInstanceOf(element, globalObject.Element)) {
+    if (element && isInstanceOfForIE11(element, globalObject.Element)) {
       // @ts-expect-error: Type ElementEventMap is missing events: https://github.com/skbkontur/retail-ui/pull/2946#discussion_r931072657
       element.removeEventListener('mouseenter', this.handleMouseEnter);
       // @ts-expect-error: See the comment above
@@ -617,11 +618,11 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     const anchorElement = this.anchorElement;
 
     warning(
-      anchorElement && isInstanceOf(anchorElement, globalObject.Element),
+      anchorElement && isInstanceOfForIE11(anchorElement, globalObject.Element),
       'Anchor element is not defined or not instance of Element',
     );
 
-    if (!(anchorElement && isInstanceOf(anchorElement, globalObject.Element))) {
+    if (!(anchorElement && isInstanceOfForIE11(anchorElement, globalObject.Element))) {
       return location;
     }
 

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -24,7 +24,7 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { callChildRef } from '../../lib/callChildRef/callChildRef';
 import { isInstanceWithAnchorElement } from '../../lib/InstanceWithAnchorElement';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 import { PopupPin } from './PopupPin';
 import { Offset, PopupHelper, PositionObject, Rect } from './PopupHelper';
@@ -321,7 +321,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     const useWrapper = this.getProps().useWrapper;
 
     let anchor: Nullable<React.ReactNode> = null;
-    if (isInstanceOfForIE11(anchorElement, globalObject.Element)) {
+    if (isInstanceOf(anchorElement, globalObject.Element)) {
       this.updateAnchorElement(anchorElement);
     } else if (React.isValidElement(anchorElement)) {
       anchor = useWrapper ? <span>{anchorElement}</span> : anchorElement;
@@ -346,7 +346,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     // which should be called within updateAnchorElement
     // in the case when the anchor is not refable
 
-    const canGetAnchorNode = !!anchorWithRef || isInstanceOfForIE11(anchorElement, globalObject.Element);
+    const canGetAnchorNode = !!anchorWithRef || isInstanceOf(anchorElement, globalObject.Element);
 
     return (
       <RenderContainer anchor={anchorWithRef || anchor} ref={canGetAnchorNode ? null : this.updateAnchorElement}>
@@ -369,7 +369,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   };
 
   private addEventListeners(element: Nullable<Element>) {
-    if (element && isInstanceOfForIE11(element, globalObject.Element)) {
+    if (element && isInstanceOf(element, globalObject.Element)) {
       // @ts-expect-error: Type ElementEventMap is missing events: https://github.com/skbkontur/retail-ui/pull/2946#discussion_r931072657
       element.addEventListener('mouseenter', this.handleMouseEnter);
       // @ts-expect-error: See the comment above
@@ -384,7 +384,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   }
 
   private removeEventListeners(element: Nullable<Element>) {
-    if (element && isInstanceOfForIE11(element, globalObject.Element)) {
+    if (element && isInstanceOf(element, globalObject.Element)) {
       // @ts-expect-error: Type ElementEventMap is missing events: https://github.com/skbkontur/retail-ui/pull/2946#discussion_r931072657
       element.removeEventListener('mouseenter', this.handleMouseEnter);
       // @ts-expect-error: See the comment above
@@ -618,11 +618,11 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     const anchorElement = this.anchorElement;
 
     warning(
-      anchorElement && isInstanceOfForIE11(anchorElement, globalObject.Element),
+      anchorElement && isInstanceOf(anchorElement, globalObject.Element),
       'Anchor element is not defined or not instance of Element',
     );
 
-    if (!(anchorElement && isInstanceOfForIE11(anchorElement, globalObject.Element))) {
+    if (!(anchorElement && isInstanceOf(anchorElement, globalObject.Element))) {
       return location;
     }
 

--- a/packages/react-ui/internal/RenderLayer/RenderLayer.tsx
+++ b/packages/react-ui/internal/RenderLayer/RenderLayer.tsx
@@ -6,7 +6,7 @@ import { CommonProps, CommonWrapper } from '../CommonWrapper';
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { Nullable } from '../../typings/utility-types';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 export interface RenderLayerProps extends CommonProps {
   children: JSX.Element;
@@ -120,7 +120,7 @@ export class RenderLayer extends React.Component<RenderLayerProps> {
     const target = event.target || event.srcElement;
     const node = this.getAnchorNode();
 
-    if (!node || (isInstanceOfForIE11(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node))) {
+    if (!node || (isInstanceOf(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node))) {
       return;
     }
 

--- a/packages/react-ui/internal/RenderLayer/RenderLayer.tsx
+++ b/packages/react-ui/internal/RenderLayer/RenderLayer.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { listen as listenFocusOutside, containsTargetOrRenderContainer } from '../../lib/listenFocusOutside';
 import { CommonProps, CommonWrapper } from '../CommonWrapper';
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { Nullable } from '../../typings/utility-types';
 import { createPropsGetter } from '../../lib/createPropsGetter';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 export interface RenderLayerProps extends CommonProps {
   children: JSX.Element;
@@ -119,7 +120,7 @@ export class RenderLayer extends React.Component<RenderLayerProps> {
     const target = event.target || event.srcElement;
     const node = this.getAnchorNode();
 
-    if (!node || (isInstanceOf(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node))) {
+    if (!node || (isInstanceOfForIE11(target, globalObject.Element) && containsTargetOrRenderContainer(target)(node))) {
       return;
     }
 

--- a/packages/react-ui/lib/dom/tabbableHelpers.ts
+++ b/packages/react-ui/lib/dom/tabbableHelpers.ts
@@ -1,7 +1,8 @@
 import { tabbable, FocusableElement, isFocusable } from 'tabbable';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { Nullable } from '../../typings/utility-types';
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 
 /**
  * Поиск всех элементов, у которых tabindex > -1, в переданном родителе
@@ -14,7 +15,7 @@ import { Nullable } from '../../typings/utility-types';
 export const getTabbableElements = (
   parent: Nullable<Element | Document> = globalObject.document,
 ): FocusableElement[] => {
-  if (!parent || !parent.children.length || !isInstanceOf(parent, globalObject.Element)) {
+  if (!parent || !parent.children.length || !isInstanceOfForIE11(parent, globalObject.Element)) {
     return [];
   }
   return tabbable(parent);

--- a/packages/react-ui/lib/dom/tabbableHelpers.ts
+++ b/packages/react-ui/lib/dom/tabbableHelpers.ts
@@ -2,7 +2,7 @@ import { tabbable, FocusableElement, isFocusable } from 'tabbable';
 import { globalObject } from '@skbkontur/global-object';
 
 import { Nullable } from '../../typings/utility-types';
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 
 /**
  * Поиск всех элементов, у которых tabindex > -1, в переданном родителе
@@ -15,7 +15,7 @@ import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 export const getTabbableElements = (
   parent: Nullable<Element | Document> = globalObject.document,
 ): FocusableElement[] => {
-  if (!parent || !parent.children.length || !isInstanceOfForIE11(parent, globalObject.Element)) {
+  if (!parent || !parent.children.length || !isInstanceOf(parent, globalObject.Element)) {
     return [];
   }
   return tabbable(parent);

--- a/packages/react-ui/lib/events/fixClickFocusIE.ts
+++ b/packages/react-ui/lib/events/fixClickFocusIE.ts
@@ -1,14 +1,15 @@
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { getClosestFocusableElement } from '../dom/tabbableHelpers';
 import { isIE11, isEdge } from '../client';
+import { isInstanceOfForIE11 } from '../isInstanceOfForIE11';
 
 export const fixClickFocusIE = (e: Event) => {
   if (isIE11 || isEdge) {
     // workaround for the IE/Edge focus bug
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14306303/
     if (globalObject.document && globalObject.document.activeElement !== e.target) {
-      if (isInstanceOf(e.target, globalObject.HTMLElement)) {
+      if (isInstanceOfForIE11(e.target, globalObject.HTMLElement)) {
         const closestFocusable = getClosestFocusableElement(e.target);
         if (closestFocusable) {
           closestFocusable.focus();

--- a/packages/react-ui/lib/events/fixClickFocusIE.ts
+++ b/packages/react-ui/lib/events/fixClickFocusIE.ts
@@ -2,14 +2,14 @@ import { globalObject } from '@skbkontur/global-object';
 
 import { getClosestFocusableElement } from '../dom/tabbableHelpers';
 import { isIE11, isEdge } from '../client';
-import { isInstanceOfForIE11 } from '../isInstanceOfForIE11';
+import { isInstanceOf } from '../isInstanceOf';
 
 export const fixClickFocusIE = (e: Event) => {
   if (isIE11 || isEdge) {
     // workaround for the IE/Edge focus bug
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14306303/
     if (globalObject.document && globalObject.document.activeElement !== e.target) {
-      if (isInstanceOfForIE11(e.target, globalObject.HTMLElement)) {
+      if (isInstanceOf(e.target, globalObject.HTMLElement)) {
         const closestFocusable = getClosestFocusableElement(e.target);
         if (closestFocusable) {
           closestFocusable.focus();

--- a/packages/react-ui/lib/events/keyboard/identifiers.ts
+++ b/packages/react-ui/lib/events/keyboard/identifiers.ts
@@ -1,6 +1,7 @@
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
 import { isMac } from '../../client';
+import { isInstanceOfForIE11 } from '../../isInstanceOfForIE11';
 
 import { extractCode } from './extractCode';
 import { KeyboardEventCodes as Codes } from './KeyboardEventCodes';
@@ -13,7 +14,7 @@ type ISSome = (...is: IS[]) => IS;
 // IE 9+ supports char attribute
 // https://developer.mozilla.org/ru/docs/Web/API/KeyboardEvent
 const getChar = (e: E & { char?: string; nativeEvent?: { char?: string } }) =>
-  isInstanceOf(e, globalObject.KeyboardEvent) ? e.char : e.nativeEvent?.char;
+  isInstanceOfForIE11(e, globalObject.KeyboardEvent) ? e.char : e.nativeEvent?.char;
 
 export const isShortcutCopy: IS = (e) =>
   ((isMac ? e.metaKey : e.ctrlKey) && extractCode(e) === Codes.KeyC) ||

--- a/packages/react-ui/lib/events/keyboard/identifiers.ts
+++ b/packages/react-ui/lib/events/keyboard/identifiers.ts
@@ -1,7 +1,7 @@
 import { globalObject } from '@skbkontur/global-object';
 
 import { isMac } from '../../client';
-import { isInstanceOfForIE11 } from '../../isInstanceOfForIE11';
+import { isInstanceOf } from '../../isInstanceOf';
 
 import { extractCode } from './extractCode';
 import { KeyboardEventCodes as Codes } from './KeyboardEventCodes';
@@ -14,7 +14,7 @@ type ISSome = (...is: IS[]) => IS;
 // IE 9+ supports char attribute
 // https://developer.mozilla.org/ru/docs/Web/API/KeyboardEvent
 const getChar = (e: E & { char?: string; nativeEvent?: { char?: string } }) =>
-  isInstanceOfForIE11(e, globalObject.KeyboardEvent) ? e.char : e.nativeEvent?.char;
+  isInstanceOf(e, globalObject.KeyboardEvent) ? e.char : e.nativeEvent?.char;
 
 export const isShortcutCopy: IS = (e) =>
   ((isMac ? e.metaKey : e.ctrlKey) && extractCode(e) === Codes.KeyC) ||

--- a/packages/react-ui/lib/isInstanceOf.ts
+++ b/packages/react-ui/lib/isInstanceOf.ts
@@ -1,0 +1,11 @@
+export function isInstanceOf<C extends new (...args: any) => any>(
+  instance?: unknown,
+  constructor?: C,
+): instance is InstanceType<C> {
+  try {
+    //@ts-expect-error Can't use typeof operator to type guard, because in IE11 it incorrectly types constructor as 'object' instead of 'function'.
+    return instance instanceof constructor;
+  } catch (_) {
+    return false;
+  }
+}

--- a/packages/react-ui/lib/isInstanceOf.ts
+++ b/packages/react-ui/lib/isInstanceOf.ts
@@ -2,10 +2,5 @@ export function isInstanceOf<C extends new (...args: any) => any>(
   instance?: unknown,
   constructor?: C,
 ): instance is InstanceType<C> {
-  try {
-    //@ts-expect-error Can't use typeof operator to type guard, because in IE11 it incorrectly types constructor as 'object' instead of 'function'.
-    return instance instanceof constructor;
-  } catch (_) {
-    return false;
-  }
+  return !!constructor && instance instanceof constructor;
 }

--- a/packages/react-ui/lib/isInstanceOfForIE11.ts
+++ b/packages/react-ui/lib/isInstanceOfForIE11.ts
@@ -1,6 +1,0 @@
-export function isInstanceOfForIE11<C extends new (...args: any) => any>(
-  instance?: unknown,
-  constructor?: C,
-): instance is InstanceType<C> {
-  return typeof constructor?.constructor === 'function' && instance instanceof constructor;
-}

--- a/packages/react-ui/lib/isInstanceOfForIE11.ts
+++ b/packages/react-ui/lib/isInstanceOfForIE11.ts
@@ -1,0 +1,6 @@
+export function isInstanceOfForIE11<C extends new (...args: any) => any>(
+  instance?: unknown,
+  constructor?: C,
+): instance is InstanceType<C> {
+  return typeof constructor?.constructor === 'function' && instance instanceof constructor;
+}

--- a/packages/react-ui/lib/listenFocusOutside.ts
+++ b/packages/react-ui/lib/listenFocusOutside.ts
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { globalObject } from '@skbkontur/global-object';
 
-import { isInstanceOfForIE11 } from './isInstanceOfForIE11';
+import { isInstanceOf } from './isInstanceOf';
 import { isFirefox } from './client';
 
 interface FocusOutsideEventHandler {
@@ -75,7 +75,7 @@ export function findRenderContainer(node: Element, rootNode: Element, container?
     currentNode === rootNode ||
     currentNode === globalObject.document?.body ||
     currentNode === globalObject.document?.documentElement ||
-    !isInstanceOfForIE11(currentNode, globalObject.Element)
+    !isInstanceOf(currentNode, globalObject.Element)
   ) {
     return container ? container : null;
   }

--- a/packages/react-ui/lib/listenFocusOutside.ts
+++ b/packages/react-ui/lib/listenFocusOutside.ts
@@ -1,7 +1,8 @@
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
+import { isInstanceOfForIE11 } from './isInstanceOfForIE11';
 import { isFirefox } from './client';
 
 interface FocusOutsideEventHandler {
@@ -74,7 +75,7 @@ export function findRenderContainer(node: Element, rootNode: Element, container?
     currentNode === rootNode ||
     currentNode === globalObject.document?.body ||
     currentNode === globalObject.document?.documentElement ||
-    !isInstanceOf(currentNode, globalObject.Element)
+    !isInstanceOfForIE11(currentNode, globalObject.Element)
   ) {
     return container ? container : null;
   }

--- a/packages/react-ui/lib/rootNode/getRootNode.ts
+++ b/packages/react-ui/lib/rootNode/getRootNode.ts
@@ -4,7 +4,7 @@ import React from 'react';
 import warning from 'warning';
 import { globalObject } from '@skbkontur/global-object';
 
-import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
+import { isInstanceOf } from '../../lib/isInstanceOf';
 import { Nullable } from '../../typings/utility-types';
 
 import { isInstanceWithRootNode } from './rootNodeDecorator';
@@ -34,7 +34,7 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<E
     return null;
   }
 
-  if (isInstanceOfForIE11(instance, globalObject.Element)) {
+  if (isInstanceOf(instance, globalObject.Element)) {
     // instance can be an Element already if its coming
     // from Refs of intrinsic elements (<div />, <button />, etc.)
     return instance;
@@ -47,7 +47,7 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<E
     // the "getRootNode" method, but we can ignore it here
     // because we'd already checked the instance on being an Element
     // which is a subclass of Node, so, just fixing types here
-    if (!isInstanceOfForIE11(instance, globalObject.Node)) {
+    if (!isInstanceOf(instance, globalObject.Node)) {
       rootNode = instance.getRootNode();
     }
   }
@@ -80,5 +80,5 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<E
   }
 
   // the findDOMNode can also return Text, but we are only interested in Elements, so just filter it
-  return isInstanceOfForIE11(rootNode, globalObject.Element) ? rootNode : null;
+  return isInstanceOf(rootNode, globalObject.Element) ? rootNode : null;
 };

--- a/packages/react-ui/lib/rootNode/getRootNode.ts
+++ b/packages/react-ui/lib/rootNode/getRootNode.ts
@@ -2,8 +2,9 @@
 import { findDOMNode } from 'react-dom';
 import React from 'react';
 import warning from 'warning';
-import { globalObject, isInstanceOf } from '@skbkontur/global-object';
+import { globalObject } from '@skbkontur/global-object';
 
+import { isInstanceOfForIE11 } from '../../lib/isInstanceOfForIE11';
 import { Nullable } from '../../typings/utility-types';
 
 import { isInstanceWithRootNode } from './rootNodeDecorator';
@@ -33,7 +34,7 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<E
     return null;
   }
 
-  if (isInstanceOf(instance, globalObject.Element)) {
+  if (isInstanceOfForIE11(instance, globalObject.Element)) {
     // instance can be an Element already if its coming
     // from Refs of intrinsic elements (<div />, <button />, etc.)
     return instance;
@@ -46,7 +47,7 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<E
     // the "getRootNode" method, but we can ignore it here
     // because we'd already checked the instance on being an Element
     // which is a subclass of Node, so, just fixing types here
-    if (!isInstanceOf(instance, globalObject.Node)) {
+    if (!isInstanceOfForIE11(instance, globalObject.Node)) {
       rootNode = instance.getRootNode();
     }
   }
@@ -79,5 +80,5 @@ export const getRootNode = (instance: Nullable<React.ReactInstance>): Nullable<E
   }
 
   // the findDOMNode can also return Text, but we are only interested in Elements, so just filter it
-  return isInstanceOf(rootNode, globalObject.Element) ? rootNode : null;
+  return isInstanceOfForIE11(rootNode, globalObject.Element) ? rootNode : null;
 };


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
В IE 11 внутри функции `isInstanceOf` `typeof` определяет конструкторы `Element`, `Node`, `MouseEvent` и другие как объекты. Хотя в хроме и других браузерах - как функции.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Как я понял, IE 11 не поддерживает фичи ES6, в том числе классы. Проверка, является ли поле `constructor` прокинутого класса функцией, вместо проверки самого класса решило проблему. Сделал исправленную версию функции `isInstanceOf`  в библиотеке.

Отдельным коммитом добавил фикс проверки, где использовалось определение isBrowser вместо вызова.
## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->
fix [IF-1576](https://yt.skbkontur.ru/issue/IF-1576)
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
