### PR TITLE
docs(MaskedInput): change css styles for primary example

### DIFF
--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -32,4 +32,8 @@
   .sbdocs-wrapper:has(#disable-toc) > .css-1wizkyk[data-comp-name='TableOfContents Insertion5'] {
     display: none;
   }
+  #story--input-elements-maskedinput--mask--primary-inner tbody td:first-child {
+    display: flex;
+    flex-direction: column;
+  }
 </style>


### PR DESCRIPTION
## Проблема

в MaskedInput primary пример выходил за границы экрана

## Решение

Левую колонку (там где defaultValue, mask) — сделал `column`, Для экранов свыше 1200px теперь таблица примеров без горизонтальной прокрутки
<img width="540" alt="image" src="https://github.com/user-attachments/assets/9d7c39e5-cf65-4cd6-953d-c9e0e9bd7521">

## Ссылки

[YouTrack](https://yt.skbkontur.ru/issue/IF-1918/Dopolneniya-dlya-perehoda-na-novuyu-dokumentaciyu)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
