### PR TITLE
docs(Calendar): Add Calendar example with prices

### DIFF
--- a/packages/react-ui/components/Calendar/Calendar.md
+++ b/packages/react-ui/components/Calendar/Calendar.md
@@ -106,6 +106,8 @@ const theme = React.useContext(ThemeContext);
 
 ### Кастомный рендер дня
 
+Для кастомнизации дней в календаре используется метод `renderDay` и компонент [Calendar.Day](#/Components/Calendar/Calendar.Day)
+
 ```jsx harmony
 import { Tooltip, Hint, CalendarDay } from '@skbkontur/react-ui';
 
@@ -142,6 +144,44 @@ const renderDay = (props) => {
   onValueChange={setValue}
   renderDay={renderDay}
 />;
+```
+
+### Календарь с ценами
+
+Пример с кастомизацией темы и кастомным рендером дня 
+
+```jsx harmony
+import { ThemeContext, ThemeFactory, CalendarDay } from '@skbkontur/react-ui';
+
+const theme = React.useContext(ThemeContext);
+
+function renderDay(props) {
+  const [date, month] = props.date.split('.').map(Number);
+  const randomDay = date % 6 === 0 || date % 7 === 0 || date % 8 === 0;
+  const randomPrice = Math.round((date / month) * 1000);
+
+  return (
+    <CalendarDay {...props}>
+      <div style={{ fontSize: theme.calendarCellFontSize }}>{date}</div>
+      <div style={{ fontSize: '11px', fontFeatureSettings: 'tnum', fontVariantNumeric: 'tabular-nums' }}>
+        {randomDay ? <>{randomPrice}&thinsp;₽</> : <span style={{ color: theme.tokenTextColorDisabled }}>—</span>}
+      </div>
+    </CalendarDay>
+  );
+}
+
+const [value, setValue] = React.useState(null);
+
+<ThemeContext.Provider
+  value={ThemeFactory.create({
+    calendarCellSize: '56px',
+    calendarCellLineHeight: '1.5',
+    calendarWrapperHeight: '600px',
+    calendarCellBorderRadius: '8px'
+  }, theme)}
+>
+  <Calendar value={value} renderDay={renderDay} onValueChange={setValue} />
+</ThemeContext.Provider>
 ```
 
 #### Локали по умолчанию


### PR DESCRIPTION
## Изменения

Дополнил документацию `<Calendar>` примером календаря с кастомизацией темы и кастомным рендерингом дня

- [x] Добавил пример календаря с ценами (по запросу продукта Контур.Отель и КЕДов)
- [x] Указал ссылку на описание Calendar.Day

## Ссылки
[Обращение с вопросами по кастомизации DatePicker / Calendar](https://chat.skbkontur.ru/kontur/pl/4qbgrjo7bpyupy76ehrtidbo4y)


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ✅ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
