### PR TITLE
fix(Select): pass disabled in _renderButton, add visual attributes

### DIFF
--- a/packages/react-ui/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react-ui/components/RadioGroup/RadioGroup.tsx
@@ -11,6 +11,7 @@ import { Theme } from '../../lib/theming/Theme';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
+import { getVisualStateDataAttributes } from '../../internal/CommonWrapper/utils/getVisualStateDataAttributes';
 
 import { styles } from './RadioGroup.styles';
 import { Prevent } from './Prevent';
@@ -154,7 +155,15 @@ export class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGrou
   }
 
   public renderMain() {
-    const { width, onMouseLeave, onMouseOver, onMouseEnter, onBlur, 'aria-describedby': ariaDescribedby } = this.props;
+    const {
+      width,
+      onMouseLeave,
+      onMouseOver,
+      onMouseEnter,
+      onBlur,
+      'aria-describedby': ariaDescribedby,
+      disabled,
+    } = this.props;
     const style = {
       width: width ?? 'auto',
     };
@@ -165,7 +174,7 @@ export class RadioGroup<T> extends React.Component<RadioGroupProps<T>, RadioGrou
     };
 
     return (
-      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
+      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props} {...getVisualStateDataAttributes({ disabled })}>
         <FocusTrap onBlur={onBlur}>
           <span
             data-tid={RadioGroupDataTids.root}

--- a/packages/react-ui/components/RadioGroup/__tests__/RadioGroup-test.tsx
+++ b/packages/react-ui/components/RadioGroup/__tests__/RadioGroup-test.tsx
@@ -303,4 +303,10 @@ describe('<RadioGroup />', () => {
     expect(radioGroup).toHaveAttribute('aria-describedby', 'elementRadioGroupId');
     expect(radioGroup).toHaveAccessibleDescription('Description Radio group');
   });
+
+  it('should have visual state disabled attribute', () => {
+    render(<RadioGroup items={['one', 'two']} disabled />);
+
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('data-visual-state-disabled');
+  });
 });

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -368,6 +368,7 @@ export class Select<TValue = {}, TItem = {}> extends React.Component<SelectProps
       onClick: this.toggle,
       onKeyDown: this.handleKey,
       size: this.getProps().size,
+      disabled: this.getProps().disabled,
     };
 
     return buttonParams;

--- a/packages/react-ui/components/Select/__tests__/Select-test.tsx
+++ b/packages/react-ui/components/Select/__tests__/Select-test.tsx
@@ -304,6 +304,12 @@ describe('Select', () => {
 
       expect(screen.getByRole('button')).toHaveAttribute('aria-label', ariaLabel);
     });
+
+    it('sets value disabled `_renderButton` is passed', () => {
+      render(<Select disabled _renderButton={(params) => <button {...params}>test</button>} />);
+
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
   });
 
   describe('Locale', () => {

--- a/packages/react-ui/components/Token/Token.tsx
+++ b/packages/react-ui/components/Token/Token.tsx
@@ -12,6 +12,7 @@ import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { CloseButtonIcon } from '../../internal/CloseButtonIcon/CloseButtonIcon';
 import { SizeProp } from '../../lib/types/props';
 import { reactGetTextContent } from '../../lib/reactGetTextContent';
+import { getVisualStateDataAttributes } from '../../internal/CommonWrapper/utils/getVisualStateDataAttributes';
 
 import { styles, colorStyles } from './Token.styles';
 import { TokenLocale, TokenLocaleHelper } from './locale';
@@ -154,7 +155,7 @@ export class Token extends React.Component<TokenProps> {
     );
 
     return (
-      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
+      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props} {...getVisualStateDataAttributes({ disabled })}>
         <TokenView
           className={classNames}
           size={size}

--- a/packages/react-ui/components/Token/__tests__/Token-test.tsx
+++ b/packages/react-ui/components/Token/__tests__/Token-test.tsx
@@ -127,5 +127,11 @@ describe('Token', () => {
 
       expect(screen.getByRole('button')).toHaveAttribute('aria-label', TokenLocalesRu.removeButtonAriaLabel + ' ');
     });
+
+    it('should have visual state disabled attribute', () => {
+      render(<Token disabled />);
+
+      expect(screen.getByTestId(TokenDataTids.root)).toHaveAttribute('data-visual-state-disabled');
+    });
   });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Пришел Женя Иванов, с проблемой, что сложно тестировать компоненты RadioGroup, Select, Token
Сложно понять задисаблен ли контрол.

Еще заметили баг что в Select при использовании _renderButton не прокидывается disabled проп

<!-- Подробно опиши решаемую проблему. -->

## Решение

Добавили визуальные атрибуты, прокинули disabled
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
