### PR TITLE
feat(ScrollContainer): new prop 'scrollRef'

### DIFF
--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -22,6 +22,7 @@ import {
   convertScrollbarYScrollState,
 } from './ScrollContainer.helpers';
 import { ScrollAxis, ScrollBar, ScrollBarScrollState } from './ScrollBar';
+import { callChildRef } from '../../lib/callChildRef/callChildRef';
 
 export type ScrollContainerScrollStateX = 'left' | 'scroll' | 'right';
 export type ScrollContainerScrollStateY = 'top' | 'scroll' | 'bottom';
@@ -81,7 +82,7 @@ export interface ScrollContainerProps extends CommonProps {
    * Отключить анимации
    */
   disableAnimations?: boolean;
-  scrollRef?: React.ForwardedRef<HTMLDivElement | null>;
+  scrollRef?: React.Ref<HTMLDivElement | null>;
 }
 
 export const ScrollContainerDataTids = {
@@ -203,14 +204,7 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
           {scrollbarX}
           <div
             style={innerStyle}
-            ref={(el) => {
-              this.refInner(el);
-              if (typeof this.props.scrollRef === 'function') {
-                this.props.scrollRef(el);
-              } else if (this.props.scrollRef) {
-                this.props.scrollRef.current = el;
-              }
-            }}
+            ref={this.refInner}
             className={cx(styles.inner(), globalClasses.inner, isIE11 && styles.innerIE11())}
             data-tid={ScrollContainerDataTids.inner}
             onScroll={this.handleNativeScroll}
@@ -352,6 +346,10 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
       this.inner.removeEventListener('wheel', this.handleInnerScrollWheel);
     }
     this.inner = element;
+
+    if (this.props.scrollRef) {
+      callChildRef(this.props.scrollRef, element);
+    }
   };
 
   private handleNativeScroll = (event: React.UIEvent<HTMLDivElement>) => {

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -13,6 +13,7 @@ import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { getDOMRect } from '../../lib/dom/getDOMRect';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isTestEnv } from '../../lib/currentEnvironment';
+import { callChildRef } from '../../lib/callChildRef/callChildRef';
 
 import { styles, globalClasses } from './ScrollContainer.styles';
 import { scrollSizeParametersNames } from './ScrollContainer.constants';
@@ -22,7 +23,6 @@ import {
   convertScrollbarYScrollState,
 } from './ScrollContainer.helpers';
 import { ScrollAxis, ScrollBar, ScrollBarScrollState } from './ScrollBar';
-import { callChildRef } from '../../lib/callChildRef/callChildRef';
 
 export type ScrollContainerScrollStateX = 'left' | 'scroll' | 'right';
 export type ScrollContainerScrollStateY = 'top' | 'scroll' | 'bottom';

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -81,6 +81,7 @@ export interface ScrollContainerProps extends CommonProps {
    * Отключить анимации
    */
   disableAnimations?: boolean;
+  scrollRef?: React.MutableRefObject<HTMLDivElement | null>;
 }
 
 export const ScrollContainerDataTids = {
@@ -202,7 +203,12 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
           {scrollbarX}
           <div
             style={innerStyle}
-            ref={this.refInner}
+            ref={(el) => {
+              this.refInner(el);
+              if (this.props.scrollRef) {
+                this.props.scrollRef.current = el;
+              }
+            }}
             className={cx(styles.inner(), globalClasses.inner, isIE11 && styles.innerIE11())}
             data-tid={ScrollContainerDataTids.inner}
             onScroll={this.handleNativeScroll}

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -81,7 +81,7 @@ export interface ScrollContainerProps extends CommonProps {
    * Отключить анимации
    */
   disableAnimations?: boolean;
-  scrollRef?: React.MutableRefObject<HTMLDivElement | null>;
+  scrollRef?: React.ForwardedRef<HTMLDivElement | null>;
 }
 
 export const ScrollContainerDataTids = {
@@ -205,7 +205,9 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
             style={innerStyle}
             ref={(el) => {
               this.refInner(el);
-              if (this.props.scrollRef) {
+              if (typeof this.props.scrollRef === 'function') {
+                this.props.scrollRef(el);
+              } else if (this.props.scrollRef) {
                 this.props.scrollRef.current = el;
               }
             }}


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
Компонент `ScrollContainer` не предоставляет возможность получить доступ к элементу прокрутки за его пределами.
Такая функциональность крайне полезна и в качестве яркого примера можно привести виртуализацию, а именно когда задействуется прокрутка внешнего документа, в частности когда необходимо назначить пользовательский родительский элемент прокрутки.

## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Для решения проблемы был добавлен проп `scrollRef` с типом `React.Ref` (выбор типа обусловлен заявленной поддержкой react начиная с 16.9.0).
Элемент прокрутки присваивается `refInner` и внутри `refInner` уже присваивается `scrollRef` с помощью хелпера `callChildRef` (чтобы поддержать [ref callback'и](https://react.dev/reference/react-dom/components/common#ref-callback) и чтобы избежать [лишних вызовов (последний абзац)](https://react.dev/reference/react-dom/components/common#ref-callback)), благодаря чему не нарушается обратная совместимость:

```
  private refInner = (element: HTMLElement | null) => {
    ... other code
    if (this.props.scrollRef) {
      callChildRef(this.props.scrollRef, element);
    }
  };
```

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
