### PR TITLE
fix(Calendar,DatePicker): use human month format in scrollToMonth()

### DIFF
--- a/packages/react-ui/components/Calendar/Calendar.md
+++ b/packages/react-ui/components/Calendar/Calendar.md
@@ -197,3 +197,39 @@ const en_GB = {
   dayCellChooseDateAriaLabel: 'Выбрать дату',
 };
 ```
+
+
+### Скролл к месяцу
+
+```jsx harmony
+import { Button, Gapped } from '@skbkontur/react-ui';
+
+const initialValue = "02.09.2023";
+const [value, setValue] = React.useState(initialValue);
+const calendarRef = React.useRef(null);
+
+<>
+  <Gapped gap={8} verticalAlign="top">
+    <Calendar
+      value={value}
+      ref={calendarRef}
+      onValueChange={setValue}
+    />
+    
+    <Gapped vertical gap={8}>
+      <Button onClick={() => calendarRef.current.scrollToMonth(1, 2023)}>
+        I квартал
+      </Button>
+      <Button onClick={() => calendarRef.current.scrollToMonth(4, 2023)}>
+        II квартал
+      </Button>
+      <Button onClick={() => calendarRef.current.scrollToMonth(7, 2023)}>
+        III квартал
+      </Button>
+      <Button onClick={() => calendarRef.current.scrollToMonth(10, 2023)}>
+        IV квартал
+      </Button>
+    </Gapped>
+  </Gapped>
+</>;
+```

--- a/packages/react-ui/components/Calendar/Calendar.tsx
+++ b/packages/react-ui/components/Calendar/Calendar.tsx
@@ -187,7 +187,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     const { value, onMonthChange } = this.props;
     if (value && !shallowEqual(value, prevProps.value)) {
       const date = new InternalDate().parseValue(value).getComponentsLikeNumber();
-      this.scrollToMonth(date.month - 1, date.year);
+      this.scrollToMonth(date.month, date.year);
     }
 
     if (onMonthChange) {
@@ -224,6 +224,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
    * @public
    */
   public scrollToMonth = async (month: number, year: number) => {
+    const monthNative = CalendarUtils.getMonthInNativeFormat(month);
+
     if (this.animation.inProgress()) {
       this.animation.finish();
       // FIXME: Dirty hack to await batched updates
@@ -233,18 +235,20 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     const minDate = this.getDateInNativeFormat(this.getProps().minDate);
     const maxDate = this.getDateInNativeFormat(this.getProps().maxDate);
 
-    if (minDate && isGreater(minDate, create(32, month, year))) {
-      this.scrollToMonth(minDate.month, minDate.year);
+    if (minDate && isGreater(minDate, create(32, monthNative, year))) {
+      const minMonth = CalendarUtils.getMonthInHumanFormat(minDate.month);
+      this.scrollToMonth(minMonth, minDate.year);
       return;
     }
 
-    if (maxDate && isLess(maxDate, create(0, month, year))) {
-      this.scrollToMonth(maxDate.month, maxDate.year);
+    if (maxDate && isLess(maxDate, create(0, monthNative, year))) {
+      const maxMonth = CalendarUtils.getMonthInHumanFormat(maxDate.month);
+      this.scrollToMonth(maxMonth, maxDate.year);
       return;
     }
 
     const currentMonth = this.state.months[1];
-    const diffInMonths = currentMonth.month + currentMonth.year * 12 - month - year * 12;
+    const diffInMonths = currentMonth.month + currentMonth.year * 12 - monthNative - year * 12;
 
     if (diffInMonths === 0) {
       this.scrollTo(0);
@@ -255,7 +259,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
     const onEnd = () => {
       this.setState({
-        months: CalendarUtils.getMonths(month, year),
+        months: CalendarUtils.getMonths(monthNative, year),
         scrollPosition: 0,
       });
     };
@@ -275,7 +279,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     if (diffInMonths > 0) {
       const monthsToPrependCount = Math.min(Math.abs(diffInMonths) - 1, maxMonthsToAdd);
       const monthsToPrepend = Array.from({ length: monthsToPrependCount }, (_, index) => {
-        return MonthViewModel.create(month + index, year);
+        return MonthViewModel.create(monthNative + index, year);
       });
       this.setState(
         (state) => {
@@ -306,7 +310,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     if (diffInMonths < 0) {
       const monthsToAppendCount = Math.min(Math.abs(diffInMonths), maxMonthsToAdd);
       const monthsToAppend = Array.from({ length: monthsToAppendCount }, (_, index) => {
-        return MonthViewModel.create(month + index - monthsToAppendCount + 2, year);
+        return MonthViewModel.create(monthNative + index - monthsToAppendCount + 2, year);
       });
       this.setState(
         (state) => {
@@ -430,7 +434,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
       .filter(([top, month]) => CalendarUtils.isMonthVisible(top, month, this.theme));
   }
 
-  private handleMonthYearChange = (month: number, year: number) => {
+  private handleMonthYearChange = (monthNative: number, year: number) => {
+    const month = CalendarUtils.getMonthInHumanFormat(monthNative);
     this.scrollToMonth(month, year);
   };
 

--- a/packages/react-ui/components/Calendar/Month.tsx
+++ b/packages/react-ui/components/Calendar/Month.tsx
@@ -15,7 +15,7 @@ import { styles as cellStyles } from './DayCellView.styles';
 interface MonthProps {
   top: number;
   month: MonthViewModel;
-  onMonthYearChange: (month: number, year: number) => void;
+  onMonthYearChange: (monthNative: number, year: number) => void;
 }
 
 export class Month extends React.Component<MonthProps> {

--- a/packages/react-ui/components/Calendar/__tests__/Calendar.test.tsx
+++ b/packages/react-ui/components/Calendar/__tests__/Calendar.test.tsx
@@ -140,6 +140,20 @@ describe('Calendar', () => {
     expect(screen.getByText(renamedMonths[6])).toBeInTheDocument();
   });
 
+  it('scrollToMonth method scrolls to correct month', async () => {
+    const month = 5;
+    const year = 2024;
+
+    const refCalendar = React.createRef<Calendar>();
+    const onMonthChange = jest.fn(({ month, year }) => ({ month, year }));
+
+    render(<Calendar value="02.06.2017" onValueChange={jest.fn()} onMonthChange={onMonthChange} ref={refCalendar} />);
+
+    refCalendar.current?.scrollToMonth(month, year);
+
+    await waitFor(() => expect(onMonthChange).toHaveReturnedWith({ month, year }), { timeout: 5000 });
+  });
+
   describe('a11y', () => {
     it('month selector has correct aria-label attribute (ru)', () => {
       const date = '1.2.2021';

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -25,7 +25,7 @@ import { Calendar, CalendarDateShape, CalendarProps } from '../Calendar';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { Button } from '../Button';
-import { getTodayDate } from '../Calendar/CalendarUtils';
+import { getMonthInHumanFormat, getTodayDate } from '../Calendar/CalendarUtils';
 import { SizeProp } from '../../lib/types/props';
 import { responsiveLayout } from '../ResponsiveLayout/decorator';
 
@@ -429,7 +429,8 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
     this.handleSelect(today);
 
     if (this.calendar) {
-      const { month, year } = this.state.today;
+      const { month: monthNative, year } = this.state.today;
+      const month = getMonthInHumanFormat(monthNative);
       this.calendar.scrollToMonth(month, year);
     }
   };

--- a/packages/react-ui/components/DatePicker/MobilePicker.tsx
+++ b/packages/react-ui/components/DatePicker/MobilePicker.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useLayoutEffect, useRef, useState } from 'react';
 
 import { Calendar } from '../Calendar';
-import * as CalendarUtils from '../Calendar/CalendarUtils';
+import { getMonthInHumanFormat, getTodayDate } from '../Calendar/CalendarUtils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { MobilePopup } from '../../internal/MobilePopup';
 import { DateInput } from '../DateInput';
@@ -58,16 +58,18 @@ export const MobilePicker: React.FC<MobilePickerProps> = (props) => {
   }, []);
 
   const calendarRef = useRef<Calendar>(null);
-  const [today] = useState(() => CalendarUtils.getTodayDate());
+  const [{ month: monthNative, year }] = useState(() => getTodayDate());
+  const month = getMonthInHumanFormat(monthNative);
+
   const onTodayClick = () => {
     if (calendarRef.current) {
-      calendarRef.current.scrollToMonth(today.month, today.year);
+      calendarRef.current.scrollToMonth(month, year);
     }
   };
 
   useEffectWithoutInitCall(() => {
     if (props.value && calendarRef.current) {
-      const month = +props.value.substring(3, 5);
+      const month = getMonthInHumanFormat(+props.value.substring(3, 5));
       const year = +props.value.substring(6);
       calendarRef.current.scrollToMonth(month, year);
     }

--- a/packages/react-ui/components/DatePicker/Picker.tsx
+++ b/packages/react-ui/components/DatePicker/Picker.tsx
@@ -12,7 +12,7 @@ import { Calendar } from '../Calendar';
 import { CalendarDateShape } from '../Calendar/CalendarDateShape';
 import { Theme } from '../../lib/theming/Theme';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
-import { getTodayDate } from '../Calendar/CalendarUtils';
+import { getMonthInHumanFormat, getTodayDate } from '../Calendar/CalendarUtils';
 import { isTheme2022 } from '../../lib/theming/ThemeHelpers';
 import { Button } from '../Button';
 import { ArrowAUpIcon16Light } from '../../internal/icons2022/ArrowAUpIcon/ArrowAUp16Light';
@@ -153,7 +153,8 @@ export class Picker extends React.Component<PickerProps, PickerState> {
     }
 
     if (this.calendar) {
-      const { month, year } = this.state.today;
+      const { month: monthNative, year } = this.state.today;
+      const month = getMonthInHumanFormat(monthNative);
       this.calendar.scrollToMonth(month, year);
     }
   };


### PR DESCRIPTION
> **Ломающие изменения 5.x**
> Для скролла календаря к январю 2024 заменить:
> `scrollToMonth(0, 2024)` →  `scrollToMonth(1, 2024)`

## Проблема

Метод календаря `calendarRef.current.scrollToMonth(1, 2024)` скроллит на февраль 2024, а не на январь.

В то время `onValueChange` и `value`, где месяц начинается с `1`, а не `0`, что может приводить к ошибкам при подстановке одних и тех же значений.

## Решение

- В `<Calendar>` метод `scrollToMonth` теперь принимает человеческий формат месяца и внутри переводит его в нативный 
- В `<DatePicker>` вызывает `scrollToMonth` с в человеческом формате месяца 
- Подготовил тест для проверки работы метода `scrollToMonth()` через `onValueChange()`

## Ссылки

- https://yt.skbkontur.ru/issue/IF-1860
- https://yt.skbkontur.ru/issue/IF-87

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅  unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
