### PR TITLE
docs(Autocomplete): add examples

### DIFF
--- a/packages/react-ui/components/Autocomplete/Autocomplete.md
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.md
@@ -1,4 +1,6 @@
 ```jsx harmony
+import { Autocomplete } from '@skbkontur/react-ui';
+
 const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
 
 const [value, setValue] = React.useState('Kappa');
@@ -6,9 +8,9 @@ const [value, setValue] = React.useState('Kappa');
 <Autocomplete source={items} value={value} onValueChange={setValue} />;
 ```
 
-Очистить значение в `Autocomplete` можно только с помощью пустой строки
+Очистить значение в `Autocomplete` можно только с помощью пустой строки.
 ```jsx harmony
-import { Button, Group } from '@skbkontur/react-ui';
+import { Autocomplete, Button, Group } from '@skbkontur/react-ui';
 
 const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
 
@@ -22,7 +24,7 @@ const [value, setValue] = React.useState('Kappa');
 
 У Autocomplete есть 3 стандартных размера.
 ```jsx harmony
-import { Gapped } from '@skbkontur/react-ui';
+import { Autocomplete, Gapped } from '@skbkontur/react-ui';
 
 const items = ['Маленький', 'Средний', 'Большой'];
 
@@ -35,4 +37,75 @@ const [valueLarge, setValueLarge] = React.useState('Большой');
   <Autocomplete source={items} value={valueMedium} onValueChange={setValueMedium} size={'medium'} />
   <Autocomplete source={items} value={valueLarge} onValueChange={setValueLarge} size={'large'} />
 </Gapped>
+```
+
+Можно выделять введеное значение при фокусе.
+```jsx harmony
+import { Autocomplete } from '@skbkontur/react-ui';
+
+const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
+
+const [value, setValue] = React.useState('');
+
+<Autocomplete source={items} value={value} onValueChange={setValue} selectAllOnFocus />
+```
+
+Расположение иконки слева и справа.
+```jsx harmony
+import { Autocomplete, Gapped } from '@skbkontur/react-ui';
+import { SearchLoupeIcon16Regular } from '@skbkontur/icons/SearchLoupeIcon16Regular';
+
+const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
+
+const [valueLeft, setValueLeft] = React.useState('');
+const [valueRight, setValueRight] = React.useState('');
+
+<Gapped>
+  <Autocomplete source={items} value={valueLeft} onValueChange={setValueLeft} leftIcon={<SearchLoupeIcon16Regular />} />
+  <Autocomplete source={items} value={valueRight} onValueChange={setValueRight} rightIcon={<SearchLoupeIcon16Regular />} />
+</Gapped>
+```
+
+Изменение ширины меню.
+```jsx harmony
+import { Autocomplete } from '@skbkontur/react-ui';
+
+const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
+
+const [value, setValue] = React.useState('');
+
+<Autocomplete source={items} value={value} onValueChange={setValue} menuWidth={'80%'} />
+```
+
+Расположение выпадающего окна Autocomplete.
+```jsx harmony
+import { Autocomplete } from '@skbkontur/react-ui';
+
+const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
+
+const [value, setValue] = React.useState('');
+
+<Autocomplete source={items} value={value} onValueChange={setValue} menuPos={'top'} />
+```
+
+Отрисовка тени у выпадающего меню.
+```jsx harmony
+import { Autocomplete } from '@skbkontur/react-ui';
+
+const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
+
+const [value, setValue] = React.useState('');
+
+<Autocomplete source={items} value={value} onValueChange={setValue} hasShadow />
+```
+
+Использование режима прозрачной рамки.
+```jsx harmony
+import { Autocomplete } from '@skbkontur/react-ui';
+
+const items = ['Grey Face', 'Grey Space', 'Kappa', 'Keepo', 'Resident Sleeper'];
+
+const [value, setValue] = React.useState('Kappa');
+
+<Autocomplete source={items} value={value} onValueChange={setValue} borderless />
 ```


### PR DESCRIPTION
## Проблема

В виду отсутствия примера использования компонента с использованием props (selectAllOnFocus, leftIcon и rightIcon, menuWidth, menuPos, hasShadow, borderless), пользователь может не знать о такой возможности

## Решение

Добавил примеры использования

## Ссылки

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
