### PR TITLE
chore(Button): add true root data-tid

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -195,6 +195,7 @@ export interface ButtonState {
 }
 
 export const ButtonDataTids = {
+  trueRoot: 'Button__trueRoot',
   root: 'Button__root',
   spinner: 'Button__spinner',
 } as const;
@@ -495,7 +496,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
 
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
-        <span {...wrapProps}>
+        <span {...wrapProps} data-tid={ButtonDataTids.trueRoot}>
           <button data-tid={ButtonDataTids.root} ref={this._ref} {...rootProps}>
             {innerShadowNode}
             {outlineNode}


### PR DESCRIPTION
## Проблема

В кнопке дата-тид Button__root устанавливается на кнопку, а не на корень компонента

## Решение

Добавила data-tid `trueRoot` на корневой элемент кнопки. Договорились, что изменим названия на корректные в рамках мажорного релиза (IF-1742)

## Ссылки

fix IF-1741

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
