### PR TITLE
fix(Autocomplete, ComboBox): disable browser autofill

### DIFF
--- a/packages/react-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.tsx
@@ -237,6 +237,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
     const inputProps = {
       ...rest,
       width: '100%',
+      autoComplete: 'off',
       onValueChange: this.handleValueChange,
       onKeyDown: this.handleKeyDown,
       onFocus: this.handleFocus,
@@ -307,6 +308,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
 
   private renderMobileMenu = () => {
     const inputProps: InputProps = {
+      autoComplete: 'off',
       autoFocus: true,
       width: '100%',
       onValueChange: this.handleValueChange,

--- a/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
+++ b/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
@@ -347,6 +347,12 @@ describe('<Autocomplete />', () => {
     expect(menuItems).toHaveTextContent('1');
   });
 
+  it('should disable default browser autofill', () => {
+    const props = { value: '', source: [], onValueChange: () => '' };
+    render(<Autocomplete {...props} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'off');
+  });
+
   describe('a11y', () => {
     it('should connect dropdown with input through aria-controls', async () => {
       const Comp = () => {

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -1258,6 +1258,12 @@ describe('ComboBox', () => {
     expect(screen.getByTestId(InputLikeTextDataTids.nativeInput)).toBeDisabled();
   });
 
+  it('should disable default browser autofill', () => {
+    render(<ComboBox getItems={() => Promise.resolve([])} />);
+    userEvent.click(screen.getByTestId(InputLikeTextDataTids.root));
+    expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'off');
+  });
+
   describe('a11y', () => {
     it('props aria-describedby applied correctly on Input', () => {
       const getItems = () => {

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
@@ -250,6 +250,7 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
     }
 
     const inputProps: InputProps = {
+      autoComplete: 'off',
       autoFocus: true,
       width: '100%',
       onFocus,
@@ -333,6 +334,7 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
           ref={this.refInput}
           warning={warning}
           inputMode={inputMode}
+          autoComplete="off"
           aria-describedby={ariaDescribedby}
           aria-controls={this.menuId}
           aria-label={ariaLabel}


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Нативный браузерный [autofill](https://html.spec.whatwg.org/multipage/forms.html#attr-form-autocomplete) дублирует и перекрывает подсказки в `<Autocomplete>` и `<ComboBox>`
 
_Autocomplete_
<img width="350" alt="image" src="https://github.com/skbkontur/retail-ui/assets/22644149/f5e7a595-7418-4cfd-95d0-3b8757cf8ceb">

_ComboBox_
<img src="https://github.com/skbkontur/retail-ui/assets/22644149/2bfc6084-384c-43f0-a716-de231f8a89ce" width="350" alt="" />


## Решение

- В `<ComboBoxView>` для `<input>` указал атрибут [`autocomplete="off"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values).
- В `<Autocomplete>` добавил атрибут для десктопной и мобильной версии

_P.S. Не стал добавлять аналогичный атрибут в `<TokenInput>`, который использует `<textarea>`. Не смог воспроизвести autofill-поведение `<textarea>` в Chrome, Firefox и Safari_

## Ссылки

- https://yt.skbkontur.ru/issue/IF-1624/
- https://kontur.slack.com/archives/C013HTCE18Q/p1705926378481079

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)

