### PR TITLE
fix(RenderContainer): remove side effects from constructor

### DIFF
--- a/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
+++ b/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
@@ -17,14 +17,6 @@ export class RenderContainer extends React.Component<RenderContainerProps> {
 
   private readonly rootId: string = RenderContainer.getRootId();
 
-  constructor(props: RenderContainerProps) {
-    super(props);
-
-    if (props.children) {
-      this.mountContainer();
-    }
-  }
-
   public shouldComponentUpdate(nextProps: RenderContainerProps) {
     if (!this.props.children && nextProps.children) {
       this.mountContainer();
@@ -40,6 +32,10 @@ export class RenderContainer extends React.Component<RenderContainerProps> {
   }
 
   public render() {
+    if (this.props.children) {
+      this.mountContainer();
+    }
+
     return <RenderInnerContainer {...this.props} domContainer={this.domContainer} rootId={this.rootId} />;
   }
 


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Криво работают порталы при серверном рендеринге в строгом режиме на 18-й версии Реакта.
Причина в двойном рендеринге в дев режиме.

Если точнее, то дело в специфичном двойном рендеринге метода `constructor()` у классовых компонентов:
> When __Strict Mode__ is on, React will call `constructor twice` in development and then throw away one of the instances. This helps you notice the accidental side effects that need to be moved out of the `constructor()`. [^1]

В компоненте `RenderContainer` в методе `constructor()` как раз были побочные эффекты - в DOM монтировался div-контейнер для портала.

Песочница с багом:
— https://stackblitz.com/edit/stackblitz-starters-hhdbkc?file=app%2Fpage.tsx

[^1]: https://react.dev/reference/react/Component#constructor-caveats

## Решение

Для исправление достаточно было перенести проблемный код в метод `render()`.

Песочница с исправлением:
— https://stackblitz.com/edit/ssr-strictmode?file=next.config.js

Релиз контролов с фиксом: `4.19.1-ssr-strictmode.0`

## Ссылки

`IF-1631`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
