### PR TITLE
feat: пробрасывается data-tid с validation container  на корневой span

### DIFF
--- a/packages/react-ui-validations/.prettierignore
+++ b/packages/react-ui-validations/.prettierignore
@@ -12,3 +12,6 @@ yarn-error.log
 npm-debug.log
 
 *.md
+
+.creevey
+dist

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -19,6 +19,7 @@ export interface ValidationSettings {
 export type ValidateArgumentType = boolean | ValidationSettings;
 
 export interface ValidationContainerProps {
+  'data-tid'?: string;
   children?: React.ReactNode;
   onValidationUpdated?: (isValid?: Nullable<boolean>) => void;
   scrollOffset?: number | ScrollOffset;
@@ -76,6 +77,7 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
   public render() {
     return (
       <ValidationContextWrapper
+        data-tid={this.props["data-tid"]}
         ref={this.refChildContext}
         scrollOffset={this.props.scrollOffset}
         disableSmoothScroll={this.getProps().disableSmoothScroll}

--- a/packages/react-ui-validations/src/ValidationContainer.tsx
+++ b/packages/react-ui-validations/src/ValidationContainer.tsx
@@ -77,7 +77,7 @@ export class ValidationContainer extends React.Component<ValidationContainerProp
   public render() {
     return (
       <ValidationContextWrapper
-        data-tid={this.props["data-tid"]}
+        data-tid={this.props['data-tid']}
         ref={this.refChildContext}
         scrollOffset={this.props.scrollOffset}
         disableSmoothScroll={this.getProps().disableSmoothScroll}

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -164,37 +164,36 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
 
   private featureFlags!: ValidationsFeatureFlags;
 
-  public render() {
-    const { children, 'data-tid': dataTid } = this.props;
+  private children = (flags: ValidationsFeatureFlags) => {
+    if (flags.validationsRemoveExtraSpans) {
+      return this.props.children;
+    }
 
+    return <span>{this.props.children}</span>;
+  };
+
+  private renderChildren = (children: ValidationContextWrapperProps['children']) => {
+    if (React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        'data-tid': this.props['data-tid'],
+      });
+    }
+
+    return children;
+  };
+
+  public render() {
     return (
       <ValidationsFeatureFlagsContext.Consumer>
         {(flags) => {
           this.featureFlags = getFullValidationsFlagsContext(flags);
           return (
             <ValidationContext.Provider value={this}>
-              {this.featureFlags.validationsRemoveExtraSpans ? (
-                this.renderChildren(children, dataTid)
-              ) : (
-                <span data-tid={dataTid}>{children}</span>
-              )}
+              {this.renderChildren(this.children(this.featureFlags))}
             </ValidationContext.Provider>
           );
         }}
       </ValidationsFeatureFlagsContext.Consumer>
     );
   }
-
-  private renderChildren = (
-    children: ValidationContextWrapperProps['children'],
-    dataTid: ValidationContextWrapperProps['data-tid'],
-  ) => {
-    if (React.isValidElement(children)) {
-      return React.cloneElement(children, {
-        'data-tid': dataTid,
-      });
-    }
-
-    return children;
-  };
 }

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -16,6 +16,7 @@ export interface ValidationContextSettings {
 }
 
 export interface ValidationContextWrapperProps {
+  'data-tid'?: string;
   children?: React.ReactNode;
   onValidationUpdated?: (isValid?: boolean) => void;
   scrollOffset?: number | ScrollOffset;
@@ -170,7 +171,11 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
           this.featureFlags = getFullValidationsFlagsContext(flags);
           return (
             <ValidationContext.Provider value={this}>
-              {this.featureFlags.validationsRemoveExtraSpans ? this.props.children : <span>{this.props.children}</span>}
+              {this.featureFlags.validationsRemoveExtraSpans ? (
+                this.props.children
+              ) : (
+                <span data-tid={this.props['data-tid']}>{this.props.children}</span>
+              )}
             </ValidationContext.Provider>
           );
         }}

--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -165,6 +165,8 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
   private featureFlags!: ValidationsFeatureFlags;
 
   public render() {
+    const { children, 'data-tid': dataTid } = this.props;
+
     return (
       <ValidationsFeatureFlagsContext.Consumer>
         {(flags) => {
@@ -172,9 +174,9 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
           return (
             <ValidationContext.Provider value={this}>
               {this.featureFlags.validationsRemoveExtraSpans ? (
-                this.props.children
+                this.renderChildren(children, dataTid)
               ) : (
-                <span data-tid={this.props['data-tid']}>{this.props.children}</span>
+                <span data-tid={dataTid}>{children}</span>
               )}
             </ValidationContext.Provider>
           );
@@ -182,4 +184,17 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
       </ValidationsFeatureFlagsContext.Consumer>
     );
   }
+
+  private renderChildren = (
+    children: ValidationContextWrapperProps['children'],
+    dataTid: ValidationContextWrapperProps['data-tid'],
+  ) => {
+    if (React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        'data-tid': dataTid,
+      });
+    }
+
+    return children;
+  };
 }

--- a/packages/react-ui-validations/stories/ValidationContainer.stories.tsx
+++ b/packages/react-ui-validations/stories/ValidationContainer.stories.tsx
@@ -11,7 +11,7 @@ export default {
 const validation: ValidationInfo = { message: 'Error', type: 'immediate', level: 'error', independent: true };
 
 export const Default = () => (
-  <ValidationContainer>
+  <ValidationContainer data-tid="TestTid">
     <Gapped vertical gap={20}>
       <ValidationWrapper validationInfo={validation}>
         <div>Tooltip</div>

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -15,6 +15,16 @@ import { FocusMode, ValidationContainer, ValidationContainerProps, ValidationWra
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
 
 describe('ValidationContainer', () => {
+  it('renders passed data-tid on container', () => {
+    render(
+      <ValidationContainer data-tid="passed-container">
+        <div />
+      </ValidationContainer>,
+    );
+
+    expect(screen.getByTestId('passed-container')).toBeInTheDocument();
+  });
+
   it('renders passed children', () => {
     render(
       <ValidationContainer>

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -11,7 +11,13 @@ import {
   TokenInputType,
 } from '@skbkontur/react-ui';
 
-import { FocusMode, ValidationContainer, ValidationContainerProps, ValidationWrapper } from '../src';
+import {
+  FocusMode,
+  ValidationContainer,
+  ValidationContainerProps,
+  ValidationsFeatureFlagsContext,
+  ValidationWrapper,
+} from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
 
 describe('ValidationContainer', () => {
@@ -23,6 +29,31 @@ describe('ValidationContainer', () => {
     );
 
     expect(screen.getByTestId('passed-container')).toBeInTheDocument();
+  });
+
+  it('renders passed data-tid on container when validationsRemoveExtraSpans enabled', () => {
+    render(
+      <ValidationsFeatureFlagsContext.Provider value={{ validationsRemoveExtraSpans: true }}>
+        <ValidationContainer data-tid="passed-container">
+          <div />
+        </ValidationContainer>
+      </ValidationsFeatureFlagsContext.Provider>,
+    );
+
+    expect(screen.getByTestId('passed-container')).toBeInTheDocument();
+  });
+
+  it('not renders passed data-tid on container when validationsRemoveExtraSpans enabled', () => {
+    render(
+      <ValidationsFeatureFlagsContext.Provider value={{ validationsRemoveExtraSpans: true }}>
+        <ValidationContainer data-tid="passed-container">
+          <div />
+          <div />
+        </ValidationContainer>
+      </ValidationsFeatureFlagsContext.Provider>,
+    );
+
+    expect(screen.queryByTestId('passed-container')).toBeNull();
   });
 
   it('renders passed children', () => {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Не пробрасывается data-tid с ValidationContainer, это сильно усложняет е2е тестирование в продуктах

## Решение

Прокинуть data-tid через ValidationContainer

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
