### PR TITLE
fix(Autocomplete): fix dropdown position when disablePortal=true

### DIFF
--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:557c3b2e9522533d9aae35fd9ab95246f44cc0d3c0d12fd4e1ed970d1edb758b
+size 7202

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3f746925216348532346ebe9846375c19d23d50f9530a31353d2c6aaef15ff
+size 8962

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05963fcece3c9a925da69dff90108b6473b1ddcdfc568afdbcc65a019cbb2037
+size 7655

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b3a6a4fc70942642d4ef95c184ab9a76d767e333e4d946c8e50cabe713d729
+size 7238

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af1137b763e5a6979aca56ba8546a000e9c47140b2ca744c2aeae3c057ec047d
+size 6573

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6cd8cfc02fc553d2d7ad98a49f3ec8b33a4810f86eeb81280d3d2701eaa143
+size 32952

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54e5439b8bd325c6fce12c3f5ba9d84071858e291261ece16c9b613eadd2b449
+size 35671

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a84cb9fd15d229d344eee3ce59676144e80779a2cf8139b97e96b293e1235703
+size 32927

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d1d95a19d8a70eb5b393d9dec51b7044744cb8dfa68dfb1f7d99e075884682
+size 32958

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu bottom/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eeb06f077e987a1154a8fe30f740c50caa3cb9b6ac6a4634601f2aa09c40d76b
+size 31912

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d478c3e6c770f7f176e383ca7c6b7a5d7b451bfcdfa30b016140a36fba91f1
+size 7268

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c93563fcca1068e7adab71c525a12b708952701876626ec83028dc56dd392578
+size 8967

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3605c19a531d22075ab7a841221342e128f900f8a08914845fcedd1fdc5171ba
+size 7826

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f5f54b2ab16e7a720f761ded59ee08df247c0bbfe2e40bbb51e517c36f89c78
+size 7275

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8afb2a6609ff5e8484aa1fea2b5ba406917afb617c7e41f6178cd9fd08a5a45
+size 6671

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc0a942a7fecf4a15b55ee215a02961a0884fdae7f4c399989d19b6e7f85288e
+size 32996

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dba394de64ebab242023c6a4e144fbe1d4926f4c2436e18916362703ffd74cb
+size 35635

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7da8e46d8210806b8a4de96cbee7faf8aac2fdefc3c2417800e52d42dee2863
+size 33766

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad19ac262f552004dfed3f9aba83fcb95c3d53efe2240b7140dc5fcb95e998df
+size 33001

