### PR TITLE
fix(): add modifier -? to NonNullableRecursive type

### DIFF
--- a/packages/react-ui-validations/src/Validations/PathHelper.ts
+++ b/packages/react-ui-validations/src/Validations/PathHelper.ts
@@ -2,11 +2,15 @@ const classicFunctionRegEx =
   /^\s*function\s*\(\s*([A-Za-z0-9_$]+)\s*\)\s*\{\s*(?:(?:"use strict"|'use strict');?)?\s*return\s+\1\s*([.[].*?)?\s*;?\s*\}\s*$/;
 const arrowFunctionRegEx = /^\s*\(?\s*([A-Za-z0-9_$]+)\s*\)?\s*=>\s*\1\s*([.[].*?)?\s*$/;
 
+type OldNonNullable<T> = T extends null | undefined ? never : T; // необходим для имитации старой версии NonNullable (до v5.5.3 typescript)
+
 type NonNullableRecursive<T> = {
-  [K in keyof T]: T[K] extends Record<string, unknown> ? NonNullable<NonNullableRecursive<T[K]>> : NonNullable<T[K]>;
+  [K in keyof T]: T[K] extends Record<string, unknown>
+    ? OldNonNullable<NonNullableRecursive<T[K]>>
+    : OldNonNullable<T[K]>;
 };
 
-export type LambdaPath<T, TChild> = (x: NonNullable<NonNullableRecursive<T>>) => TChild;
+export type LambdaPath<T, TChild> = (x: OldNonNullable<NonNullableRecursive<T>>) => TChild;
 
 export function extractPath(lambda: string): string {
   const match = classicFunctionRegEx.exec(lambda) || arrowFunctionRegEx.exec(lambda);

--- a/packages/react-ui-validations/src/Validations/PathHelper.ts
+++ b/packages/react-ui-validations/src/Validations/PathHelper.ts
@@ -2,15 +2,11 @@ const classicFunctionRegEx =
   /^\s*function\s*\(\s*([A-Za-z0-9_$]+)\s*\)\s*\{\s*(?:(?:"use strict"|'use strict');?)?\s*return\s+\1\s*([.[].*?)?\s*;?\s*\}\s*$/;
 const arrowFunctionRegEx = /^\s*\(?\s*([A-Za-z0-9_$]+)\s*\)?\s*=>\s*\1\s*([.[].*?)?\s*$/;
 
-type OldNonNullable<T> = T extends null | undefined ? never : T; // необходим для имитации старой версии NonNullable (до v5.5.3 typescript)
-
 type NonNullableRecursive<T> = {
-  [K in keyof T]: T[K] extends Record<string, unknown>
-    ? OldNonNullable<NonNullableRecursive<T[K]>>
-    : OldNonNullable<T[K]>;
+  [K in keyof T]-?: T[K] extends Record<string, unknown> ? NonNullable<NonNullableRecursive<T[K]>> : NonNullable<T[K]>;
 };
 
-export type LambdaPath<T, TChild> = (x: OldNonNullable<NonNullableRecursive<T>>) => TChild;
+export type LambdaPath<T, TChild> = (x: NonNullable<NonNullableRecursive<T>>) => TChild;
 
 export function extractPath(lambda: string): string {
   const match = classicFunctionRegEx.exec(lambda) || arrowFunctionRegEx.exec(lambda);

--- a/packages/react-ui-validations/tests/Validator.test.ts
+++ b/packages/react-ui-validations/tests/Validator.test.ts
@@ -259,4 +259,23 @@ describe('Validator', () => {
     expect(itemRule).toHaveBeenNthCalledWith(2, 'yyy', 1, ['xxx', 'yyy', 'zzz']);
     expect(itemRule).toHaveBeenNthCalledWith(3, 'zzz', 2, ['xxx', 'yyy', 'zzz']);
   });
+
+  it('should not appear compile error', () => {
+    interface TypeWithOptionalProps {
+      innerOptionalField?: string;
+    }
+
+    const validator = createValidator<{ optionalField?: TypeWithOptionalProps }>((b) => {
+      b.prop(
+        (x) => x.optionalField,
+        (optionalFieldBuilder) => {
+          optionalFieldBuilder.prop(
+            (optionalField) => optionalField.innerOptionalField,
+            (prop) => prop.invalid((v) => !v, '123', 'lostfocus'),
+          );
+        },
+      );
+    });
+    expect(validator).not.toBe(null);
+  });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьюторов можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

По гайдам [узел может содержать null или undefined](https://tech.skbkontur.ru/react-ui-validations/#/missing-nodes) , но в случае когда узел содержит опциональный параметр в типе, возникает ошибка.

## Решение

Это hot-fix для задачи [IF-1828](https://yt.skbkontur.ru/issue/IF-1828/Validator-Obnovit-ispolzovanie-tipa-NonNullable)
Добавили модификатор `-?` 

## Ссылки

Задача: [IF-1828](https://yt.skbkontur.ru/issue/IF-1828/Validator-Obnovit-ispolzovanie-tipa-NonNullable)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
