### PR TITLE
feat(validations): use `ThemeContext`

### DIFF
--- a/packages/react-ui-validations/.creevey/images/FeatureFlags/fixedValidationTextColors/chromeDefault.png
+++ b/packages/react-ui-validations/.creevey/images/FeatureFlags/fixedValidationTextColors/chromeDefault.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e932d66db4aad1bc7506631bba30f38e83a9ccef5875345593cda9015d95294
+size 11669

--- a/packages/react-ui-validations/docs/Pages/Displaying/FeatureFlags/FeatureFlagsContext.md
+++ b/packages/react-ui-validations/docs/Pages/Displaying/FeatureFlags/FeatureFlagsContext.md
@@ -29,14 +29,19 @@
 ### fixedValidationTextColors
 
 В ValidationText будут использоваться цвета по гайдам для error и warning.
+
+Для кастомизации цветов используйте переменные темы `validationsTextColorWarning` и
+`validationsTextColorError`.
+
 В Validations 2.0 фича будет применена по умолчанию.
 
     !!DemoWithCode!!FeatureFlagsExampleFixedValidationTextColors
 
-### darkTheme
+### darkTheme*
 
-На данный момент работает только в паре с **fixedValidationTextColors: true**.
-В ValidationText будут использоваться цвета по гайдам для error и warning из темной темы
+Работает только в паре с **fixedValidationTextColors: true** и если нет переменных темы `validationsTextColorWarning` и
+`validationsTextColorError`.
+В ValidationText будут использоваться цвета по гайдам для error и warning из тёмной темы.
 
     !!DemoWithCode!!FeatureFlagsExampleFixedValidationTextColorsDarkTheme
 

--- a/packages/react-ui-validations/src/ReactUiDetection.ts
+++ b/packages/react-ui-validations/src/ReactUiDetection.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { isNonNullable } from '../src/utils/isNonNullable';
 
 declare function require(name: string): any;
@@ -5,9 +7,12 @@ declare function require(name: string): any;
 const defaultOrNamed = (module: any, component: string) =>
   module && module.__esModule && module.default ? module.default : module[component];
 
-const Tooltip = defaultOrNamed(require('__REACT_UI_PACKAGE__/components/Tooltip'), 'Tooltip');
+const importContext = (module: any, component: string) => module[component] || React.createContext({});
 
