### PR TITLE
docs(Button): add example with narrow, warning, error

### DIFF
--- a/packages/react-ui-validations/CHANGELOG.md
+++ b/packages/react-ui-validations/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.16.0](https://github.com/skbkontur/retail-ui/tree/master/packages/react-ui-validations/compare/react-ui-validations@1.15.1...react-ui-validations@1.16.0) (2024-06-17)
+
+
+### Features
+
+* **validations:** use `ThemeContext` ([#3446](https://github.com/skbkontur/retail-ui/tree/master/packages/react-ui-validations/issues/3446)) ([74fd90b](https://github.com/skbkontur/retail-ui/tree/master/packages/react-ui-validations/commit/74fd90b337968eed217a478bf913e6ce2f7fe962))
+
+
+
+
+
 ## [1.15.1](https://github.com/skbkontur/retail-ui/tree/master/packages/react-ui-validations/compare/react-ui-validations@1.15.0...react-ui-validations@1.15.1) (2024-05-22)
 
 

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ui-validations",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Validations for @skbkontur/react-ui",
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/react-ui/CHANGELOG.md
+++ b/packages/react-ui/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.25.1](https://github.com/skbkontur/retail-ui/compare/@skbkontur/react-ui@4.25.0...@skbkontur/react-ui@4.25.1) (2024-06-17)
+
+**Note:** Version bump only for package @skbkontur/react-ui
+
+
+
+
+
+# [4.25.0](https://github.com/skbkontur/retail-ui/compare/@skbkontur/react-ui@4.24.0...@skbkontur/react-ui@4.25.0) (2024-06-17)
+
+
+### Features
+
+* update colors 2024 ([#3447](https://github.com/skbkontur/retail-ui/issues/3447)) ([85dd419](https://github.com/skbkontur/retail-ui/commit/85dd41988a9ceca49815560e38d3ed6f5c25db96))
+* **validations:** use `ThemeContext` ([#3446](https://github.com/skbkontur/retail-ui/issues/3446)) ([74fd90b](https://github.com/skbkontur/retail-ui/commit/74fd90b337968eed217a478bf913e6ce2f7fe962))
+
+
+
+
+
 # [4.24.0](https://github.com/skbkontur/retail-ui/compare/@skbkontur/react-ui@4.23.0...@skbkontur/react-ui@4.24.0) (2024-06-05)
 
 

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -212,3 +212,14 @@ const renderExampleRow = (title, styles, index) => {
   {renderExampleRow('Изменение цвета ссылки', differentColorStyles)}
 </table>
 ```
+
+
+Кнопка может быть узкой
+
+```jsx harmony
+import { Button } from '@skbkontur/react-ui';
+
+<Button narrow>
+  Создать отчет
+</Button>
+```

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -223,3 +223,19 @@ import { Button } from '@skbkontur/react-ui';
   Создать отчет
 </Button>
 ```
+
+
+У кнопки есть состояния валидации
+
+```jsx harmony
+import { Gapped, Button } from '@skbkontur/react-ui';
+
+<Gapped gap={5}>
+  <Button warning>
+    Warning
+  </Button>
+  <Button error>
+    Error
+  </Button>
+</Gapped>
+```

--- a/packages/react-ui/index.ts
+++ b/packages/react-ui/index.ts
@@ -55,6 +55,8 @@ export * from './lib/theming/themes/DefaultTheme8pxOld';
 export * from './lib/theming/themes/FlatTheme8pxOld';
 export * from './lib/theming/themes/Theme2022';
 export * from './lib/theming/themes/Theme2022Dark';
+export * from './lib/theming/themes/Theme2022Update2024';
+export * from './lib/theming/themes/Theme2022DarkUpdate2024';
 export * from './lib/types/props';
 export * from './internal/Popup/types';
 export * as ColorFunctions from './lib/styles/ColorFunctions';

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skbkontur/react-ui",
-  "version": "4.24.0",
+  "version": "4.25.1",
   "description": "UI Components",
   "main": "cjs/index.js",
   "module": "index.js",


### PR DESCRIPTION
## Проблема

В виду отсутствия примера использования узкой кнопки и показа состояния валидации, пользователь может не знать о такой возможности

## Решение

Добавил примеры использования

## Ссылки


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