--- a/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/menuPos/focus and type text menu top/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d87bd5b7471049f7889301ecfcf5f0651ddf0787eb96f1cce9858da05194885a
+size 31016

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:557c3b2e9522533d9aae35fd9ab95246f44cc0d3c0d12fd4e1ed970d1edb758b
+size 7202

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3f746925216348532346ebe9846375c19d23d50f9530a31353d2c6aaef15ff
+size 8962

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05963fcece3c9a925da69dff90108b6473b1ddcdfc568afdbcc65a019cbb2037
+size 7655

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b3a6a4fc70942642d4ef95c184ab9a76d767e333e4d946c8e50cabe713d729
+size 7238

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af1137b763e5a6979aca56ba8546a000e9c47140b2ca744c2aeae3c057ec047d
+size 6573

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6cd8cfc02fc553d2d7ad98a49f3ec8b33a4810f86eeb81280d3d2701eaa143
+size 32952

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54e5439b8bd325c6fce12c3f5ba9d84071858e291261ece16c9b613eadd2b449
+size 35671

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a84cb9fd15d229d344eee3ce59676144e80779a2cf8139b97e96b293e1235703
+size 32927

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d1d95a19d8a70eb5b393d9dec51b7044744cb8dfa68dfb1f7d99e075884682
+size 32958

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu bottom/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eeb06f077e987a1154a8fe30f740c50caa3cb9b6ac6a4634601f2aa09c40d76b
+size 31912

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d478c3e6c770f7f176e383ca7c6b7a5d7b451bfcdfa30b016140a36fba91f1
+size 7268

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c93563fcca1068e7adab71c525a12b708952701876626ec83028dc56dd392578
+size 8967

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3605c19a531d22075ab7a841221342e128f900f8a08914845fcedd1fdc5171ba
+size 7826

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f5f54b2ab16e7a720f761ded59ee08df247c0bbfe2e40bbb51e517c36f89c78
+size 7275

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8afb2a6609ff5e8484aa1fea2b5ba406917afb617c7e41f6178cd9fd08a5a45
+size 6671

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc0a942a7fecf4a15b55ee215a02961a0884fdae7f4c399989d19b6e7f85288e
+size 32996

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dba394de64ebab242023c6a4e144fbe1d4926f4c2436e18916362703ffd74cb
+size 35635

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7da8e46d8210806b8a4de96cbee7faf8aac2fdefc3c2417800e52d42dee2863
+size 33766

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad19ac262f552004dfed3f9aba83fcb95c3d53efe2240b7140dc5fcb95e998df
+size 33001

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text menu top/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d87bd5b7471049f7889301ecfcf5f0651ddf0787eb96f1cce9858da05194885a
+size 31016

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d478c3e6c770f7f176e383ca7c6b7a5d7b451bfcdfa30b016140a36fba91f1
+size 7268

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c93563fcca1068e7adab71c525a12b708952701876626ec83028dc56dd392578
+size 8967

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3605c19a531d22075ab7a841221342e128f900f8a08914845fcedd1fdc5171ba
+size 7826

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chrome8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f5f54b2ab16e7a720f761ded59ee08df247c0bbfe2e40bbb51e517c36f89c78
+size 7275

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chromeDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/chromeDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8afb2a6609ff5e8484aa1fea2b5ba406917afb617c7e41f6178cd9fd08a5a45
+size 6671

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc0a942a7fecf4a15b55ee215a02961a0884fdae7f4c399989d19b6e7f85288e
+size 32996

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox2022.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dba394de64ebab242023c6a4e144fbe1d4926f4c2436e18916362703ffd74cb
+size 35635

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox2022Dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7da8e46d8210806b8a4de96cbee7faf8aac2fdefc3c2417800e52d42dee2863
+size 33766

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox8px.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefox8px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad19ac262f552004dfed3f9aba83fcb95c3d53efe2240b7140dc5fcb95e998df
+size 33001

--- a/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefoxDark.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/with disabled portal/focus and type text/firefoxDark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d87bd5b7471049f7889301ecfcf5f0651ddf0787eb96f1cce9858da05194885a
+size 31016

