### PR TITLE
fix(TokenInput): fixes after visual changes

### DIFF
--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b4aaedf614754807bae88a5bf42332fd75f4336be2b4cce9610578b62cb883b
+size 2638

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f47a6dd0fc65bb9adfe8fbddd3d99200aae28dea5a1507de47ec0aba27123be
+size 2717

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71c6310f759f0cb674f7f2048ef06ec11fa091a8d5d0c60f25a3492105df836c
+size 2599

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41aac7bff6dc9f2ad1c32896e73b79dcc44297ef9f4628529ea2872c4ad37e44
+size 2697

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chromeDark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24fdc74d14973ac81e7c14f42672f2a959222d07d097b1c5e97599d878d2b46e
+size 2570

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chromeFlat8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/chromeFlat8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c5d9c302166345d73f88579f0bb411b22a4e15afb4ee0c31b3d5c9ae72e590c
+size 2666

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dfe98ae09c7e38521abe4eeea85cbaef4168a00063d750193dd4e214a3a5422
+size 4972

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01ac85673f181e6738256a7b3a4576386d7fd01d9287a85504fcd2d34cdcfba6
+size 4692

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a62b66e53e239d7ca856e0b54cdf677f5f22d0adc79812777c5c55826e901ea
+size 4952

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bec2bb1ebcc11e054f56aed14606ebc3e5b1c8a38625817bbdb518c88b1cabc5
+size 5029

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d81406109e5f2e4bad792f29ac030a6b271fcc861d8113f1ed782f3241b27ba8
+size 4532

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefoxFlat8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/idle/firefoxFlat8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef93d535a485325ae929990206276c7ed7ea7d6a2bf5c3205332b7b48b8fcb06
+size 5013

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffbd082b106b15764d4a586eb5ecf3e920dc4f44db31acb0520575f20c13734f
+size 4137

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8b4f57c0b131e54ae7504f509d1aa9373554dde582484625a5394a7b5e50afd
+size 5843

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:906a39bc2209f8ab885b4ddcb433a9041163b1148248fa4f5811607454e77ff0
+size 4205

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e49cdaf134d16236a9bcbfe384e462a5a6cb89677ab889e251e56aa642f2f6f2
+size 4136

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chromeDark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8a20d4f63b87c5a60f5e222f926904f5092787884b150ebd4fe46cfc36cab17
+size 3212

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chromeFlat8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/chromeFlat8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e49cdaf134d16236a9bcbfe384e462a5a6cb89677ab889e251e56aa642f2f6f2
+size 4136

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d15b6ca87ba679be3d6764c4bf5d7c6dae15d5a8a0ee32b5d0bce2846d55746
+size 7072

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4070e0eb13d569c4f6328566f4fd22a435a1149f0be9eb4502ebe5b7c9b94e4
+size 9118

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b47e89836f015c7c0c73fc83d070b6383ad4dba87536b9aa75c807fad9b00c73
+size 6906

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b612d8e2bae1475af1d0bfa628a4cd88b28dbf01b6e76d338264896c44d52d
+size 7092

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19ff48e648cf3387de463b00a615435ef9fe62f4395800d3a22f6e918cc1d3f9
+size 5900

--- a/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefoxFlat8px.png
+++ b/packages/react-ui/.creevey/images/TokenInput/with placeholder and width/selected/firefoxFlat8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2b612d8e2bae1475af1d0bfa628a4cd88b28dbf01b6e76d338264896c44d52d
+size 7092

--- a/packages/react-ui/components/Token/TokenView.tsx
+++ b/packages/react-ui/components/Token/TokenView.tsx
@@ -11,10 +11,11 @@ import { globalClasses, styles } from './Token.styles';
 export interface TokenViewProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: TokenSize;
   closeButton?: ReactNode;
+  hideCloseButton?: boolean;
 }
 
 export function TokenView(props: TokenViewProps) {
-  const { size = 'small', children, closeButton, className, ...rest } = props;
+  const { size = 'small', children, closeButton, hideCloseButton, className, ...rest } = props;
   const theme = useContext(ThemeContext);
   const getSizeClassName = (size: TokenSize) => {
     switch (size) {
@@ -27,6 +28,9 @@ export function TokenView(props: TokenViewProps) {
         return styles.tokenSmall(theme);
     }
   };
+  const closeButtonNode = hideCloseButton ? null : (
+    <span className={cx(styles.removeIcon(theme), globalClasses.removeIcon)}>{closeButton}</span>
+  );
 
   return (
     <CommonWrapper {...props}>
@@ -38,7 +42,7 @@ export function TokenView(props: TokenViewProps) {
         })}
       >
         {children}
-        <span className={cx(styles.removeIcon(theme), globalClasses.removeIcon)}>{closeButton}</span>
+        {closeButtonNode}
       </div>
     </CommonWrapper>
   );

