### PR TITLE
fix: program validation on multi fields IF-1719

### DIFF
--- a/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
+++ b/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
@@ -227,10 +227,12 @@ export class ValidationWrapperInternal extends React.Component<
     }
 
     return new Promise((resolve) => {
-      this.setState({ validation }, resolve);
-      if (Boolean(current) !== Boolean(validation)) {
-        this.context.onValidationUpdated(this, !validation);
-      }
+      this.setState({ validation }, () => {
+        if (Boolean(current) !== Boolean(validation)) {
+          this.context.onValidationUpdated(this, !validation);
+        }
+        resolve();
+      });
     });
   }
 

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   Button,
   ComboBox,
@@ -21,7 +22,6 @@ import {
   ValidationWrapper,
 } from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
-import userEvent from '@testing-library/user-event';
 
 describe('ValidationContainer', () => {
   it('renders passed data-tid on container', () => {

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import {
+  Button,
   ComboBox,
   DatePicker,
   FileUploader,
@@ -11,7 +12,14 @@ import {
   TokenInputType,
 } from '@skbkontur/react-ui';
 
-import { FocusMode, ValidationContainer, ValidationContainerProps, ValidationWrapper } from '../src';
+import {
+  FocusMode,
+  ValidationContainer,
+  ValidationContainerProps,
+  ValidationInfo,
+  ValidationsFeatureFlagsContext,
+  ValidationWrapper,
+} from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
 
 describe('ValidationContainer', () => {
@@ -23,6 +31,31 @@ describe('ValidationContainer', () => {
     );
 
     expect(screen.getByTestId('passed-container')).toBeInTheDocument();
+  });
+
+  it('renders passed data-tid on container when validationsRemoveExtraSpans enabled', () => {
+    render(
+      <ValidationsFeatureFlagsContext.Provider value={{ validationsRemoveExtraSpans: true }}>
+        <ValidationContainer data-tid="passed-container">
+          <div />
+        </ValidationContainer>
+      </ValidationsFeatureFlagsContext.Provider>,
+    );
+
+    expect(screen.getByTestId('passed-container')).toBeInTheDocument();
+  });
+
+  it('not renders passed data-tid on container when validationsRemoveExtraSpans enabled', () => {
+    render(
+      <ValidationsFeatureFlagsContext.Provider value={{ validationsRemoveExtraSpans: true }}>
+        <ValidationContainer data-tid="passed-container">
+          <div />
+          <div />
+        </ValidationContainer>
+      </ValidationsFeatureFlagsContext.Provider>,
+    );
+
+    expect(screen.queryByTestId('passed-container')).toBeNull();
   });
 
   it('renders passed children', () => {
@@ -126,6 +159,90 @@ describe('ValidationContainer', () => {
       await containerRef.current?.validate(false);
 
       expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+  });
+
+  describe('on validation updated', () => {
+    const renderValidationContainer = (
+      children: React.ReactElement,
+      props?: ValidationContainerProps,
+    ): React.RefObject<ValidationContainer> => {
+      const containerRef = React.createRef<ValidationContainer>();
+      render(
+        <ValidationContainer ref={containerRef} {...props}>
+          {children}
+        </ValidationContainer>,
+      );
+      return containerRef;
+    };
+    const validate = (value: string) => {
+      return value.includes('bad') ? ({ message: 'Ошибка', type: 'submit' } as ValidationInfo) : null;
+    };
+
+    it('works with one field', async () => {
+      const ValidationForm = () => {
+        const [value1, setValue1] = React.useState('bad');
+
+        return (
+          <>
+            <ValidationWrapper validationInfo={validate(value1)}>
+              <Input value={value1} onValueChange={setValue1} />
+            </ValidationWrapper>
+            <Button onClick={() => setValue1('good')}>Repair</Button>
+          </>
+        );
+      };
+
+      const onValidationUpdated = jest.fn();
+      const containerRef = renderValidationContainer(<ValidationForm />, { onValidationUpdated });
+      await containerRef.current?.submit();
+      const errors = await screen.findAllByText('Ошибка');
+      expect(errors.length).toBe(1);
+
+      screen.getByRole('button', { name: 'Repair' }).click();
+      expect(onValidationUpdated).toBeCalledWith(true);
+    });
+
+    it('works with multiple fields', async () => {
+      const ValidationForm = () => {
+        const [value1, setValue1] = React.useState('bad');
+        const [value2, setValue2] = React.useState('bad');
+        const validationContainerRef = React.useRef<ValidationContainer>(null);
+
+        return (
+          <>
+            <ValidationWrapper validationInfo={validate(value1)}>
+              <Input value={value1} onValueChange={setValue1} />
+            </ValidationWrapper>
+            <ValidationWrapper validationInfo={validate(value2)}>
+              <Input value={value2} onValueChange={setValue2} />
+            </ValidationWrapper>
+            <Button onClick={() => setValue1('good')}>Partial Repair</Button>
+            <Button
+              onClick={() => {
+                setValue1('good');
+                setValue2('good');
+              }}
+            >
+              Repair
+            </Button>
+            <Button onClick={() => validationContainerRef.current?.submit()}>Submit</Button>
+          </>
+        );
+      };
+
+      const onValidationUpdated = jest.fn();
+      const containerRef = renderValidationContainer(<ValidationForm />, { onValidationUpdated });
+      await containerRef.current?.submit();
+
+      const errors = await screen.findAllByText('Ошибка');
+      expect(errors.length).toBe(1);
+
+      screen.getByRole('button', { name: 'Partial Repair' }).click();
+      expect(onValidationUpdated).toBeCalledWith(false);
+
+      screen.getByRole('button', { name: 'Repair' }).click();
+      expect(onValidationUpdated).toBeCalledWith(true);
     });
   });
 });

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -21,6 +21,7 @@ import {
   ValidationWrapper,
 } from '../src';
 import { smoothScrollIntoView } from '../src/smoothScrollIntoView';
+import userEvent from '@testing-library/user-event';
 
 describe('ValidationContainer', () => {
   it('renders passed data-tid on container', () => {
@@ -43,19 +44,6 @@ describe('ValidationContainer', () => {
     );
 
     expect(screen.getByTestId('passed-container')).toBeInTheDocument();
-  });
-
-  it('not renders passed data-tid on container when validationsRemoveExtraSpans enabled', () => {
-    render(
-      <ValidationsFeatureFlagsContext.Provider value={{ validationsRemoveExtraSpans: true }}>
-        <ValidationContainer data-tid="passed-container">
-          <div />
-          <div />
-        </ValidationContainer>
-      </ValidationsFeatureFlagsContext.Provider>,
-    );
-
-    expect(screen.queryByTestId('passed-container')).toBeNull();
   });
 
   it('renders passed children', () => {
@@ -199,7 +187,7 @@ describe('ValidationContainer', () => {
       const errors = await screen.findAllByText('Ошибка');
       expect(errors.length).toBe(1);
 
-      screen.getByRole('button', { name: 'Repair' }).click();
+      await userEvent.click(screen.getByRole('button', { name: 'Repair' }));
       expect(onValidationUpdated).toBeCalledWith(true);
     });
 
@@ -238,10 +226,10 @@ describe('ValidationContainer', () => {
       const errors = await screen.findAllByText('Ошибка');
       expect(errors.length).toBe(1);
 
-      screen.getByRole('button', { name: 'Partial Repair' }).click();
+      await userEvent.click(screen.getByRole('button', { name: 'Partial Repair' }));
       expect(onValidationUpdated).toBeCalledWith(false);
 
-      screen.getByRole('button', { name: 'Repair' }).click();
+      await userEvent.click(screen.getByRole('button', { name: 'Repair' }));
       expect(onValidationUpdated).toBeCalledWith(true);
     });
   });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Если при проверке по нажатию submit несколько (2 и более) полей станут невалидными, а затем их значения исправятся программно, то событие onValidationUpdated не вызовется.
Но если поле одно, то всё работает.

## Решение

Вызов resolve внутри Promise теперь находится внутри коллбэка. Добавлены unit-тесты, проверяющие описанное поведение. В unit-тестах screen.getByRole(...).click() заменен на await userEvent.click(screen.getByRole(...)), так как иначе тесты падают.

## Ссылки

[IF-1719](https://yt.skbkontur.ru/issue/IF-1719/Validacii.-Esli-po-sabmitu-2-polej-stanut-nevalidnymi-to-programmnoe-ispravlenie-ne-vyzyvaet-onValidationUpdated)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