--- a/packages/react-ui/components/Autocomplete/Autocomplete.styles.ts
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.styles.ts
@@ -8,4 +8,9 @@ export const styles = memoizeStyle({
       width: ${t.inputWidth};
     `;
   },
+  noPortal() {
+    return css`
+      position: relative;
+    `;
+  },
 });

--- a/packages/react-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.tsx
@@ -229,6 +229,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
       menuMaxHeight,
       preventWindowScroll,
       source,
+      menuPos,
       width = this.theme.inputWidth,
       mobileMenuHeaderText,
       'aria-label': ariaLabel,

--- a/packages/react-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.tsx
@@ -8,6 +8,7 @@ import { locale } from '../../lib/locale/decorators';
 import { getRandomID, isNullable } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
+import { cx } from '../../lib/theming/Emotion';
 import { isKeyArrowDown, isKeyArrowUp, isKeyEnter, isKeyEscape } from '../../lib/events/keyboard/identifiers';
 import { Input, InputProps } from '../Input';
 import { DropdownContainer, DropdownContainerProps } from '../../internal/DropdownContainer';
@@ -248,7 +249,9 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
       <RenderLayer onFocusOutside={this.handleBlur} onClickOutside={this.handleClickOutside} active={focused}>
         <span
           data-tid={AutocompleteDataTids.root}
-          className={styles.root(this.theme)}
+          className={cx(styles.root(this.theme), {
+            [styles.noPortal()]: disablePortal,
+          })}
           style={{ width }}
           ref={this.refRootSpan}
         >

--- a/packages/react-ui/components/Autocomplete/__stories__/Autocomplete.stories.tsx
+++ b/packages/react-ui/components/Autocomplete/__stories__/Autocomplete.stories.tsx
@@ -65,6 +65,27 @@ const sizeTests: CreeveyTests = {
   },
 };
 
+const menuPosTests: CreeveyTests = {
+  async 'focus and type text menu top'() {
+    const screenshotElement = this.browser.findElement({ css: '#test-element' });
+    const autocompleteElements = await this.browser.findElements({ css: '[data-comp-name~="Autocomplete"]' });
+
+    await this.browser.actions({ bridge: true }).click(autocompleteElements[0]).sendKeys('o').perform();
+    await delay(1000);
+
+    await this.expect(await screenshotElement.takeScreenshot()).to.matchImage();
+  },
+  async 'focus and type text menu bottom'() {
+    const screenshotElement = this.browser.findElement({ css: '#test-element' });
+    const autocompleteElements = await this.browser.findElements({ css: '[data-comp-name~="Autocomplete"]' });
+
+    await this.browser.actions({ bridge: true }).click(autocompleteElements[1]).sendKeys('o').perform();
+    await delay(1000);
+
+    await this.expect(await screenshotElement.takeScreenshot()).to.matchImage();
+  },
+};
+
 export const Simple: Story = () => <UncontrolledAutocomplete source={['One', 'Two', 'Three']} />;
 Simple.storyName = 'simple';
 
@@ -83,6 +104,29 @@ Simple.parameters = {
         await this.expect(await autocompleteElement.takeScreenshot()).to.matchImage();
       },
       ...commonTests,
+    },
+  },
+};
+
+export const WithDisabledPortal: Story = () => {
+  const source = ['One', 'Two', 'Three'];
+
+  return (
+    <div>
+      <Gapped style={{ height: '300px', width: '1000px', margin: '200px' }}>
+        <UncontrolledAutocomplete disablePortal source={source} menuPos={'top'} />
+        <UncontrolledAutocomplete disablePortal source={source} menuPos={'bottom'} />
+      </Gapped>
+    </div>
+  );
+};
+WithDisabledPortal.storyName = 'with disabled portal';
+
+WithDisabledPortal.parameters = {
+  creevey: {
+    tests: {
+      ...commonTests,
+      ...menuPosTests,
     },
   },
 };
@@ -434,5 +478,25 @@ Size.storyName = 'size';
 Size.parameters = {
   creevey: {
     tests: sizeTests,
+  },
+};
+
+export const MenuPos = () => {
+  const source = ['One', 'Two', 'Three'];
+
+  return (
+    <div>
+      <Gapped style={{ height: '300px', width: '1000px', margin: '200px' }}>
+        <UncontrolledAutocomplete source={source} menuPos={'top'} />
+        <UncontrolledAutocomplete source={source} menuPos={'bottom'} />
+      </Gapped>
+    </div>
+  );
+};
+MenuPos.storyName = 'menuPos';
+
+MenuPos.parameters = {
+  creevey: {
+    tests: menuPosTests,
   },
 };


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Дропдаун компонента Autocomplete неправильно позиционируется относительно инпута, когда `disablePortal=true`.

Добавил тесты для комбинаций `disablePortal` и `menuPos`.

Убрал непреднамеренную передачу пропа `menuPos` в компонент `Input`.

## Решение

Добавил для рутового дом-элемента компонента Autocomplete стиль `position: relative`, когда `disablePortal=true`.

## Ссылки

Close [IF-918](https://yt.skbkontur.ru/issue/IF-918)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
