### PR TITLE
fix(Loader): fix Loader in 18 react

### DIFF
--- a/packages/react-ui/lib/taskWithDelayAndMinimalDuration.ts
+++ b/packages/react-ui/lib/taskWithDelayAndMinimalDuration.ts
@@ -77,6 +77,7 @@ export class TaskWithDelayAndMinimalDuration {
   };
 
   public clearTask = () => {
+    this.isTaskActive = false;
     this.clearTimeoutBeforeTaskStart();
     this.clearTimeoutBeforeTaskStop();
   };


### PR DESCRIPTION
## Проблема

Если Лоадер активен при маунте, то в 18 реакте не отображается спинер. [Песочница](https://codesandbox.io/p/sandbox/auto-components-d8qjks?file=%2Fpackage.json) 

## Решение

Решение нашел Эдуард в веточке IF-1780, решили продублировать в мастер так как это баг.
Причина: в 18 реакте компонент рендерится дважды:
при первом маунте вызывается `this.spinnerTask.start()`, которая запускает лоадер (и сетит isTaskActive в true)
Затем компонент анмаунтится.
При повторном маунте в методе старт проверяется что лоадер еще не запущен:

```
 if (this.isTaskActive) {
      return;
    }
```

    
а так как мы при анмаунте не сбросили переменную `isTaskActive` в `false`, то выполение прерывается и спинер не показывается. 
    Решение простое - при анмаунте устанавливать `isTaskActive` в `false`

## Ссылки

fix IF-1825

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
