### PR TITLE
feat(ScrollСontainer): add value `never` to `showScrollbar` prop

### DIFF
--- a/packages/react-ui/.creevey/images/ScrollContainer/Never Show Scroll Bar/chrome.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Never Show Scroll Bar/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:195bb57396896a8ffebff756da0faf30eda0d1d0145111a6617a42604517175d
+size 3285

--- a/packages/react-ui/.creevey/images/ScrollContainer/Never Show Scroll Bar/firefox.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Never Show Scroll Bar/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a377b3f6b84371cae9dadf60c79599d5ee104cefd1a4a15b3f5cdbe0db1e420
+size 3431

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -193,7 +193,6 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
         <div
           data-tid={ScrollContainerDataTids.root}
           className={styles.root()}
-          onMouseEnter={this.handleMouseEnter}
           onMouseMove={this.handleMouseMove}
           onMouseLeave={this.handleMouseLeave}
         >
@@ -403,17 +402,16 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
     }
   };
 
-  private handleMouseEnter = () => {
-    this.getProps().showScrollBar === 'hover' &&
-      this.setState({ isScrollBarXVisible: true, isScrollBarYVisible: true, isHovered: true });
-  };
-
   private handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
     const right = getDOMRect(event.currentTarget).right - event.pageX;
     const bottom = getDOMRect(event.currentTarget).bottom - event.pageY;
 
     this.scrollY?.setHover(right <= 12);
     this.scrollX?.setHover(right >= 12 && bottom <= 12);
+
+    this.getProps().showScrollBar === 'hover' &&
+      !this.state.isHovered &&
+      this.setState({ isScrollBarXVisible: true, isScrollBarYVisible: true, isHovered: true });
   };
 
   private handleMouseLeave = () => {

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -162,6 +162,14 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
     if (prevProps.disabled !== this.props.disabled && !this.props.disabled) {
       this.updateInnerElement();
     }
+
+    if (prevProps.showScrollBar !== this.props.showScrollBar) {
+      if (this.props.showScrollBar === 'always') {
+        this.setState({ isScrollBarXVisible: true, isScrollBarYVisible: true });
+      } else if (this.props.showScrollBar === 'never') {
+        this.setState({ isScrollBarXVisible: false, isScrollBarYVisible: false });
+      }
+    }
   }
 
   public render = () => {
@@ -177,10 +185,8 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
       maxWidth: props.maxWidth,
     };
 
-    const showScrollBar = props.showScrollBar !== 'never';
-
-    const scrollbarY = showScrollBar && this.renderScrollbar('y');
-    const scrollbarX = showScrollBar && this.renderScrollbar('x');
+    const scrollbarY = this.renderScrollbar('y');
+    const scrollbarX = this.renderScrollbar('x');
 
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -71,7 +71,7 @@ export interface ScrollContainerProps extends CommonProps {
   /**
    * Показывать скроллбар
    */
-  showScrollBar?: 'always' | 'scroll' | 'hover';
+  showScrollBar?: 'always' | 'scroll' | 'hover' | 'never';
   /**
    * Задержка перед скрытием скроллбара, ms. Работает только если `hideScrollBar = true` или `showScrollBar = 'scroll' | 'hover'`
    */
@@ -177,8 +177,10 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
       maxWidth: props.maxWidth,
     };
 
-    const scrollbarY = this.renderScrollbar('y');
-    const scrollbarX = this.renderScrollbar('x');
+    const showScrollBar = props.showScrollBar !== 'never';
+
+    const scrollbarY = showScrollBar && this.renderScrollbar('y');
+    const scrollbarX = showScrollBar && this.renderScrollbar('x');
 
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>

--- a/packages/react-ui/components/ScrollContainer/__stories__/ScrollContainer.stories.tsx
+++ b/packages/react-ui/components/ScrollContainer/__stories__/ScrollContainer.stories.tsx
@@ -706,3 +706,24 @@ ShowScrollBarOnHover.parameters = {
     },
   },
 };
+
+export const NeverShowScrollBar: Story = () => (
+  <div style={wrapperStyle}>
+    <ScrollContainer showScrollBar={'never'} disableAnimations>
+      <div style={{ width: 300 }}>
+        {Array(30)
+          .fill(null)
+          .map((_, i) => (
+            <div style={{ width: 200 }} key={i}>
+              {i}
+            </div>
+          ))}
+      </div>
+    </ScrollContainer>
+  </div>
+);
+NeverShowScrollBar.parameters = {
+  creevey: {
+    skip: { 'themes dont affect logic': { in: /^(?!\b(firefox|chrome)\b)/ } },
+  },
+};


### PR DESCRIPTION
## Проблема

Проблема возникла в [SideMenu](https://git.skbkontur.ru/ui/ui-parking/-/merge_requests/527) при сворачивании до иконок: при сворачивании `ScrollContainer` считает, что есть переполнение контента внутри и добавляет горизонтальный скроллбар: 

https://github.com/skbkontur/retail-ui/assets/32093844/822caf3e-d69b-4a03-be45-b139cb4f6a24

Пробовала монтировать `ScrollContainer` только после полного открытия `SideMenu`, но тогда не срабатывает проп `showScrollbar = 'hover'`, так как при монтировании ScrollContainer'а мышь уже находится над ним и не срабатывает событие `onMouseEnter`. 
Считаю, что лучшим решением было бы добавить состояние`showScrollbar = 'never'` и изменять его на `showScrollbar = 'hover'` после открытия `SideMenu`

## Решение

Добавила состояние`showScrollbar = 'never'`

Проблему с тем, что при маунте скролл контейнера с `showScrollbar = 'hover'` с мышью над ним - не исправила. Так как сразу при маунте невозможно определить положение мыши. 

## Ссылки

fix IF-1621

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