-export { Tooltip };
+const Tooltip = defaultOrNamed(require('__REACT_UI_PACKAGE__/components/Tooltip'), 'Tooltip');
+const ThemeContext = importContext(require('__REACT_UI_PACKAGE__/lib/theming/ThemeContext'), 'ThemeContext');
+
+export { Tooltip, ThemeContext };
 
 export class ReactUiDetection {
   public static isDatePicker(childrenArray: any): boolean {

--- a/packages/react-ui-validations/src/ValidationText.tsx
+++ b/packages/react-ui-validations/src/ValidationText.tsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
 
 import { Nullable } from '../typings/Types';
+import { ThemeValidations } from '../typings/theme-context';
 
 import { getFullValidationsFlagsContext, ValidationsFeatureFlagsContext } from './utils/featureFlagsContext';
 import { TextPosition, Validation } from './ValidationWrapperInternal';
 import { getValidationTextColor } from './utils/getValidationTextColor';
+import { ThemeContext } from './ReactUiDetection';
 
 export interface ValidationTextProps {
   pos: TextPosition;
@@ -14,10 +16,9 @@ export interface ValidationTextProps {
 }
 
 export const ValidationText = ({ pos, children, validation, 'data-tid': dataTid }: ValidationTextProps) => {
+  const theme = useContext<ThemeValidations>(ThemeContext);
   const featureFlags = getFullValidationsFlagsContext(useContext(ValidationsFeatureFlagsContext));
-  const color = featureFlags.fixedValidationTextColors
-    ? getValidationTextColor(featureFlags.darkTheme, validation?.level)
-    : '#d43517';
+  const color = getValidationTextColor(featureFlags, theme, validation?.level);
 
   if (pos === 'right') {
     const childrenAndValidationText = (

--- a/packages/react-ui-validations/src/utils/getValidationTextColor.ts
+++ b/packages/react-ui-validations/src/utils/getValidationTextColor.ts
@@ -1,10 +1,27 @@
 import type { ValidationLevel } from '../ValidationWrapperInternal';
+import { ThemeValidations } from '../../typings/theme-context';
 
-export function getValidationTextColor(darkTheme = false, level: ValidationLevel = 'error') {
-  switch (level) {
-    case 'warning':
-      return darkTheme ? '#fdd481' : '#ef8b17';
-    case 'error':
-      return darkTheme ? '#ff887b' : '#cb3d35';
+import { ValidationsFeatureFlags } from './featureFlagsContext';
+
+export const DEFAULT_TEXT_COLOR = '#d43517';
+
+export function getValidationTextColor(
+  flags: ValidationsFeatureFlags,
+  theme: ThemeValidations,
+  level: ValidationLevel = 'error',
+) {
+  if (flags.fixedValidationTextColors) {
+    if (!theme.validationsTextColorWarning && !theme.validationsTextColorError) {
+      switch (level) {
+        case 'warning':
+          return flags.darkTheme ? '#fdd481' : '#ef8b17';
+        case 'error':
+          return flags.darkTheme ? '#ff887b' : '#cb3d35';
+      }
+    }
+    return (
+      (level === 'warning' ? theme.validationsTextColorWarning : theme.validationsTextColorError) || DEFAULT_TEXT_COLOR
+    );
   }
+  return DEFAULT_TEXT_COLOR;
 }

--- a/packages/react-ui-validations/src/utils/getValidationTextColor.ts
+++ b/packages/react-ui-validations/src/utils/getValidationTextColor.ts
@@ -1,5 +1,5 @@
 import type { ValidationLevel } from '../ValidationWrapperInternal';
-import { ThemeValidations } from '../../typings/theme-context';
+import type { ThemeValidations } from '../../typings/theme-context';
 
 import { ValidationsFeatureFlags } from './featureFlagsContext';
 

--- a/packages/react-ui-validations/stories/FeatureFlags.stories.tsx
+++ b/packages/react-ui-validations/stories/FeatureFlags.stories.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
-import {
-  DARK_THEME,
-  Gapped,
-  Input,
-  ThemeContext,
-  ThemeFactory,
-} from '@skbkontur/react-ui';
+import { Meta } from '@storybook/react';
+import { DARK_THEME, Gapped, Input, ThemeContext, ThemeFactory } from '@skbkontur/react-ui';
 
-import {
-  text,
-  ValidationContainer,
-  ValidationsFeatureFlagsContext,
-  ValidationWrapper,
-} from '../../../../src';
+import { text, ValidationContainer, ValidationsFeatureFlagsContext, ValidationWrapper } from '../src';
+
+export default {
+  title: 'FeatureFlags',
+} as Meta;
 
 function ValidationExamples() {
   return (
@@ -55,9 +49,7 @@ function DarkTheme() {
   return (
     <div style={{ background: '#2b2b2b' }}>
       <ThemeContext.Provider value={DARK_THEME}>
-        <ValidationsFeatureFlagsContext.Provider
-          value={{ fixedValidationTextColors: true }}
-        >
+        <ValidationsFeatureFlagsContext.Provider value={{ fixedValidationTextColors: true }}>
           <ValidationExamples />
         </ValidationsFeatureFlagsContext.Provider>
       </ThemeContext.Provider>
@@ -70,13 +62,11 @@ function CustomTheme() {
     <div style={{ background: '#faf7f3' }}>
       <ThemeContext.Provider
         value={ThemeFactory.create({
-          validationsTextColorWarning: 'orange',
+          validationsTextColorWarning: 'sandybrown',
           validationsTextColorError: 'red',
         })}
       >
-        <ValidationsFeatureFlagsContext.Provider
-          value={{ fixedValidationTextColors: true }}
-        >
+        <ValidationsFeatureFlagsContext.Provider value={{ fixedValidationTextColors: true }}>
           <ValidationExamples />
         </ValidationsFeatureFlagsContext.Provider>
       </ThemeContext.Provider>
@@ -84,12 +74,11 @@ function CustomTheme() {
   );
 }
 
-export default function FeatureFlagsExampleFixedValidationTextColors() {
-  return (
-    <Gapped vertical>
-      <LightTheme />
-      <DarkTheme />
-      <CustomTheme />
-    </Gapped>
-  );
-}
+export const FeatureFlag_fixedValidationTextColors = () => (
+  <Gapped vertical>
+    <LightTheme />
+    <DarkTheme />
+    <CustomTheme />
+  </Gapped>
+);
+FeatureFlag_fixedValidationTextColors.storyName = 'fixedValidationTextColors';

--- a/packages/react-ui-validations/stories/ValidationContainer.stories.tsx
+++ b/packages/react-ui-validations/stories/ValidationContainer.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { Button, Gapped, Input } from '@skbkontur/react-ui';
+import { Button, Gapped, Input, ThemeContext, ThemeFactory } from '@skbkontur/react-ui';
 
 import { text, ValidationContainer, ValidationInfo, ValidationsFeatureFlagsContext, ValidationWrapper } from '../src';
 
@@ -71,31 +71,38 @@ export const WithWrapperError = () => (
 );
 
 export const WithWrapperErrorWithoutSpan = () => (
-  <Gapped vertical gap={20}>
-    <ValidationsFeatureFlagsContext.Provider
-      value={{ validationsRemoveExtraSpans: true, fixedValidationTextColors: true, darkTheme: true }}
-    >
-      <ValidationContainer>
-        <div>
-          <Button>Submit</Button>
-          <ValidationWrapper renderMessage={text('bottom')} validationInfo={validationWarning}>
-            <Input />
-          </ValidationWrapper>
-        </div>
-      </ValidationContainer>
-    </ValidationsFeatureFlagsContext.Provider>
+  <ThemeContext.Provider
+    value={ThemeFactory.create({
+      validationsTextColorWarning: '',
+      validationsTextColorError: '',
+    })}
+  >
+    <Gapped vertical gap={20}>
+      <ValidationsFeatureFlagsContext.Provider
+        value={{ validationsRemoveExtraSpans: true, fixedValidationTextColors: true, darkTheme: true }}
+      >
+        <ValidationContainer>
+          <div>
+            <Button>Submit</Button>
+            <ValidationWrapper renderMessage={text('bottom')} validationInfo={validationWarning}>
+              <Input />
+            </ValidationWrapper>
+          </div>
+        </ValidationContainer>
+      </ValidationsFeatureFlagsContext.Provider>
 
-    <ValidationsFeatureFlagsContext.Provider
-      value={{ validationsRemoveExtraSpans: false, fixedValidationTextColors: true }}
-    >
-      <ValidationContainer>
-        <div>
-          <Button>Submit</Button>
-          <ValidationWrapper renderMessage={text('bottom')} validationInfo={validation}>
-            <Input />
-          </ValidationWrapper>
-        </div>
-      </ValidationContainer>
-    </ValidationsFeatureFlagsContext.Provider>
-  </Gapped>
+      <ValidationsFeatureFlagsContext.Provider
+        value={{ validationsRemoveExtraSpans: false, fixedValidationTextColors: true }}
+      >
+        <ValidationContainer>
+          <div>
+            <Button>Submit</Button>
+            <ValidationWrapper renderMessage={text('bottom')} validationInfo={validation}>
+              <Input />
+            </ValidationWrapper>
+          </div>
+        </ValidationContainer>
+      </ValidationsFeatureFlagsContext.Provider>
+    </Gapped>
+  </ThemeContext.Provider>
 );

--- a/packages/react-ui-validations/typings/theme-context.d.ts
+++ b/packages/react-ui-validations/typings/theme-context.d.ts
@@ -1,0 +1,6 @@
+// переменные из темы пакета react-ui
+// packages/react-ui/internal/themes/DefaultTheme.ts
+export interface ThemeValidations {
+  validationsTextColorError: string;
+  validationsTextColorWarning: string;
+}

--- a/packages/react-ui/internal/ThemePlayground/constants.ts
+++ b/packages/react-ui/internal/ThemePlayground/constants.ts
@@ -39,6 +39,7 @@ export const VARIABLES_GROUPS = [
   { title: 'Legacy', prefix: 'chb slt' },
   { title: 'GlobalLoader', prefix: 'globalLoader' },
   { title: 'CloseButtonIcon', prefix: 'closeBtnIcon' },
+  { title: 'react-ui-validations', prefix: 'validations' },
 ];
 
 export const DEPRECATED_VARIABLES: Array<keyof Theme> = [];

--- a/packages/react-ui/internal/themes/DarkTheme.ts
+++ b/packages/react-ui/internal/themes/DarkTheme.ts
@@ -241,6 +241,11 @@ export class DarkTheme extends (class {} as typeof DefaultThemeInternal) {
   public static fileUploaderDisabledLinkColor = 'rgba(255, 255, 255, 0.32)';
   public static fileUploaderDisabledIconColor = 'rgba(255, 255, 255, 0.32)';
   //#endregion
+
+  //#region react-ui-validations
+  public static validationsTextColorError = '#ff887b';
+  public static validationsTextColorWarning = '#fdd481';
+  //#endregion
 }
 
 export const DarkThemeInternal = Object.setPrototypeOf(

--- a/packages/react-ui/internal/themes/DefaultTheme.ts
+++ b/packages/react-ui/internal/themes/DefaultTheme.ts
@@ -2793,6 +2793,11 @@ export class DefaultTheme {
   public static miniModalHeaderPaddingMobile = '32px 16px 0';
   public static miniModalBodyPaddingMobile = '16px 16px 0';
   //#endregion
+
+  //#region react-ui-validations
+  public static validationsTextColorError = '#cb3d35';
+  public static validationsTextColorWarning = '#ef8b17';
+  //#endregion
 }
 
 export const DefaultThemeInternal = exposeGetters(DefaultTheme);


### PR DESCRIPTION

## Проблема

Цвета для текста сообщения вшиты в пакет валидаций.
Из-за чего их нельзя кастомизировать, нормально обновлять, и настраивать под тёмную тему.

## Решение

Добавил переменные темы `validationsTextColorError` и `validationsTextColorWarning` и применил `ThemeContext` из `react-ui` внутри `react-ui-validations`.

В пакете валидаций пакет `react-ui` указан в `peerDependencies`, поэтому мы можем использовать его компоненты.
Подобным образом мы уже используем `Tooltip`.

## Ссылки

[IF-1788](https://yt.skbkontur.ru/issue/IF-1788) Валидации: цвет для текста сообщения нельзя кастомизировать

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
