### PR TITLE
feat(ValidationWrapper): add data-validation-level

### DIFF
--- a/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
+++ b/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
@@ -112,6 +112,7 @@ export class ValidationWrapperInternal extends React.Component<
 
     let clonedChild: React.ReactElement<any> = children ? (
       React.cloneElement(children, {
+        'data-component-validation-level': validation?.level,
         ref: this.customRef,
         error: !this.isChanging && getLevel(validation) === 'error',
         warning: !this.isChanging && getLevel(validation) === 'warning',

--- a/packages/react-ui-validations/tests/ValidationWrapper.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationWrapper.test.tsx
@@ -81,5 +81,41 @@ describe('ValidationWrapper', () => {
       );
       expect(screen.queryByText(inputValue)).toBeInTheDocument();
     });
+
+    it('attribute data-component-validation-level not sets when validation null', () => {
+      const { container } = render(
+        <ValidationContainer>
+          <ValidationWrapper validationInfo={null}>
+            <div />
+          </ValidationWrapper>
+        </ValidationContainer>,
+      );
+
+      expect(container.querySelector("[data-component-validation-level]")).not.toBeInTheDocument();
+    });
+
+    it('attribute data-component-validation-level sets error on level error', () => {
+      const { container } = render(
+        <ValidationContainer>
+          <ValidationWrapper validationInfo={{ type: 'immediate', message: 'error message', level: 'error' }}>
+            <div />
+          </ValidationWrapper>
+        </ValidationContainer>,
+      );
+
+      expect(container.querySelector("[data-component-validation-level='error']")).toBeInTheDocument();
+    });
+
+    it('attribute data-component-validation-level sets warning on level warning', () => {
+      const { container } = render(
+        <ValidationContainer>
+          <ValidationWrapper validationInfo={{ type: 'immediate', message: 'warning message', level: 'warning' }}>
+            <div />
+          </ValidationWrapper>
+        </ValidationContainer>,
+      );
+
+      expect(container.querySelector("[data-component-validation-level='warning']")).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

По мотивам задачи https://yt.skbkontur.ru/issue/IF-1646

в е2е тестах сложно определить состояние контролла, warning оно или error

## Решение

добавляем дата атрибут с уровнем ошибки "data-component-validation-level"

нэйминг "data-component" указывает на то, что этот data атрибут относится именно к компоненту а не прокинут снаружи, это позволит немного уменьшить вероятность того что продукт случайно прокинет такое же название data атрибута и они схлопнутся.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
