### PR TITLE
fix: program validation on multi fields IF-1719

### DIFF
--- a/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
+++ b/packages/react-ui-validations/src/ValidationWrapperInternal.tsx
@@ -248,10 +248,12 @@ export class ValidationWrapperInternal extends React.Component<
     }
 
     return new Promise((resolve) => {
-      this.setState({ validation }, resolve);
-      if (Boolean(current) !== Boolean(validation)) {
-        this.context.onValidationUpdated(this, !validation);
-      }
+      this.setState({ validation }, () => {
+        if (Boolean(current) !== Boolean(validation)) {
+          this.context.onValidationUpdated(this, !validation);
+        }
+        resolve();
+      });
     });
   }
 

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -188,7 +188,7 @@ describe('ValidationContainer', () => {
             <ValidationWrapper validationInfo={validate(value1)}>
               <Input value={value1} onValueChange={setValue1} />
             </ValidationWrapper>
-            <Button onClick={() => setValue1('good')}>Repair</Button>
+            <button onClick={() => setValue1('good')}>Repair</button>
           </>
         );
       };
@@ -196,8 +196,7 @@ describe('ValidationContainer', () => {
       const onValidationUpdated = jest.fn();
       const containerRef = renderValidationContainer(<ValidationForm />, { onValidationUpdated });
       await containerRef.current?.submit();
-      const errors = await screen.findAllByText('Ошибка');
-      expect(errors.length).toBe(1);
+      expect(onValidationUpdated).toBeCalledWith(false);
 
       screen.getByRole('button', { name: 'Repair' }).click();
       expect(onValidationUpdated).toBeCalledWith(true);
@@ -217,15 +216,15 @@ describe('ValidationContainer', () => {
             <ValidationWrapper validationInfo={validate(value2)}>
               <Input value={value2} onValueChange={setValue2} />
             </ValidationWrapper>
-            <Button onClick={() => setValue1('good')}>Partial Repair</Button>
-            <Button
+            <button onClick={() => setValue1('good')}>Partial Repair</button>
+            <button
               onClick={() => {
                 setValue1('good');
                 setValue2('good');
               }}
             >
               Repair
-            </Button>
+            </button>
             <Button onClick={() => validationContainerRef.current?.submit()}>Submit</Button>
           </>
         );
@@ -235,8 +234,7 @@ describe('ValidationContainer', () => {
       const containerRef = renderValidationContainer(<ValidationForm />, { onValidationUpdated });
       await containerRef.current?.submit();
 
-      const errors = await screen.findAllByText('Ошибка');
-      expect(errors.length).toBe(1);
+      expect(onValidationUpdated).toBeCalledWith(false);
 
       screen.getByRole('button', { name: 'Partial Repair' }).click();
       expect(onValidationUpdated).toBeCalledWith(false);

--- a/packages/react-ui-validations/tests/ValidationContainer.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationContainer.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import {
+  Button,
   ComboBox,
   DatePicker,
   FileUploader,
@@ -15,6 +16,7 @@ import {
   FocusMode,
   ValidationContainer,
   ValidationContainerProps,
+  ValidationInfo,
   ValidationsFeatureFlagsContext,
   ValidationWrapper,
 } from '../src';
@@ -157,6 +159,90 @@ describe('ValidationContainer', () => {
       await containerRef.current?.validate(false);
 
       expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+  });
+
+  describe('on validation updated', () => {
+    const renderValidationContainer = (
+      children: React.ReactElement,
+      props?: ValidationContainerProps,
+    ): React.RefObject<ValidationContainer> => {
+      const containerRef = React.createRef<ValidationContainer>();
+      render(
+        <ValidationContainer ref={containerRef} {...props}>
+          {children}
+        </ValidationContainer>,
+      );
+      return containerRef;
+    };
+    const validate = (value: string) => {
+      return value.includes('bad') ? ({ message: 'Ошибка', type: 'submit' } as ValidationInfo) : null;
+    };
+
+    it('works with one field', async () => {
+      const ValidationForm = () => {
+        const [value1, setValue1] = React.useState('bad');
+
+        return (
+          <>
+            <ValidationWrapper validationInfo={validate(value1)}>
+              <Input value={value1} onValueChange={setValue1} />
+            </ValidationWrapper>
+            <Button onClick={() => setValue1('good')}>Repair</Button>
+          </>
+        );
+      };
+
+      const onValidationUpdated = jest.fn();
+      const containerRef = renderValidationContainer(<ValidationForm />, { onValidationUpdated });
+      await containerRef.current?.submit();
+      const errors = await screen.findAllByText('Ошибка');
+      expect(errors.length).toBe(1);
+
+      screen.getByRole('button', { name: 'Repair' }).click();
+      expect(onValidationUpdated).toBeCalledWith(true);
+    });
+
+    it('works with multiple fields', async () => {
+      const ValidationForm = () => {
+        const [value1, setValue1] = React.useState('bad');
+        const [value2, setValue2] = React.useState('bad');
+        const validationContainerRef = React.useRef<ValidationContainer>(null);
+
+        return (
+          <>
+            <ValidationWrapper validationInfo={validate(value1)}>
+              <Input value={value1} onValueChange={setValue1} />
+            </ValidationWrapper>
+            <ValidationWrapper validationInfo={validate(value2)}>
+              <Input value={value2} onValueChange={setValue2} />
+            </ValidationWrapper>
+            <Button onClick={() => setValue1('good')}>Partial Repair</Button>
+            <Button
+              onClick={() => {
+                setValue1('good');
+                setValue2('good');
+              }}
+            >
+              Repair
+            </Button>
+            <Button onClick={() => validationContainerRef.current?.submit()}>Submit</Button>
+          </>
+        );
+      };
+
+      const onValidationUpdated = jest.fn();
+      const containerRef = renderValidationContainer(<ValidationForm />, { onValidationUpdated });
+      await containerRef.current?.submit();
+
+      const errors = await screen.findAllByText('Ошибка');
+      expect(errors.length).toBe(1);
+
+      screen.getByRole('button', { name: 'Partial Repair' }).click();
+      expect(onValidationUpdated).toBeCalledWith(false);
+
+      screen.getByRole('button', { name: 'Repair' }).click();
+      expect(onValidationUpdated).toBeCalledWith(true);
     });
   });
 });

--- a/packages/react-ui/components/Calendar/Calendar.tsx
+++ b/packages/react-ui/components/Calendar/Calendar.tsx
@@ -54,18 +54,6 @@ export interface CalendarProps extends CommonProps {
    */
   minDate?: string;
   /**
-   * Задаёт начальную дату периода
-   *
-   * Дата задаётся в формате `dd.mm.yyyy`
-   */
-  periodStartDate?: string;
-  /**
-   * Задаёт конечную дату периода
-   *
-   * Дата задаётся в формате `dd.mm.yyyy`
-   */
-  periodEndDate?: string;
-  /**
    * Функция для определения праздничных дней
    * @default (_day, isWeekend) => isWeekend
    * @param {string} day - строка в формате `dd.mm.yyyy`

--- a/packages/react-ui/components/DatePicker/DatePicker.md
+++ b/packages/react-ui/components/DatePicker/DatePicker.md
@@ -274,30 +274,23 @@ class DatePickerFormatting extends React.Component {
 <DatePickerFormatting />;
 ```
 
-### Период дат
-Подбробный пример в [Calendar](#/Components/Calendar)
-
-```jsx harmony
-const [value, setValue] = React.useState('12.05.2022');
-
-<DatePicker
-  value={value}
-  onValueChange={setValue}
-  periodStartDate="16.05.2022"
-  periodEndDate="20.05.2022"
-/>;
-```
-
 ### Кастомный рендер дня
 Подбробный пример в [Calendar](#/Components/Calendar)
 
 ```jsx harmony
+import { CalendarDay } from "@skbkontur/react-ui";
+
 const [value, setValue] = React.useState('12.05.2022');
 
-const renderDay = (date, defaultProps, RenderDefault) => {
-  const isEven = defaultProps.children % 2 === 0;
+const renderDay = (props) => {
+  const [date] = props.date.split('.').map(Number);
+  const isEven = date % 2 === 0;
 
-  return <RenderDefault {...defaultProps} isDisabled={isEven} />;
+  if (isEven) {
+    return <CalendarDay {...props} style={{ background: '#e9f8e3' }} />
+  }
+  
+  return <CalendarDay {...props} />
 };
 
 


### PR DESCRIPTION
Предыдущий PR (3450) был закрыт, так как вливание было в ветку с будущей мажорной версией 5.х, а изменение -- не ломающее, а фикс бага.

## Проблема

Если при проверке по нажатию submit несколько (2 и более) полей станут невалидными, а затем их значения исправятся программно, то событие onValidationUpdated не вызовется.
Но если поле одно, то всё работает.

## Решение

Вызов resolve внутри Promise теперь находится внутри коллбэка. Добавлены unit-тесты, проверяющие описанное поведение. В unit-тестах screen.getByRole(...).click() заменен на await userEvent.click(screen.getByRole(...)), так как иначе тесты падают.

## Ссылки

[IF-1719](https://yt.skbkontur.ru/issue/IF-1719/Validacii.-Esli-po-sabmitu-2-polej-stanut-nevalidnymi-to-programmnoe-ispravlenie-ne-vyzyvaet-onValidationUpdated)
[Предыдущий PR](https://github.com/skbkontur/retail-ui/pull/3450)

## Чек-лист перед запросом ревью

Добавлены тесты на все изменения
✅ unit-тесты для логики
⬜ скриншоты для верстки и кросс-браузерности
⬜ нерелевантно

Добавлена (обновлена) документация
⬜ styleguidist для пропов и примеров использования компонентов
⬜ jsdoc для утилит и хелперов
⬜ комментарии для неочевидных мест в коде
⬜ прочие инструкции (README.md, contributing.md и др.)
✅ нерелевантно

Изменения корректно типизированы
✅ без использования any (см. PR 2856)
⬜ нерелевантно

Прочее
✅ все тесты и линтеры на CI проходят
✅ в коде нет лишних изменений
✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)