### PR TITLE
docs(featureFlags): remove testFeatureFlags validations

### DIFF
--- a/packages/react-ui-validations/src/ValidationContextWrapper.tsx
+++ b/packages/react-ui-validations/src/ValidationContextWrapper.tsx
@@ -4,11 +4,6 @@ import { ValidationWrapperInternal } from './ValidationWrapperInternal';
 import type { ScrollOffset, ValidateArgumentType } from './ValidationContainer';
 import { isNullable } from './utils/isNullable';
 import { FocusMode } from './FocusMode';
-import {
-  getFullValidationsFlagsContext,
-  ValidationsFeatureFlags,
-  ValidationsFeatureFlagsContext,
-} from './utils/featureFlagsContext';
 
 export interface ValidationContextSettings {
   scrollOffset: ScrollOffset;
@@ -162,19 +157,9 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
     return FocusMode.None;
   }
 
-  // удалить private featureFlags - используется для тестовой фичи
-  // для private children и render ниже в коментах версия, которая была до использования тестового фиче-флага
-  private featureFlags!: ValidationsFeatureFlags;
-  private children = (flags: ValidationsFeatureFlags) => {
-    if (flags.testFeature) {
-      return <span style={{ color: 'green' }}>Фиче-флаг включен</span>;
-    }
-
+  private children = () => {
     return <span>{this.props.children}</span>;
   };
-  // private children = () => {
-  //   // return <span>{this.props.children}</span>;
-  // };
 
   private renderChildren = (children: ValidationContextWrapperProps['children']) => {
     if (React.isValidElement(children)) {
@@ -187,20 +172,6 @@ export class ValidationContextWrapper extends React.Component<ValidationContextW
   };
 
   public render() {
-    return (
-      <ValidationsFeatureFlagsContext.Consumer>
-        {(flags) => {
-          this.featureFlags = getFullValidationsFlagsContext(flags);
-          return (
-            <ValidationContext.Provider value={this}>
-              {this.renderChildren(this.children(this.featureFlags))}
-            </ValidationContext.Provider>
-          );
-        }}
-      </ValidationsFeatureFlagsContext.Consumer>
-    );
+    return <ValidationContext.Provider value={this}>{this.renderChildren(this.children())}</ValidationContext.Provider>;
   }
-  // public render() {
-  //   return <ValidationContext.Provider value={this}>{this.renderChildren(this.children())}</ValidationContext.Provider>;
-  // }
 }

--- a/packages/react-ui-validations/src/utils/featureFlagsContext/ValidationsFeatureFlagsContext.tsx
+++ b/packages/react-ui-validations/src/utils/featureFlagsContext/ValidationsFeatureFlagsContext.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 
-export type FeatureFlags = 'testFeature';
+export type FeatureFlags = '';
 
 export type ValidationsFeatureFlags = Partial<Record<FeatureFlags, boolean>>;
 
-export const validationsFeatureFlagsDefault: ValidationsFeatureFlags = {
-  testFeature: false,
-};
+export const validationsFeatureFlagsDefault: ValidationsFeatureFlags = {};
 
 export const ValidationsFeatureFlagsContext =
   React.createContext<ValidationsFeatureFlags>(validationsFeatureFlagsDefault);

--- a/packages/react-ui-validations/stories/docs/FeatureFlags.mdx
+++ b/packages/react-ui-validations/stories/docs/FeatureFlags.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Meta } from '@storybook/blocks';
-import { Required } from '../Checkbox.stories';
+import { Meta } from '@storybook/blocks';
 
 <Meta title="FeatureFlags validations" />
 
@@ -7,8 +6,4 @@ import { Required } from '../Checkbox.stories';
 
 Включение и отключение отдельных фич через ValidationsFeatureFlagsContext
 
-## Тестовый фиче-флаг
-
-При включении тестового фиче-флага должен появиться текст
-
-<Canvas of={Required} />
+## Нет доступных фиче-флагов


### PR DESCRIPTION
## Проблема

## Решение

Удаление тестового фиче-флага, который был нужен для проверки переключателя фиче-флагов в документации.

## Ссылки## 
## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