--- a/packages/react-ui/components/TokenInput/TokenInput.styles.ts
+++ b/packages/react-ui/components/TokenInput/TokenInput.styles.ts
@@ -123,17 +123,17 @@ export const styles = memoizeStyle({
   },
   inputSmall(t: Theme) {
     return css`
-      ${inputSizeMixin(t.tokenFontSizeSmall, t.tokenLineHeightSmall)};
+      ${inputSizeMixin(t.tokenFontSizeSmall, t.tokenInputLineHeightSmall)};
     `;
   },
   inputMedium(t: Theme) {
     return css`
-      ${inputSizeMixin(t.tokenFontSizeMedium, t.tokenLineHeightMedium)};
+      ${inputSizeMixin(t.tokenFontSizeMedium, t.tokenInputLineHeightMedium)};
     `;
   },
   inputLarge(t: Theme) {
     return css`
-      ${inputSizeMixin(t.tokenFontSizeLarge, t.tokenLineHeightLarge)};
+      ${inputSizeMixin(t.tokenFontSizeLarge, t.tokenInputLineHeightLarge)};
     `;
   },
 

--- a/packages/react-ui/components/TokenInput/TokenInput.styles.ts
+++ b/packages/react-ui/components/TokenInput/TokenInput.styles.ts
@@ -78,9 +78,6 @@ export const styles = memoizeStyle({
 
   input(t: Theme) {
     return css`
-      min-width: 0;
-      max-width: 100%;
-      width: 50px;
       background: transparent;
       border: none;
       box-shadow: none;
@@ -97,6 +94,8 @@ export const styles = memoizeStyle({
       word-break: break-all;
       padding: 0;
       margin: 0;
+      flex: 1 1 100%;
+
       &::-ms-clear {
         display: none;
       }
@@ -149,6 +148,12 @@ export const styles = memoizeStyle({
       /* fix text color in safari */
       -webkit-text-fill-color: currentcolor;
       color: ${t.tokenInputTextColorDisabled};
+    `;
+  },
+
+  inputPlaceholderWrapper() {
+    return css`
+      flex: 1 1 100%;
     `;
   },
 

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -425,7 +425,6 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       error,
       warning,
       disabled,
-      placeholder,
       renderNotFound,
       hideMenuIfEmptyInputValue,
       inputMode,
@@ -460,8 +459,6 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       // вычисляем ширину чтобы input автоматически перенёсся на следующую строку при необходимости
       width: inputValueWidth,
       height: inputValueHeight,
-      // input растягивается на всю ширину чтобы placeholder не обрезался
-      flex: selectedItems && selectedItems.length === 0 ? 1 : undefined,
       // в ie не работает, но альтернативный способ --- дать tabindex для label --- предположительно ещё сложнее
       caretColor: this.isCursorVisible ? undefined : 'transparent',
     };
@@ -477,25 +474,36 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
       [styles.inputDisabled(theme)]: !!disabled,
     });
 
