### PR TITLE
docs(DatePicker,Calendar): remove period props

### DIFF
--- a/packages/react-ui/components/Calendar/Calendar.tsx
+++ b/packages/react-ui/components/Calendar/Calendar.tsx
@@ -54,18 +54,6 @@ export interface CalendarProps extends CommonProps {
    */
   minDate?: string;
   /**
-   * Задаёт начальную дату периода
-   *
-   * Дата задаётся в формате `dd.mm.yyyy`
-   */
-  periodStartDate?: string;
-  /**
-   * Задаёт конечную дату периода
-   *
-   * Дата задаётся в формате `dd.mm.yyyy`
-   */
-  periodEndDate?: string;
-  /**
    * Функция для определения праздничных дней
    * @default (_day, isWeekend) => isWeekend
    * @param {string} day - строка в формате `dd.mm.yyyy`

--- a/packages/react-ui/components/DatePicker/DatePicker.md
+++ b/packages/react-ui/components/DatePicker/DatePicker.md
@@ -274,20 +274,6 @@ class DatePickerFormatting extends React.Component {
 <DatePickerFormatting />;
 ```
 
-### Период дат
-Подбробный пример в [Calendar](#/Components/Calendar)
-
-```jsx harmony
-const [value, setValue] = React.useState('12.05.2022');
-
-<DatePicker
-  value={value}
-  onValueChange={setValue}
-  periodStartDate="16.05.2022"
-  periodEndDate="20.05.2022"
-/>;
-```
-
 ### Кастомный рендер дня
 Подбробный пример в [Calendar](#/Components/Calendar)
 

--- a/packages/react-ui/components/DatePicker/DatePicker.md
+++ b/packages/react-ui/components/DatePicker/DatePicker.md
@@ -278,12 +278,19 @@ class DatePickerFormatting extends React.Component {
 Подбробный пример в [Calendar](#/Components/Calendar)
 
 ```jsx harmony
+import { CalendarDay } from "@skbkontur/react-ui";
+
 const [value, setValue] = React.useState('12.05.2022');
 
-const renderDay = (date, defaultProps, RenderDefault) => {
-  const isEven = defaultProps.children % 2 === 0;
+const renderDay = (props) => {
+  const [date] = props.date.split('.').map(Number);
+  const isEven = date % 2 === 0;
 
-  return <RenderDefault {...defaultProps} isDisabled={isEven} />;
+  if (isEven) {
+    return <CalendarDay {...props} style={{ background: '#e9f8e3' }} />
+  }
+  
+  return <CalendarDay {...props} />
 };
 
 


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В рамках задачи [IF-87 Компонент выбора периода](https://yt.skbkontur.ru/issue/IF-87/Komponent-vybora-perioda) заметил, что в PR #3415 были удалены не все упоминания пропсов `periodStartDate` и `periodEndDate`

## Решение

- Починил пример с кастомными днями в `<DatePicker />` 
- Удалил пример из документации `<DatePicker />` 
- Удалил описание jsdoc props `periodStartDate` и `periodEndDate` в `<Calendar />`

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

- https://tech.skbkontur.ru/react-ui/#/Components/Calendar/Calendar
- [https://tech.skbkontur.ru/react-ui/#/Components/DatePicker](https://tech.skbkontur.ru/react-ui/#/Components/DatePicker:~:text=VIEW%20CODE-,%D0%9F%D0%B5%D1%80%D0%B8%D0%BE%D0%B4%20%D0%B4%D0%B0%D1%82,-%D0%9F%D0%BE%D0%B4%D0%B1%D1%80%D0%BE%D0%B1%D0%BD%D1%8B%D0%B9%20%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80%20%D0%B2)

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ✅ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
