### PR TITLE
docs(Button): add example with narrow, warning, error

### DIFF
--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -228,7 +228,7 @@ import { Button } from '@skbkontur/react-ui';
 У кнопки есть состояния валидации.
 
 ```jsx harmony
-import { Gapped, Button } from '@skbkontur/react-ui';
+import { Button, Gapped } from '@skbkontur/react-ui';
 
 <Gapped gap={5}>
   <Button warning>

--- a/packages/react-ui/components/Button/Button.md
+++ b/packages/react-ui/components/Button/Button.md
@@ -60,15 +60,15 @@ import { XIcon16Regular } from '@skbkontur/icons/XIcon16Regular';
 
 ```jsx harmony
 <div
-    style={{
-      display: "flex",
-      alignItems: "end",
-      gap: '10px',
-    }}
-  >
-    <Button size="small">Маленькая</Button>
-    <Button size="medium">Средняя</Button>
-    <Button size="large">Большая</Button>
+  style={{
+    display: "flex",
+    alignItems: "end",
+    gap: '10px',
+  }}
+>
+  <Button size="small">Маленькая</Button>
+  <Button size="medium">Средняя</Button>
+  <Button size="large">Большая</Button>
 </div>
 ```
 
@@ -133,7 +133,7 @@ const handleClick = () => {
 
 ```
 
-Пример кнопки с пропом `theme`
+Пример кнопки с пропом `theme`.
 
 ```jsx harmony
 import { Button, Gapped } from '@skbkontur/react-ui';
@@ -146,7 +146,7 @@ import { Button, Gapped } from '@skbkontur/react-ui';
 ```
 
 
-Пример кастомизации кнопки-ссылки
+Пример кастомизации кнопки-ссылки.
 
 ```jsx harmony
 import { Toast } from "@skbkontur/react-ui";
@@ -211,4 +211,31 @@ const renderExampleRow = (title, styles, index) => {
   {renderExampleRow('Ссылка с подчеркиванием при наведении', underlineOnHoverStyles)}
   {renderExampleRow('Изменение цвета ссылки', differentColorStyles)}
 </table>
+```
+
+
+Кнопка может быть узкой.
+
+```jsx harmony
+import { Button } from '@skbkontur/react-ui';
+
+<Button narrow>
+  Создать отчет
+</Button>
+```
+
+
+У кнопки есть состояния валидации.
+
+```jsx harmony
+import { Gapped, Button } from '@skbkontur/react-ui';
+
+<Gapped gap={5}>
+  <Button warning>
+    Warning
+  </Button>
+  <Button error>
+    Error
+  </Button>
+</Gapped>
 ```


### PR DESCRIPTION
## Проблема

В виду отсутствия примера использования узкой кнопки и показа состояния валидации, пользователь может не знать о такой возможности

## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

Добавил примеры использования

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
