### PR TITLE
feat: remove textareaUseSafari17Workaround feature flag

### DIFF
--- a/packages/react-ui/.styleguide/helpers.js
+++ b/packages/react-ui/.styleguide/helpers.js
@@ -91,7 +91,7 @@ const getCommonSections = () => {
     { name: 'Roadmap', content: path.join(__dirname, '../ROADMAP.md') },
     { name: 'Migration', content: path.join(__dirname, '../MIGRATION.md'), exampleMode: 'expand' },
     { name: 'LocaleContext', content: path.join(__dirname, '../lib/locale/LOCALECONTEXT.md') },
-    { name: 'FeatureFlagsContext', content: path.join(__dirname, '../lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md') },
+    // { name: 'FeatureFlagsContext', content: path.join(__dirname, '../lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md') }, // TODO включить когда появятся фиче-флаги
     { name: 'DataTids', content: path.join(__dirname, '../internal/DataTids/DATATIDS.md') },
     { name: 'SSR', content: path.join(__dirname, '../SSR.md') },
     { name: 'Mobiles', content: path.join(__dirname, '../MOBILES.md') },

--- a/packages/react-ui/components/Textarea/Textarea.tsx
+++ b/packages/react-ui/components/Textarea/Textarea.tsx
@@ -11,18 +11,13 @@ import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { RenderLayer } from '../../internal/RenderLayer';
 import { ResizeDetector } from '../../internal/ResizeDetector';
-import { isIE11, isSafari17 } from '../../lib/client';
+import { isIE11, isSafariWithTextareaBug } from '../../lib/client';
 import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
 import { isTestEnv } from '../../lib/currentEnvironment';
 import { cx } from '../../lib/theming/Emotion';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { SizeProp } from '../../lib/types/props';
-import {
-  getFullReactUIFlagsContext,
-  ReactUIFeatureFlags,
-  ReactUIFeatureFlagsContext,
-} from '../../lib/featureFlagsContext';
 
 import { getTextAreaHeight } from './TextareaHelpers';
 import { styles } from './Textarea.styles';
@@ -209,7 +204,6 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
   };
 
   private getProps = createPropsGetter(Textarea.defaultProps);
-  private featureFlags!: ReactUIFeatureFlags;
 
   private getRootSizeClassName() {
     switch (this.getProps().size) {
@@ -301,23 +295,16 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
 
   public render() {
     return (
-      <ReactUIFeatureFlagsContext.Consumer>
-        {(flags) => {
-          this.featureFlags = getFullReactUIFlagsContext(flags);
+      <ThemeContext.Consumer>
+        {(theme) => {
+          this.theme = theme;
           return (
-            <ThemeContext.Consumer>
-              {(theme) => {
-                this.theme = theme;
-                return (
-                  <CommonWrapper rootNodeRef={this.setRootNode} {...this.getProps()}>
-                    {this.renderMain}
-                  </CommonWrapper>
-                );
-              }}
-            </ThemeContext.Consumer>
+            <CommonWrapper rootNodeRef={this.setRootNode} {...this.getProps()}>
+              {this.renderMain}
+            </CommonWrapper>
           );
         }}
-      </ReactUIFeatureFlagsContext.Consumer>
+      </ThemeContext.Consumer>
     );
   }
 
@@ -449,8 +436,7 @@ export class Textarea extends React.Component<TextareaProps, TextareaState> {
       />
     );
 
-    const Component =
-      this.featureFlags.textareaUseSafari17Workaround && isSafari17 ? TextareaWithSafari17Workaround : 'textarea';
+    const Component = isSafariWithTextareaBug ? TextareaWithSafari17Workaround : 'textarea';
 
     return (
       <RenderLayer

--- a/packages/react-ui/components/Textarea/TextareaWithSafari17Workaround.tsx
+++ b/packages/react-ui/components/Textarea/TextareaWithSafari17Workaround.tsx
@@ -5,6 +5,7 @@ import { forwardRefAndName } from '../../lib/forwardRefAndName';
 /**
  * React textarea behaves incorrectly on first rendered in Safari version 17.*
  * Reproduce: https://codesandbox.io/p/sandbox/textarea-and-textarea-safari-bug-9v95vz
+ * was fixed in Safari version 17.4: https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes
  */
 export const TextareaWithSafari17Workaround = forwardRefAndName<
   HTMLTextAreaElement,

--- a/packages/react-ui/lib/client.ts
+++ b/packages/react-ui/lib/client.ts
@@ -23,3 +23,10 @@ export const isMobile =
 export const isIOS = /(ip[ao]d|iphone)/gi.test(userAgent);
 
 export const isSafari17 = isSafari && userAgent.includes('version/17');
+
+const is17_0v = userAgent.includes('version/17.0');
+const is17_1v = userAgent.includes('version/17.1');
+const is17_2v = userAgent.includes('version/17.2');
+const is17_3v = userAgent.includes('version/17.3');
+
+export const isSafariWithTextareaBug = isSafari && (is17_0v || is17_1v || is17_2v || is17_3v);

--- a/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
+++ b/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 
-export interface ReactUIFeatureFlags {
-  textareaUseSafari17Workaround?: boolean;
-}
+export interface ReactUIFeatureFlags {}
 
-export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {
-  textareaUseSafari17Workaround: false,
-};
+export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {};
 
 export const ReactUIFeatureFlagsContext = React.createContext<ReactUIFeatureFlags>(reactUIFeatureFlagsDefault);
 


### PR DESCRIPTION
## Проблема

Удаление textareaUseSafari17Workaround фиче-флага

## Решение

Удалила фиче-флаг. Но оставила решение для определенных версий Сафари, в которых баг воспроизводится

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
