### PR TITLE
fix(Token): prevent focus on cross

### DIFF
--- a/packages/react-ui/components/Token/Token.tsx
+++ b/packages/react-ui/components/Token/Token.tsx
@@ -2,7 +2,7 @@ import React, { AriaAttributes } from 'react';
 
 import { locale } from '../../lib/locale/decorators';
 import { CrossIcon } from '../../internal/icons/CrossIcon';
-import { emptyHandler } from '../../lib/utils';
+import { emptyHandler, getChildText } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
@@ -97,7 +97,7 @@ export class Token extends React.Component<TokenProps> {
     const theme = this.theme;
 
     const validation = getValidation(error, warning);
-    const removeButtonAriaLabel = this.locale.removeButtonAriaLabel + ' ' + children;
+    const removeButtonAriaLabel = this.locale.removeButtonAriaLabel + ' ' + getChildText(children);
 
     const icon = isTheme2022(theme) ? (
       <CloseButtonIcon side={16} color="inherit" colorHover="inherit" role="none" tabbable={false} />

--- a/packages/react-ui/components/Token/Token.tsx
+++ b/packages/react-ui/components/Token/Token.tsx
@@ -2,7 +2,7 @@ import React, { AriaAttributes } from 'react';
 
 import { locale } from '../../lib/locale/decorators';
 import { CrossIcon } from '../../internal/icons/CrossIcon';
-import { emptyHandler, getChildText } from '../../lib/utils';
+import { emptyHandler, getChildrenText } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
@@ -97,7 +97,7 @@ export class Token extends React.Component<TokenProps> {
     const theme = this.theme;
 
     const validation = getValidation(error, warning);
-    const removeButtonAriaLabel = this.locale.removeButtonAriaLabel + ' ' + getChildText(children);
+    const removeButtonAriaLabel = this.locale.removeButtonAriaLabel + ' ' + getChildrenText(children);
 
     const icon = isTheme2022(theme) ? (
       <CloseButtonIcon side={16} color="inherit" colorHover="inherit" role="none" tabbable={false} />

--- a/packages/react-ui/components/Token/Token.tsx
+++ b/packages/react-ui/components/Token/Token.tsx
@@ -100,7 +100,7 @@ export class Token extends React.Component<TokenProps> {
     const removeButtonAriaLabel = this.locale.removeButtonAriaLabel + ' ' + children;
 
     const icon = isTheme2022(theme) ? (
-      <CloseButtonIcon side={16} color="inherit" colorHover="inherit" role="none" />
+      <CloseButtonIcon side={16} color="inherit" colorHover="inherit" role="none" tabbable={false} />
     ) : (
       <CrossIcon />
     );

--- a/packages/react-ui/components/Token/__tests__/Token-test.tsx
+++ b/packages/react-ui/components/Token/__tests__/Token-test.tsx
@@ -96,19 +96,36 @@ describe('Token', () => {
       );
     });
 
-    it('can find text inside nested children with several children', () => {
-      const tokenName = 'name';
+    it('can find text inside several nested children', () => {
+      const tokenNameFirst = 'name 1';
+      const tokenNameSecond = 'name 2';
       render(
         <Token>
-          <div>{tokenName}</div>
-          <div></div>
+          <div>{tokenNameFirst}</div>
+          <div>{tokenNameSecond}</div>
         </Token>,
       );
 
       expect(screen.getByRole('button')).toHaveAttribute(
         'aria-label',
-        TokenLocalesRu.removeButtonAriaLabel + ' ' + tokenName,
+        TokenLocalesRu.removeButtonAriaLabel + ' ' + tokenNameFirst + tokenNameSecond,
       );
+    });
+
+    it('can work with token without text', () => {
+      render(<Token></Token>);
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-label', TokenLocalesRu.removeButtonAriaLabel + ' ');
+    });
+
+    it('can work with tag without text', () => {
+      render(
+        <Token>
+          <div></div>
+        </Token>,
+      );
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-label', TokenLocalesRu.removeButtonAriaLabel + ' ');
     });
   });
 });

--- a/packages/react-ui/components/Token/__tests__/Token-test.tsx
+++ b/packages/react-ui/components/Token/__tests__/Token-test.tsx
@@ -81,5 +81,34 @@ describe('Token', () => {
 
       expect(screen.getByRole('button')).toHaveAttribute('aria-label', customAriaLabel + ' ' + tokenName);
     });
+
+    it('can find text inside nested children', () => {
+      const tokenName = 'name';
+      render(
+        <Token>
+          <div>{tokenName}</div>
+        </Token>,
+      );
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        TokenLocalesRu.removeButtonAriaLabel + ' ' + tokenName,
+      );
+    });
+
+    it('can find text inside nested children with several children', () => {
+      const tokenName = 'name';
+      render(
+        <Token>
+          <div>{tokenName}</div>
+          <div></div>
+        </Token>,
+      );
+
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        TokenLocalesRu.removeButtonAriaLabel + ' ' + tokenName,
+      );
+    });
   });
 });

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -242,5 +242,7 @@ export const getChildText = (children: React.ReactNode): string => {
     return children ?? '';
   }
 
