### PR TITLE
feat(ZIndex): add support several React roots

### DIFF
--- a/packages/react-ui/.creevey/images/ZIndex/Several Roots/chrome2022.png
+++ b/packages/react-ui/.creevey/images/ZIndex/Several Roots/chrome2022.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74d3d1988e1dc59a3ddc00b85429d45d11fb7d175884b328ce90f630c29c11d6
-size 118763
+oid sha256:a20209f9ad3eb2f78a7886cfd61befed4f343508ca79ab3875b0e2ea9e2f60b3
+size 118762

--- a/packages/react-ui/.creevey/images/ZIndex/Several Roots/chrome2022.png
+++ b/packages/react-ui/.creevey/images/ZIndex/Several Roots/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74d3d1988e1dc59a3ddc00b85429d45d11fb7d175884b328ce90f630c29c11d6
+size 118763

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -114,8 +114,7 @@ export const WithClassChildren = () => (
 Реакт позволяет создавать несколько рутов. Они могут находится как в независимых ветках, так и быть вложенными.
 
 Даже если один рут находится внутри другого контекст между ними не прокидывается. Это вызывает проблемы в работе
-различных выпадашек, типа `Tooltip`, `Select`, `Modal` и других. Начиная с версии `4.26.0` основные сценарии
-исправленны.
+различных выпадашек, типа `Tooltip`, `Select`, `Modal` и других. Начиная с версии `4.26.0` основные сценарии исправлены.
 
 Однако, при удалении html-элемента, в котором был реакт-рут, необходимо явно размонтировать этот рут перед удалением:
 
@@ -133,7 +132,6 @@ React.useLayoutEffect(
 ```
 
 ---
-
 
 Когда реакт-руты находятся в независимых ветках, выпадашки не могут автоматически определить своё положение.
 
@@ -154,11 +152,16 @@ import { ZIndex } from '@skbkontur/react-ui/internal/ZIndex';
 
 ---
 
-В пример ниже несколько Тултипов открываются друг в друге. Каждый вложенный получает `z-index` на основе родительского.
+Также стоит учитывать, что текущий механизм не умеет отслеживать изменения контекста. Предполагается, что вложенный
+реакт-рут будет либо внутри `Modal`, либо внутри `SidePage`.
 
-Эта информация передётся через контекст, поэтому Тултип в том же руте но смонтированный рядом получит "дефолтный" `z-index`.
+---
 
-Но если обёрнуть его в компонент `ZIndex`, то контекст можно задать вручную.
+В примере ниже несколько Тултипов открываются друг в друге. Каждый вложенный получает `z-index` на основе родительского.
+
+Даже Тултип отрендеренный во вложенном `root 2` правильно вписывается в цепочку z-индексов.
+
+Тултип в независимом `root 3` обёрнут в `<ZIndex priority={9001}>`, поэтому всегда будет выше других всплывашек.
 
 ```jsx harmony
 import ReactDOM from 'react-dom';
@@ -215,31 +218,33 @@ function MyTooltip({ pos, color = '#fff', ...props }) {
     render={() => (
       <MyTooltip
         render={() => (
-          <MyTooltip
-            render={() => 'root 1'}
-            pos="right middle"
-          >
-            root 1
-          </MyTooltip>
+          <Root>
+            <MyTooltip
+              render={() => 'root 2'}
+              pos="right middle"
+            >
+              root 2
+            </MyTooltip>
+          </Root>
         )}
         pos="right middle"
       >
-        root 1
+        root 1.1
       </MyTooltip>
     )}
     pos="top left"
   >
-    root 1
+    root 1.1
   </MyTooltip>
   <div style={{ width: 80 }} />
-  <MyTooltip render={() => 'root 1'} pos="top center" color="gray">
-    root 1
+  <MyTooltip render={() => 'root 1.2'} pos="top center" color="gray">
+    root 1.2
   </MyTooltip>
-  <div style={{ width: 20 }} />
+  <div style={{ width: 30 }} />
   <ZIndex priority={9001}>
     <Root>
-      <MyTooltip render={() => 'root 2'} pos="top center">
-        root 2
+      <MyTooltip render={() => 'root 3'} pos="top center">
+        root 3
       </MyTooltip>
     </Root>
   </ZIndex>

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -23,16 +23,17 @@ const MyApp = () => (
 
 ### Хотим другой цвет кнопки!
 
-Нужно использовать [ThemeContext](https://tech.skbkontur.ru/react-ui/#/Customization/ThemeContext). Список переменных можно глянуть в [ThemeShowcase](https://tech.skbkontur.ru/react-ui/#/Customization/ThemeShowcase)
+Нужно использовать [ThemeContext](https://tech.skbkontur.ru/react-ui/#/Customization/ThemeContext). Список переменных
+можно глянуть в [ThemeShowcase](https://tech.skbkontur.ru/react-ui/#/Customization/ThemeShowcase)
 
 ### StrictMode
 
-Начиная с версий `@skbkontur/react-ui@3.10.0` и `@skbkontur/react-ui-validations@1.7.0`, библиотека поддерживает работу в React.StrictMode.
+Начиная с версий `@skbkontur/react-ui@3.10.0` и `@skbkontur/react-ui-validations@1.7.0`, библиотека поддерживает работу
+в React.StrictMode.
 
-Некоторым компонентам библиотеки необходимо иметь доступ до корневой DOM-ноды своих
-children. Ранее для этого использовался метод findDomNode, который в StrictMode запрещён.
-Теперь получение DOM-ноды реализовано в библиотеке через ref, из-за чего появились некоторые
-требования к компонентам, передаваемым в Hint, Tooltip, Popup или Tab:
+Некоторым компонентам библиотеки необходимо иметь доступ до корневой DOM-ноды своих children. Ранее для этого
+использовался метод findDomNode, который в StrictMode запрещён. Теперь получение DOM-ноды реализовано в библиотеке через
+ref, из-за чего появились некоторые требования к компонентам, передаваемым в Hint, Tooltip, Popup или Tab:
 
 - при передаче функциональных компонентов, они должны использовать `React.ForwardRef`:
 
@@ -46,19 +47,20 @@ const CustomFunctionComponent = React.forwardRef(
 export const WithFunctionChildren = () => (
   <React.StrictMode>
     <Hint pos="top" text="Something will never be changed" manual opened>
-      <CustomFunctionComponent />
+      <CustomFunctionComponent/>
     </Hint>
   </React.StrictMode>
 );
 ```
 
-- при использовании хука `useImperativeHandle`, возвращаемый объект должен реализовывать метод `getRootNode`, возвращающий DOM-ноду:
+- при использовании хука `useImperativeHandle`, возвращаемый объект должен реализовывать метод `getRootNode`,
+  возвращающий DOM-ноду:
 
 ```js static
 import { Hint } from '@skbkontur/react-ui';
 
 const ImperativeHandleComponent = React.forwardRef(function FN(_, ref) {
-  const rootNode = React.useRef<HTMLDivElement>(null);
+  const rootNode = React.useRef < HTMLDivElement > (null);
   React.useImperativeHandle(ref, () => ({
     foo: 'bar',
     getRootNode: () => rootNode.current,
@@ -69,7 +71,7 @@ const ImperativeHandleComponent = React.forwardRef(function FN(_, ref) {
 export const WithImperativeHandleChildren = () => (
   <React.StrictMode>
     <Hint pos="top" text="Something will never be changed" manual opened>
-      <ImperativeHandleComponent />
+      <ImperativeHandleComponent/>
     </Hint>
   </React.StrictMode>
 );
@@ -95,7 +97,7 @@ class CustomClassComponent extends React.Component {
 export const WithClassChildren = () => (
   <React.StrictMode>
     <Hint pos="top" text="Something will never be changed" manual opened>
-      <CustomClassComponent />
+      <CustomClassComponent/>
     </Hint>
   </React.StrictMode>
 );
@@ -106,6 +108,143 @@ export const WithClassChildren = () => (
 Подробнее в [пулл-реквесте](https://github.com/skbkontur/retail-ui/pull/2518)
 
 ## FAQ
+
+### Выпадашки и несколько react-рутов
+
+Реакт позволяет создавать несколько рутов. Они могут находится как в независимых ветках, так и быть вложенными.
+
+Даже если один рут находится внутри другого контекст между ними не прокидывается. Это вызывает проблемы в работе
+различных выпадашек, типа `Tooltip`, `Select`, `Modal` и других. Начиная с версии `4.26.0` основные сценарии
+исправленны.
+
+Однако, при удалении html-элемента, в котором был реакт-рут, необходимо явно размонтировать этот рут перед удалением:
+
+```tsx static
+React.useLayoutEffect(
+  () => () => {
+    if (React.version === 17) {
+      rootRef.current && ReactDOM.unmountComponentAtNode(rootRef.current);
+    } else if (React.version === 18) {
+      setTimeout(() => reactRoot.current?.unmount());
+    }
+  },
+  [],
+);
+```
+
+---
+
+
+Когда реакт-руты находятся в независимых ветках, выпадашки не могут автоматически определить своё положение.
+
+Для этого необходимо использовать внутренний компонент `ZIndex`:
+
+```tsx static
+import { ZIndex } from '@skbkontur/react-ui/internal/ZIndex';
+
+<ZIndex priority={9001}>
+  <div id="root-2" />
+</ZIndex>
+```
+
+Приоритет `9001` сделает все выпадашки внутри `root-2` выше выпадашек из других рутов. За исключением компонента `Toast`
+— он будет всё ещё выше всех.
+
+Если требуется перекрыть и его, то в приоритет надо передать `10001`.
+
+---
+
+В пример ниже несколько Тултипов открываются друг в друге. Каждый вложенный получает `z-index` на основе родительского.
+
+Эта информация передётся через контекст, поэтому Тултип в том же руте но смонтированный рядом получит "дефолтный" `z-index`.
+
+Но если обёрнуть его в компонент `ZIndex`, то контекст можно задать вручную.
+
+```jsx harmony
+import ReactDOM from 'react-dom';
+import { Tooltip, ThemeContext, ThemeFactory } from '@skbkontur/react-ui';
+
+import { ZIndex } from '@skbkontur/react-ui/internal/ZIndex';
+
+function Root({ children }) {
+  const rootRef = React.useRef(null);
+  const theme = React.useContext(ThemeContext);
+
+  React.useEffect(() => {
+    if (rootRef.current) {
+      const App = () => children;
+      children &&
+      ReactDOM.render(
+        <ThemeContext.Provider value={theme}>
+          <App />
+        </ThemeContext.Provider>,
+        rootRef.current,
+      );
+    }
+  }, []);
+
+  React.useLayoutEffect(
+    () => () => {
+      rootRef.current && ReactDOM.unmountComponentAtNode(rootRef.current);
+    },
+    [],
+  );
+
+  return <div ref={rootRef} style={{ display: 'inline-block' }} />;
+}
+
+function MyTooltip({ pos, color = '#fff', ...props }) {
+  const theme = React.useContext(ThemeContext);
+  const myTheme = ThemeFactory.create({ tooltipBg: color }, theme);
+
+  return (
+    <ThemeContext.Provider value={myTheme}>
+      <Tooltip
+        pos={pos}
+        allowedPositions={[pos]}
+        trigger="opened"
+        disableAnimations
+        {...props}
+      />
+    </ThemeContext.Provider>
+  );
+}
+
+<div style={{ display: 'flex', paddingTop: 60 }}>
+  <MyTooltip
+    render={() => (
+      <MyTooltip
+        render={() => (
+          <MyTooltip
+            render={() => 'root 1'}
+            pos="right middle"
+          >
+            root 1
+          </MyTooltip>
+        )}
+        pos="right middle"
+      >
+        root 1
+      </MyTooltip>
+    )}
+    pos="top left"
+  >
+    root 1
+  </MyTooltip>
+  <div style={{ width: 80 }} />
+  <MyTooltip render={() => 'root 1'} pos="top center" color="gray">
+    root 1
+  </MyTooltip>
+  <div style={{ width: 20 }} />
+  <ZIndex priority={9001}>
+    <Root>
+      <MyTooltip render={() => 'root 2'} pos="top center">
+        root 2
+      </MyTooltip>
+    </Root>
+  </ZIndex>
+</div>
+```
 
 ### Отключение анимаций во время тестирования
 
@@ -121,11 +260,14 @@ process.env.STORYBOOK_REACT_UI_TEST
 
 ### Прокидывание className и style компонентам
 
-Начиная с версии 2.14.0, стало возможным передавать в компоненты свои css-классы для дополнительной стилизации. Однако, не стоит пользоваться этой возможностью для вмешательства во внутренние стили компонентов. Верстка компонентов может быть изменена в любой момент без предупреждения, что приведет к поломке ваших переопределенных стилей.
+Начиная с версии 2.14.0, стало возможным передавать в компоненты свои css-классы для дополнительной стилизации. Однако,
+не стоит пользоваться этой возможностью для вмешательства во внутренние стили компонентов. Верстка компонентов может
+быть изменена в любой момент без предупреждения, что приведет к поломке ваших переопределенных стилей.
 
 ### Мобильная верстка
 
-С версии 4.0 многие компоненты умеют адаптироваться под мобильные устройства. Подробнее об управлении этим поведением в [MOBILES.md](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MOBILES.md).
+С версии 4.0 многие компоненты умеют адаптироваться под мобильные устройства. Подробнее об управлении этим поведением
+в [MOBILES.md](https://github.com/skbkontur/retail-ui/blob/master/packages/react-ui/MOBILES.md).
 
 ### Помощь в развитии
 

--- a/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
+++ b/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
@@ -9,6 +9,9 @@ import { callChildRef } from '../../lib/callChildRef/callChildRef';
 import { RenderInnerContainer } from './RenderInnerContainer';
 import { RenderContainerProps } from './RenderContainerTypes';
 
+export const PORTAL_ANCHOR_ATTR = 'data-render-container-id';
+export const PORTAL_TAG_ATTR = 'data-rendered-container-id';
+
 export class RenderContainer extends React.Component<RenderContainerProps> {
   public static __KONTUR_REACT_UI__ = 'RenderContainer';
   public static displayName = 'RenderContainer';
@@ -44,7 +47,7 @@ export class RenderContainer extends React.Component<RenderContainerProps> {
     const domContainer = globalObject.document?.createElement('div');
     if (domContainer) {
       domContainer.setAttribute('class', Upgrade.getSpecificityClassName());
-      domContainer.setAttribute('data-rendered-container-id', `${this.rootId}`);
+      domContainer.setAttribute(PORTAL_TAG_ATTR, `${this.rootId}`);
       this.domContainer = domContainer;
     }
   }

--- a/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
+++ b/packages/react-ui/internal/RenderContainer/RenderContainer.tsx
@@ -9,8 +9,8 @@ import { callChildRef } from '../../lib/callChildRef/callChildRef';
 import { RenderInnerContainer } from './RenderInnerContainer';
 import { RenderContainerProps } from './RenderContainerTypes';
 
-export const PORTAL_ANCHOR_ATTR = 'data-render-container-id';
-export const PORTAL_TAG_ATTR = 'data-rendered-container-id';
+export const PORTAL_INLET_ATTR = 'data-render-container-id';
+export const PORTAL_OUTLET_ATTR = 'data-rendered-container-id';
 
 export class RenderContainer extends React.Component<RenderContainerProps> {
   public static __KONTUR_REACT_UI__ = 'RenderContainer';
@@ -47,7 +47,7 @@ export class RenderContainer extends React.Component<RenderContainerProps> {
     const domContainer = globalObject.document?.createElement('div');
     if (domContainer) {
       domContainer.setAttribute('class', Upgrade.getSpecificityClassName());
-      domContainer.setAttribute(PORTAL_TAG_ATTR, `${this.rootId}`);
+      domContainer.setAttribute(PORTAL_OUTLET_ATTR, `${this.rootId}`);
       this.domContainer = domContainer;
     }
   }

--- a/packages/react-ui/internal/RenderContainer/RenderInnerContainer.tsx
+++ b/packages/react-ui/internal/RenderContainer/RenderInnerContainer.tsx
@@ -7,7 +7,7 @@ import { Nullable } from '../../typings/utility-types';
 import { safePropTypesInstanceOf } from '../../lib/SSRSafe';
 
 import { PortalProps, RenderContainerProps } from './RenderContainerTypes';
-import { PORTAL_ANCHOR_ATTR } from './RenderContainer';
+import { PORTAL_INLET_ATTR } from './RenderContainer';
 
 interface RenderInnerContainerProps extends RenderContainerProps {
   domContainer: Nullable<HTMLElement>;
@@ -39,7 +39,7 @@ export const Portal = ({ container, rt_rootID, children }: PortalProps) => {
   return (
     <React.Fragment>
       {container ? ReactDOM.createPortal(children, container) : <SSRPlaceholder />}
-      {container ? <noscript {...{ [PORTAL_ANCHOR_ATTR]: rt_rootID }} /> : <SSRPlaceholder />}
+      {container ? <noscript {...{ [PORTAL_INLET_ATTR]: rt_rootID }} /> : <SSRPlaceholder />}
     </React.Fragment>
   );
 };

--- a/packages/react-ui/internal/RenderContainer/RenderInnerContainer.tsx
+++ b/packages/react-ui/internal/RenderContainer/RenderInnerContainer.tsx
@@ -7,6 +7,7 @@ import { Nullable } from '../../typings/utility-types';
 import { safePropTypesInstanceOf } from '../../lib/SSRSafe';
 
 import { PortalProps, RenderContainerProps } from './RenderContainerTypes';
+import { PORTAL_ANCHOR_ATTR } from './RenderContainer';
 
 interface RenderInnerContainerProps extends RenderContainerProps {
   domContainer: Nullable<HTMLElement>;
@@ -38,7 +39,7 @@ export const Portal = ({ container, rt_rootID, children }: PortalProps) => {
   return (
     <React.Fragment>
       {container ? ReactDOM.createPortal(children, container) : <SSRPlaceholder />}
-      {container ? <noscript data-render-container-id={rt_rootID} /> : <SSRPlaceholder />}
+      {container ? <noscript {...{ [PORTAL_ANCHOR_ATTR]: rt_rootID }} /> : <SSRPlaceholder />}
     </React.Fragment>
   );
 };

--- a/packages/react-ui/internal/ZIndex/ZIndex.tsx
+++ b/packages/react-ui/internal/ZIndex/ZIndex.tsx
@@ -6,7 +6,7 @@ import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isInstanceOf } from '../../lib/isInstanceOf';
 import { LoaderDataTids } from '../../components/Loader';
-import { PORTAL_ANCHOR_ATTR, PORTAL_TAG_ATTR } from '../RenderContainer';
+import { PORTAL_INLET_ATTR, PORTAL_OUTLET_ATTR } from '../RenderContainer';
 
 import { incrementZIndex, removeZIndex, upperBorder, LayerComponentName } from './ZIndexStorage';
 
@@ -184,11 +184,11 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
   private tryGetContextByDOM = (element: HTMLDivElement) => {
     if (DEFAULT_ZINDEX_CONTEXT === this.zIndexContext && this.state.savedZIndexContext === null) {
       let savedZIndexContext = DEFAULT_ZINDEX_CONTEXT;
-      const portal = element.parentElement?.closest(`[${PORTAL_TAG_ATTR}]`);
+      const portal = element.parentElement?.closest(`[${PORTAL_OUTLET_ATTR}]`);
 
       if (isInstanceOf(portal, globalObject.HTMLElement)) {
-        const portalID = portal.getAttribute(PORTAL_TAG_ATTR);
-        const noscript = document.querySelector(`noscript[${PORTAL_ANCHOR_ATTR}="${portalID}"]`);
+        const portalID = portal.getAttribute(PORTAL_OUTLET_ATTR);
+        const noscript = document.querySelector(`noscript[${PORTAL_INLET_ATTR}="${portalID}"]`);
         const parent = noscript?.parentElement?.closest('[style*=z-index]');
 
         if (isInstanceOf(parent, globalObject.HTMLElement)) {

--- a/packages/react-ui/internal/ZIndex/ZIndex.tsx
+++ b/packages/react-ui/internal/ZIndex/ZIndex.tsx
@@ -6,8 +6,13 @@ import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 
 import { incrementZIndex, removeZIndex, upperBorder, LayerComponentName } from './ZIndexStorage';
+import { isInstanceOf } from '../../lib/isInstanceOf';
+import { LoaderDataTids } from '../../components/Loader';
+import { PORTAL_ANCHOR_ATTR, PORTAL_TAG_ATTR } from '../RenderContainer';
 
-const ZIndexContext = React.createContext({ parentLayerZIndex: 0, maxZIndex: Infinity });
+const DEFAULT_ZINDEX_CONTEXT = { parentLayerZIndex: 0, maxZIndex: Infinity };
+
+const ZIndexContext = React.createContext(DEFAULT_ZINDEX_CONTEXT);
 
 ZIndexContext.displayName = 'ZIndexContext';
 
@@ -42,6 +47,7 @@ type DefaultProps = Required<
 
 interface ZIndexState {
   zIndex: number;
+  savedZIndexContext: { parentLayerZIndex: number; maxZIndex: number } | null;
 }
 
 @rootNode
@@ -59,8 +65,9 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
     useWrapper: true,
   };
 
-  public state = {
+  public state: ZIndexState = {
     zIndex: 0,
+    savedZIndexContext: null,
   };
 
   private getProps = createPropsGetter(ZIndex.defaultProps);
@@ -77,6 +84,7 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
   };
 
   private setRootNode!: TSetRootNode;
+  private zIndexContext: { parentLayerZIndex: number; maxZIndex: number } | null = null;
 
   constructor(props: ZIndexProps) {
     super(props);
@@ -112,11 +120,13 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
 
     return (
       <ZIndexContext.Consumer>
-        {({ parentLayerZIndex, maxZIndex }) => {
+        {(context) => {
+          this.zIndexContext = context;
+          const { parentLayerZIndex, maxZIndex } = this.state.savedZIndexContext || context;
           let zIndexContextValue = { parentLayerZIndex, maxZIndex };
-
+          let newZIndex = 0;
           if (applyZIndex) {
-            const newZIndex = this.calcZIndex(parentLayerZIndex, maxZIndex);
+            newZIndex = this.calcZIndex(parentLayerZIndex, maxZIndex);
             wrapperStyle.zIndex = newZIndex;
 
             zIndexContextValue = coverChildren
@@ -148,6 +158,7 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
     const { wrapperRef } = this.props;
     this.setRootNode(element);
     wrapperRef && callChildRef(wrapperRef, element);
+    element && this.tryGetContextByDOM(element);
   };
 
   private calcZIndex(parentLayerZIndex: number, maxZIndex: number) {
@@ -168,5 +179,32 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
     const { priority, delta } = this.getProps();
 
     return incrementZIndex(priority, delta);
+  };
+
+  private tryGetContextByDOM = (element: HTMLDivElement) => {
+    if (DEFAULT_ZINDEX_CONTEXT === this.zIndexContext && this.state.savedZIndexContext === null) {
+      let savedZIndexContext = DEFAULT_ZINDEX_CONTEXT;
+      const portal = element.parentElement?.closest(`[${PORTAL_TAG_ATTR}]`);
+
+      if (isInstanceOf(portal, globalObject.HTMLElement)) {
+        const portalID = portal.getAttribute(PORTAL_TAG_ATTR);
+        const noscript = document.querySelector(`noscript[${PORTAL_ANCHOR_ATTR}="${portalID}"]`);
+        const parent = noscript?.parentElement?.closest('[style*=z-index]');
+
+        if (isInstanceOf(parent, globalObject.HTMLElement)) {
+          const newZIndex = Number(parent.style.zIndex || 0);
+
+          let maxZIndex = Infinity;
+
+          if (parent.parentElement?.dataset.tid === LoaderDataTids.veil) {
+            maxZIndex = this.calcZIndex(newZIndex, maxZIndex);
+          }
+
+          savedZIndexContext = { maxZIndex, parentLayerZIndex: newZIndex };
+        }
+      }
+
+      this.setState({ savedZIndexContext });
+    }
   };
 }

--- a/packages/react-ui/internal/ZIndex/ZIndex.tsx
+++ b/packages/react-ui/internal/ZIndex/ZIndex.tsx
@@ -4,11 +4,11 @@ import { globalObject, isBrowser } from '@skbkontur/global-object';
 import { callChildRef } from '../../lib/callChildRef/callChildRef';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-
-import { incrementZIndex, removeZIndex, upperBorder, LayerComponentName } from './ZIndexStorage';
 import { isInstanceOf } from '../../lib/isInstanceOf';
 import { LoaderDataTids } from '../../components/Loader';
 import { PORTAL_ANCHOR_ATTR, PORTAL_TAG_ATTR } from '../RenderContainer';
+
+import { incrementZIndex, removeZIndex, upperBorder, LayerComponentName } from './ZIndexStorage';
 
 const DEFAULT_ZINDEX_CONTEXT = { parentLayerZIndex: 0, maxZIndex: Infinity };
 

--- a/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
+++ b/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import { Dropdown } from '../../../components/Dropdown';
 import { Story } from '../../../typings/stories';
@@ -1153,5 +1154,169 @@ ModalWithDropdown.parameters = {
         await this.expect(await this.browser.takeScreenshot()).to.matchImage();
       },
     },
+  },
+};
+
+function Root({ children }: React.PropsWithChildren<any>) {
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const theme = React.useContext(ThemeContext);
+
+  React.useEffect(() => {
+    if (rootRef.current) {
+      const App = () => children;
+      children &&
+        ReactDOM.render(
+          <ThemeContext.Provider value={theme}>
+            <App />
+          </ThemeContext.Provider>,
+          rootRef.current,
+        );
+    }
+  }, []);
+
+  React.useLayoutEffect(
+    () => () => {
+      rootRef.current && ReactDOM.unmountComponentAtNode(rootRef.current);
+    },
+    [],
+  );
+
+  return <div ref={rootRef} style={{ display: 'inline-block' }} />;
+}
+
+function Classic({ withRoot = false }) {
+  const selectRef = React.useRef<Select>(null);
+  React.useEffect(() => {
+    selectRef.current?.open();
+  }, []);
+
+  const title = withRoot ? 'новый root' : 'текущий root';
+  const MayBeRoot = withRoot ? Root : ({ children }: React.PropsWithChildren<any>) => children;
+
+  return (
+    <div style={{ display: 'flex', columnGap: 100, flexDirection: 'column', paddingBottom: 50 }}>
+      <div>
+        <Tooltip render={() => 'Tooltip 1'} pos="bottom center" trigger="opened" allowedPositions={['bottom center']}>
+          Тултип
+        </Tooltip>
+        <br />
+        <Select
+          ref={selectRef}
+          width="120px"
+          items={[123]}
+          renderItem={() => (
+            <MayBeRoot>
+              <Tooltip
+                render={() => 'Tooltip 2'}
+                pos="right middle"
+                trigger="opened"
+                allowedPositions={['right middle']}
+              >
+                {title}
+              </Tooltip>
+            </MayBeRoot>
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ActiveLoader({ withRoot = false }) {
+  const title = withRoot ? 'новый root' : 'текущий root';
+  const MayBeRoot = withRoot ? Root : ({ children }: React.PropsWithChildren<any>) => children;
+
+  return (
+    <div style={{ display: 'flex', columnGap: 100, flexDirection: 'column' }}>
+      <div
+        style={{
+          width: 200,
+          background: '#eee',
+          padding: 10,
+        }}
+      >
+        <Loader active caption={null}>
+          <MayBeRoot>
+            {title}
+            <Classic />
+          </MayBeRoot>
+        </Loader>
+      </div>
+    </div>
+  );
+}
+
+function Upper({ withRoot = false }) {
+  const title = withRoot ? 'новый root' : 'текущий root';
+  const MayBeRoot = withRoot ? Root : ({ children }: React.PropsWithChildren<any>) => children;
+
+  return (
+    <div style={{ display: 'flex', rowGap: 200, flexDirection: 'column', minWidth: 100 }}>
+      <div>
+        <Tooltip
+          render={() => (
+            <Tooltip
+              render={() => (
+                <Tooltip
+                  render={() => 'Tooltip 3'}
+                  pos="bottom left"
+                  trigger="opened"
+                  allowedPositions={['bottom left']}
+                >
+                  Tooltip 2
+                </Tooltip>
+              )}
+              pos="bottom left"
+              trigger="opened"
+              allowedPositions={['bottom left']}
+            >
+              Tooltip 1
+            </Tooltip>
+          )}
+          pos="bottom left"
+          trigger="opened"
+          allowedPositions={['bottom left']}
+        />
+      </div>
+
+      <ZIndex priority="Modal">
+        <MayBeRoot>
+          <Tooltip render={() => 'Tooltip'} pos="top center" trigger="opened" allowedPositions={['top center']}>
+            {title}
+          </Tooltip>
+        </MayBeRoot>
+      </ZIndex>
+    </div>
+  );
+}
+
+export const SeveralRoots = () => {
+  return (
+    <div style={{ padding: 50, display: 'flex', flexDirection: 'column', rowGap: 20, width: 600 }}>
+      <div style={{ display: 'flex', columnGap: 150, justifyContent: 'space-evenly' }}>
+        <h3>Эталон</h3>
+        <h3>Root</h3>
+      </div>
+      <h3 style={{ textAlign: 'center' }}>Встроиться</h3>
+      <div style={{ display: 'flex', columnGap: 150, justifyContent: 'space-evenly' }}>
+        <Classic />
+        <Classic withRoot />
+      </div>
+      <h3 style={{ textAlign: 'center' }}>Активный Лоадер</h3>
+      <div style={{ display: 'flex', columnGap: 150, justifyContent: 'space-evenly' }}>
+        <ActiveLoader />
+        <ActiveLoader withRoot />
+      </div>
+      <h3 style={{ textAlign: 'center' }}>Выше всех</h3>
+      <div style={{ display: 'flex', columnGap: 150, justifyContent: 'space-evenly' }}>
+        <Upper />
+        <Upper withRoot />
+      </div>
+    </div>
+  );
+};
+SeveralRoots.parameters = {
+  creevey: {
+    skip: { "themes don't affect logic": { in: /^(?!\bchrome2022\b)/ } },
   },
 };

--- a/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
+++ b/packages/react-ui/internal/ZIndex/__stories__/ZIndex.stories.tsx
@@ -1279,7 +1279,7 @@ function Upper({ withRoot = false }) {
         />
       </div>
 
-      <ZIndex priority="Modal">
+      <ZIndex priority={9001}>
         <MayBeRoot>
           <Tooltip render={() => 'Tooltip'} pos="top center" trigger="opened" allowedPositions={['top center']}>
             {title}

--- a/packages/react-ui/lib/listenFocusOutside.ts
+++ b/packages/react-ui/lib/listenFocusOutside.ts
@@ -2,6 +2,8 @@ import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { globalObject } from '@skbkontur/global-object';
 
+import { PORTAL_ANCHOR_ATTR, PORTAL_TAG_ATTR } from '../internal/RenderContainer';
+
 import { isInstanceOf } from './isInstanceOf';
 import { isFirefox } from './client';
 
@@ -80,9 +82,9 @@ export function findRenderContainer(node: Element, rootNode: Element, container?
     return container ? container : null;
   }
 
-  const newContainerId = currentNode.getAttribute('data-rendered-container-id');
+  const newContainerId = currentNode.getAttribute(PORTAL_TAG_ATTR);
   if (newContainerId) {
-    const nextNode = globalObject.document?.querySelector(`[data-render-container-id~="${newContainerId}"]`);
+    const nextNode = globalObject.document?.querySelector(`[${PORTAL_ANCHOR_ATTR}~="${newContainerId}"]`);
 
     if (!nextNode) {
       throw Error(`Origin node for render container was not found`);

--- a/packages/react-ui/lib/listenFocusOutside.ts
+++ b/packages/react-ui/lib/listenFocusOutside.ts
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { globalObject } from '@skbkontur/global-object';
 
-import { PORTAL_ANCHOR_ATTR, PORTAL_TAG_ATTR } from '../internal/RenderContainer';
+import { PORTAL_INLET_ATTR, PORTAL_OUTLET_ATTR } from '../internal/RenderContainer';
 
 import { isInstanceOf } from './isInstanceOf';
 import { isFirefox } from './client';
@@ -82,9 +82,9 @@ export function findRenderContainer(node: Element, rootNode: Element, container?
     return container ? container : null;
   }
 
-  const newContainerId = currentNode.getAttribute(PORTAL_TAG_ATTR);
+  const newContainerId = currentNode.getAttribute(PORTAL_OUTLET_ATTR);
   if (newContainerId) {
-    const nextNode = globalObject.document?.querySelector(`[${PORTAL_ANCHOR_ATTR}~="${newContainerId}"]`);
+    const nextNode = globalObject.document?.querySelector(`[${PORTAL_INLET_ATTR}~="${newContainerId}"]`);
 
     if (!nextNode) {
       throw Error(`Origin node for render container was not found`);


### PR DESCRIPTION
## Проблема

Когда на странице есть несколько реакт-рутов, то выпадашки в них не могут правильно позиционироваться, т.к. теряется контекст.

## Решение

Самое простое решение на данный момент, это пытаться интерпретировать контекст через dom окружение.
Также, в контексте виджет-потребитель, текущее решение потребует обновить пакет только в виджете.

Подробнее всё описано в задаче и в `README.md`.

---

`ZIndexContext` состоит из 2-х полей `parentLayerZIndex` и `maxZIndex`.
Где `parentLayerZIndex` это фактически свойство `z-index` родителя.
А `maxZIndex` почти всегда равна `Infinity`, кроме случая с активным Лоадером, который можно обнаружить через data-tid.

| Пример в readme выглядит так |
| --- |
| ![image](https://github.com/user-attachments/assets/82a306a6-7766-4023-9930-cb25a1c2e1d3) |

## Ссылки

— https://yt.skbkontur.ru/issue/IF-1861
— https://stackblitz.com/edit/vitejs-vite-aekt94

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
