### PR TITLE
feat: remove tokenInputRemoveWhitespaceFromDefaultDelimiters feature flag

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -350,7 +350,6 @@ function foo() {}
 
    Примеры:
    - validationsRemoveExtraSpans - Избавиться от обертки span в ValidationContainer, ValidationWrapper и ValidationText
-   - tokenInputRemoveWhitespaceFromDefaultDelimiters - В TokenInput изменили разделитель по умолчанию
 
 2) Добавьте флаг в ReactUIFeatureFlags в файл ReactUIFeatureFlagsContext.tsx и в документацию FEATUREFLAGSCONTEXT.md
 

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -39,11 +39,6 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { getUid } from '../../lib/uidUtils';
 import { TokenView } from '../Token/TokenView';
-import {
-  ReactUIFeatureFlags,
-  ReactUIFeatureFlagsContext,
-  getFullReactUIFlagsContext,
-} from '../../lib/featureFlagsContext';
 
 import { TokenInputLocale, TokenInputLocaleHelper } from './locale';
 import { styles } from './TokenInput.styles';
@@ -282,7 +277,7 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
   public static defaultProps: DefaultProps<any> = {
     selectedItems: [],
     // TEMP_FAKE_FLAG помогает узнать, остались ли разделители дефолтными или пользователь передал их равными дефолтным.
-    delimiters: [',', ' ', TEMP_FAKE_FLAG],
+    delimiters: [',', TEMP_FAKE_FLAG],
     renderItem: identity,
     renderValue: identity,
     valueToString: identity,
@@ -304,9 +299,6 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     if (delimiters.every((delimiter) => delimiter !== TEMP_FAKE_FLAG)) {
       return delimiters;
     }
-    if (this.featureFlags.tokenInputRemoveWhitespaceFromDefaultDelimiters) {
-      return delimiters.filter((delimiter) => delimiter !== ' ' && delimiter !== TEMP_FAKE_FLAG);
-    }
     return delimiters.filter((delimiter) => delimiter !== TEMP_FAKE_FLAG);
   }
 
@@ -322,7 +314,6 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
   private rootId = PopupIds.root + getRandomID();
   private readonly locale!: TokenInputLocale;
   private theme!: Theme;
-  private featureFlags!: ReactUIFeatureFlags;
   private input: HTMLTextAreaElement | null = null;
   private tokensInputMenu: TokenInputMenu<T> | null = null;
   private textHelper: TextWidthHelper | null = null;
@@ -377,19 +368,12 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
 
   public render() {
     return (
-      <ReactUIFeatureFlagsContext.Consumer>
-        {(flags) => {
-          this.featureFlags = getFullReactUIFlagsContext(flags);
-          return (
-            <ThemeContext.Consumer>
-              {(theme) => {
-                this.theme = theme;
-                return this.renderMain();
-              }}
-            </ThemeContext.Consumer>
-          );
+      <ThemeContext.Consumer>
+        {(theme) => {
+          this.theme = theme;
+          return this.renderMain();
         }}
-      </ReactUIFeatureFlagsContext.Consumer>
+      </ThemeContext.Consumer>
     );
   }
 

--- a/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
+++ b/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
@@ -4,7 +4,6 @@
 
 ```typescript static
 export interface ReactUIFeatureFlags {
-  tokenInputRemoveWhitespaceFromDefaultDelimiters?: boolean;
   kebabHintRemovePin?: boolean;
   sidePageEnableFocusLockWhenBackgroundBlocked?: boolean;
   spinnerLoaderRemoveDefaultCaption?: boolean;
@@ -19,31 +18,10 @@ export interface ReactUIFeatureFlags {
 ```jsx static
 import { ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
 
-<ReactUIFeatureFlagsContext.Provider value={{ tokenInputRemoveWhitespaceFromDefaultDelimiters: true }}>{/* ... */}</ReactUIFeatureFlagsContext.Provider>;
+<ReactUIFeatureFlagsContext.Provider value={{ comboBoxAllowValueChangeInEditingState: true }}>{/* ... */}</ReactUIFeatureFlagsContext.Provider>;
 ```
 
 ## Использование
-
-### tokenInputRemoveWhitespaceFromDefaultDelimiters
-
-В TokenInput из дефолтных разделителей удалён пробел.
-В React UI 5.0 фича будет применена по умолчанию.
-
-```jsx harmony
-import { TokenInput, TokenInputType, Token, ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
-
-const [selectedItems, setSelectedItems] = React.useState([]);
-const getItems = () => {};
-
-<ReactUIFeatureFlagsContext.Provider value={{ tokenInputRemoveWhitespaceFromDefaultDelimiters: true }}>
-  <TokenInput
-    type={TokenInputType.Combined}
-    getItems={getItems}
-    selectedItems={selectedItems}
-    onValueChange={setSelectedItems}
-  />
-</ReactUIFeatureFlagsContext.Provider>
-```
 
 ### kebabHintRemovePin
 

--- a/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
+++ b/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 export interface ReactUIFeatureFlags {
-  tokenInputRemoveWhitespaceFromDefaultDelimiters?: boolean;
   kebabHintRemovePin?: boolean;
   sidePageEnableFocusLockWhenBackgroundBlocked?: boolean;
   spinnerLoaderRemoveDefaultCaption?: boolean;
@@ -14,7 +13,6 @@ export interface ReactUIFeatureFlags {
 }
 
 export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {
-  tokenInputRemoveWhitespaceFromDefaultDelimiters: false,
   kebabHintRemovePin: false,
   sidePageEnableFocusLockWhenBackgroundBlocked: false,
   spinnerLoaderRemoveDefaultCaption: false,


### PR DESCRIPTION
## Проблема

Удаление `tokenInputRemoveWhitespaceFromDefaultDelimiters` фиче-флага

## Решение

Удалила фиче-флаг. Теперь в TokenInput из дефолтных разделителей удалён пробел по умолчанию

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