-  return getChildText((children as React.ReactElement).props?.children);
+  const child = (children as React.ReactElement[])?.[0] ?? children;
+
+  return getChildText(child.props?.children);
 };

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -223,3 +223,24 @@ export const isInputLike =
 export const isKonturIcon = (icon: React.ReactElement) => {
   return Object.prototype.hasOwnProperty.call(icon?.type, '__KONTUR_ICON__');
 };
+
+/**
+ * Allows to get text of nested child
+ * The function expects that text will always be in the first node like this:
+ * ```tsx
+ *  <Component>
+ *    <div>Will find this text</div>
+ *    <div>Will NOT find this text</div>
+ *  </Component>
+ * ```
+ *
+ * @param children React's children prop
+ * @returns Nested child text or an empty string
+ */
+export const getChildText = (children: React.ReactNode): string => {
+  if (typeof children === 'string' || typeof children === 'undefined') {
+    return children ?? '';
+  }
+
+  return getChildText((children as React.ReactElement).props?.children);
+};

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -225,24 +225,24 @@ export const isKonturIcon = (icon: React.ReactElement) => {
 };
 
 /**
- * Allows to get text of nested child
- * The function expects that text will always be in the first node like this:
- * ```tsx
- *  <Component>
- *    <div>Will find this text</div>
- *    <div>Will NOT find this text</div>
- *  </Component>
- * ```
+ * Allows to get text of all nested children as a string
  *
- * @param children React's children prop
+ * @param children React's children
  * @returns Nested child text or an empty string
  */
-export const getChildText = (children: React.ReactNode): string => {
-  if (typeof children === 'string' || typeof children === 'undefined') {
-    return children ?? '';
+export function getChildrenText(children: React.ReactNode): string {
+  if (typeof children === 'string' || typeof children === 'number') {
+    return children.toString();
   }
 
-  const child = (children as React.ReactElement[])?.[0] ?? children;
+  if (Array.isArray(children)) {
+    return children.map((entry) => getChildrenText(entry)).join('');
+  }
 
-  return getChildText(child.props?.children);
-};
+  const nextChild = (children as React.ReactElement)?.props.children;
+  if (!nextChild) {
+    return '';
+  }
+
+  return getChildrenText(nextChild);
+}


### PR DESCRIPTION
## Проблема

В #3337 по ошибке оставил возможность фокусироватсья на крестике

## Решение

1. Вернул `tabbable={false}`
2. Научил `aria-label` работать с `ReactElement` — в решении я придерживаюсь эвристики, что текст будет в первой ноде и выполняю поиск только в ней. Текст может находиться сразу в нескольких нодах, либо во второй, третьей и т.д., но это менее вероятная ситуация, поэтому не стал её поддерживать — в таком случае будет просто выводиться пустая строка или часть текста

## Ссылки

IF-1670

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

3. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ✅ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

4. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

5. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