-    const textHolder = (
-      <textarea
-        id={this.textareaId}
-        ref={this.inputRef}
-        value={inputValue}
-        style={inputInlineStyles}
-        spellCheck={false}
-        disabled={disabled}
-        className={inputClassName}
-        placeholder={selectedItems.length > 0 ? undefined : placeholder}
-        onFocus={this.handleInputFocus}
-        onBlur={this.handleInputBlur}
-        onChange={this.handleChangeInputValue}
-        onKeyDown={this.handleKeyDown}
-        onPaste={this.handleInputPaste}
-        inputMode={inputMode}
-        aria-label={ariaLabel}
-        aria-describedby={ariaDescribedby}
-      />
+    const placeholder = selectedItems.length === 0 && !inputValue ? this.props.placeholder : '';
+
+    const inputNode = (
+      <TokenView
+        size={this.getProps().size}
+        className={cx({
+          // input растягивается на всю ширину чтобы placeholder не обрезался
+          [styles.inputPlaceholderWrapper()]: Boolean(placeholder),
+        })}
+        hideCloseButton={Boolean(placeholder)}
+      >
+        <textarea
+          id={this.textareaId}
+          ref={this.inputRef}
+          value={inputValue}
+          style={inputInlineStyles}
+          spellCheck={false}
+          disabled={disabled}
+          className={inputClassName}
+          placeholder={placeholder}
+          onFocus={this.handleInputFocus}
+          onBlur={this.handleInputBlur}
+          onChange={this.handleChangeInputValue}
+          onKeyDown={this.handleKeyDown}
+          onPaste={this.handleInputPaste}
+          inputMode={inputMode}
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedby}
+        />
+      </TokenView>
     );
 
     return (
@@ -513,13 +521,12 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
           >
             <TextWidthHelper
               ref={this.textHelperRef}
-              text={inputValue === '' ? placeholder : inputValue}
+              text={inputValue}
               theme={this.theme}
               size={this.getProps().size}
             />
             {this.renderTokensStart()}
-
-            <TokenView size={this.getProps().size}>{textHolder}</TokenView>
+            {inputNode}
             {showMenu && (
               <TokenInputMenu
                 popupMenuId={this.rootId}

--- a/packages/react-ui/components/TokenInput/__stories__/TokenInput.stories.tsx
+++ b/packages/react-ui/components/TokenInput/__stories__/TokenInput.stories.tsx
@@ -798,3 +798,39 @@ export const Size = () => {
   );
 };
 Size.storyName = 'size';
+
+export const WithPlaceholderAndWidth: Story = () => (
+  <div style={{ width: 100 }}>
+    <Wrapper getItems={getItems} placeholder="placeholder" width={'100%'} />
+  </div>
+);
+WithPlaceholderAndWidth.storyName = 'with placeholder and width';
+WithPlaceholderAndWidth.parameters = {
+  creevey: {
+    tests: {
+      async idle() {
+        await this.expect(await this.takeScreenshot()).to.matchImage();
+      },
+      async selected() {
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+          .click(this.browser.findElement({ css: '[data-comp-name~="TokenInput"]' }))
+          .pause(500)
+          .sendKeys('a')
+          .perform();
+        await delay(1000);
+        await this.browser
+          .actions({
+            bridge: true,
+          })
+
+          .click(this.browser.findElement({ css: '[data-comp-name~="MenuItem"]' }))
+          .perform();
+        await delay(1000);
+        await this.expect(await this.takeScreenshot()).to.matchImage();
+      },
+    },
+  },
+};

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -304,10 +304,10 @@ export class DefaultTheme {
    * @deprecated use tokenInputLineHeightSmall
    */
   public static get tokenInputLineHeight() {
-    return this.tokenLineHeight;
+    return this.controlLineHeightSmall;
   }
   public static get tokenInputLineHeightSmall() {
-    return this.tokenLineHeightSmall;
+    return this.tokenInputLineHeight;
   }
   public static get tokenInputLineHeightMedium() {
     return this.controlLineHeightMedium;

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -300,6 +300,21 @@ export class DefaultTheme {
 
   //#endregion
   //#region TokenInput
+  /**
+   * @deprecated use tokenInputLineHeightSmall
+   */
+  public static get tokenInputLineHeight() {
+    return this.tokenLineHeight;
+  }
+  public static get tokenInputLineHeightSmall() {
+    return this.tokenLineHeightSmall;
+  }
+  public static get tokenInputLineHeightMedium() {
+    return this.controlLineHeightMedium;
+  }
+  public static get tokenInputLineHeightLarge() {
+    return this.controlLineHeightLarge;
+  }
   public static get tokenInputBorderColor() {
     return this.inputBorderColor;
   }


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

После #3251 в TokenInput образовалась пара проблем, которые были найдены во время тестирования next в продуктах:
1. Была удалена переменная `tokenInputLineHeight`, которая использовалась в продукте. Значит, она нужна.
2. При наличии длинного плейсхолдера в TokenInput, после выбора первого токена из списка, высота всего TokenInput могла стать больше, чем нужно.


| До | После |
| --- | --- |
| ![image](https://github.com/skbkontur/retail-ui/assets/4607770/c3312b10-ffc1-4ea1-b020-efd8c9beb142)![image](https://github.com/skbkontur/retail-ui/assets/4607770/bbe7ebc0-7852-435f-a4a8-651253afa7fc) | ![image](https://github.com/skbkontur/retail-ui/assets/4607770/a0c52f77-97ad-4e71-be39-1bb6da223a3a)![image](https://github.com/skbkontur/retail-ui/assets/4607770/727aba61-2dd2-4664-98a6-dc3ed8c3f956) |


<!-- Подробно опиши решаемую проблему. -->

## Решение
1. Вернул переменную `tokenInputLineHeight`, и добавил соответствующие новые size-переменные.
2. Скорректировал логику работы с placeholder и верстку инпута.

### Правка для placeholder и инпута
Проблема с неправильной высотой TokenInput была в том, что при наличии плейсхолдера, его ширина задавала начальную ширину инпута. Это приводило к тому, что после выбора токена, они вместе с инпутом уже могли не поместиться в одной строке, что приводило к переносу.

Но ширина плейсхолдера по идее не должна влиять на ширину инпута после того, как плейсхолдер пропадает. Скорей всего это было сделано только для того, чтобы плейсхолдер в принципе был виден. Ведь плейсхолдер рисуется внутри инпута, а ширина инпута напрямую зависит только от введенного в него текста, который изначально пуст.

В качестве решения, я предлагаю не учитывать ширину плейсхолдера в ширине инпута, но растягивать инпут на максимум, когда плейсхолдер нужно отобразить в нем.

Также, дополнительную проблемку создавало то, что при отображении плейсхолдера резервировалось место справа для крестика токена. Но для плейсхолдера это не нужно. Убрал его.

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-1721
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

4. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

5. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
