### PR TITLE
docs(Versions): disable table of contents

### DIFF
--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -28,4 +28,8 @@
     /* see ID-10438 */
     scrollbar-width: none;
   }
+  /*Кастомные стили*/
+  .sbdocs-wrapper:has(#disable-toc) > .css-1wizkyk[data-comp-name='TableOfContents Insertion5'] {
+    display: none;
+  }
 </style>

--- a/packages/react-ui/components/__stories__/Versions/Versions.mdx
+++ b/packages/react-ui/components/__stories__/Versions/Versions.mdx
@@ -1,7 +1,7 @@
 import { VersionsLibrary } from './Versions';
 import { Meta, Unstyled } from '@storybook/blocks';
 
-<Meta title="Versions" toc={false} parameters={{ docs: { toc: false } }} />
+<Meta title="Versions" />
 
 <Unstyled id="disable-toc">
   # Версии React UI

--- a/packages/react-ui/components/__stories__/Versions/Versions.mdx
+++ b/packages/react-ui/components/__stories__/Versions/Versions.mdx
@@ -1,8 +1,10 @@
 import { VersionsLibrary } from './Versions';
-import { Meta } from '@storybook/blocks';
+import { Meta, Unstyled } from '@storybook/blocks';
 
-<Meta title="Versions" />
+<Meta title="Versions" toc={false} parameters={{ docs: { toc: false } }} />
 
-# Версии React UI
+<Unstyled id="disable-toc">
+  # Версии React UI
 
-<VersionsLibrary />
+  <VersionsLibrary />
+</Unstyled>


### PR DESCRIPTION
## Проблема

Пустое содержание на странице версий
![image](https://github.com/user-attachments/assets/b3c99c60-2c71-431f-9827-25c64ce4798c)

## Решение

Убрал содержание для компонента Versions. Пока в mdx файле в Meta не поддерживается parameters для отключения toc. Поэтому сделано вручную через <Unstyled /> и css

## Ссылки

[YouTrack](https://yt.skbkontur.ru/issue/IF-1918/Dopolneniya-dlya-perehoda-na-novuyu-dokumentaciyu)

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
