### PR TITLE
feat(react-ui): a11y: В компоненты добавлен атрибут id

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -35,7 +35,7 @@ export interface ButtonProps
       AriaAttributes,
       'aria-haspopup' | 'aria-describedby' | 'aria-controls' | 'aria-label' | 'aria-checked' | 'aria-expanded'
     >,
-    Pick<HTMLAttributes<unknown>, 'role'>,
+    Pick<HTMLAttributes<unknown>, 'role' | 'id'>,
     Pick<HTMLProps['button'], 'onClickCapture' | 'onMouseUp' | 'onMouseDown'> {
   /** @ignore */
   _noPadding?: boolean;
@@ -303,6 +303,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
       'aria-checked': ariaChecked,
       'aria-expanded': ariaExpanded,
       role,
+      id,
     } = this.props;
     const { use, type, size } = this.getProps();
     const sizeClass = this.getSizeClassName();
@@ -499,7 +500,7 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <span {...wrapProps} data-tid={ButtonDataTids.rootElement}>
-          <button data-tid={ButtonDataTids.root} ref={this._ref} {...rootProps}>
+          <button id={id} data-tid={ButtonDataTids.root} ref={this._ref} {...rootProps}>
             {innerShadowNode}
             {outlineNode}
             {arrowNode}

--- a/packages/react-ui/components/Button/__tests__/Button-test.tsx
+++ b/packages/react-ui/components/Button/__tests__/Button-test.tsx
@@ -7,6 +7,12 @@ import { THEME_2022 } from '../../../lib/theming/themes/Theme2022';
 import { Button, ButtonDataTids, ButtonType } from '../Button';
 
 describe('Button', () => {
+  it('has id attribute', () => {
+    const buttonId = 'buttonId';
+    const result = render(<Button id={buttonId}>Foo</Button>);
+    expect(result.container.querySelector(`button#${buttonId}`)).toHaveTextContent('Foo');
+  });
+
   it('has correct label', () => {
     render(<Button>Foo</Button>);
     expect(screen.getByRole('button')).toHaveTextContent('Foo');

--- a/packages/react-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/react-ui/components/ComboBox/ComboBox.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 
 import { DropdownContainerProps } from '../../internal/DropdownContainer';
 import { CustomComboBox } from '../../internal/CustomComboBox';
@@ -12,6 +12,7 @@ import { SizeProp } from '../../lib/types/props';
 
 export interface ComboBoxProps<T>
   extends Pick<DropdownContainerProps, 'menuPos'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,
     CommonProps {
   align?: 'left' | 'center' | 'right';

--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -1361,11 +1361,11 @@ export const WithExtendedItem: Story = () => {
             { id: 2, name: 'Madrid' },
             <MenuSeparator key={2} />,
             <hr key={3} />,
-            <MenuItem key={1} {...{ id: 3, name: 'London' }}>
+            <MenuItem key={1} {...{ id: '3', name: 'London' }}>
               <CustomItem id={3} name="London" />
             </MenuItem>,
             () => (
-              <MenuItem {...{ id: 4, name: 'Berlin' }}>
+              <MenuItem {...{ id: '4', name: 'Berlin' }}>
                 <CustomItem id={4} name="Berlin" />
               </MenuItem>
             ),

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { MobilePopupDataTids } from '../../../internal/MobilePopup';
 import { DEFAULT_THEME } from '../../../lib/theming/themes/DefaultTheme';
 import { HTMLProps } from '../../../typings/html';
-import { InputDataTids } from '../../../components/Input';
+import { InputDataTids } from '../../Input';
 import { MenuMessageDataTids } from '../../../internal/MenuMessage';
 import { CustomComboBoxLocaleHelper } from '../../../internal/CustomComboBox/locale';
 import { LangCodes, LocaleContext, LocaleContextProps } from '../../../lib/locale';
@@ -54,6 +54,12 @@ describe('ComboBox', () => {
 
   it('renders', () => {
     expect(() => render(<ComboBox getItems={() => Promise.resolve([])} />)).not.toThrow();
+  });
+
+  it('has id attribute', () => {
+    const comboboxId = 'comboboxId';
+    const result = render(<ComboBox id={comboboxId} getItems={() => Promise.resolve([])} />);
+    expect(result.container.querySelector(`#${comboboxId}`)).not.toBeNull();
   });
 
   it('focuses on click to input', () => {

--- a/packages/react-ui/components/CurrencyLabel/CurrencyLabel.tsx
+++ b/packages/react-ui/components/CurrencyLabel/CurrencyLabel.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 
 import { MAX_SAFE_DIGITS } from '../CurrencyInput/constants';
 import { CurrencyHelper } from '../CurrencyInput/CurrencyHelper';
 import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
 
-export interface CurrencyLabelProps extends CommonProps {
+export interface CurrencyLabelProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
   /**
    * Минимальное количество отображаемых знаков после запятой
    * @default 2
@@ -23,6 +23,7 @@ export const CurrencyLabelDataTids = {
 } as const;
 
 export const CurrencyLabel = ({
+  id,
   value,
   fractionDigits = FRACTION_DIGITS_DEFAULT,
   currencySymbol,
@@ -31,7 +32,7 @@ export const CurrencyLabel = ({
 }: CurrencyLabelProps): JSX.Element => {
   return (
     <CommonWrapper {...rest}>
-      <span data-tid={CurrencyLabelDataTids.root}>
+      <span id={id} data-tid={CurrencyLabelDataTids.root}>
         {CurrencyHelper.format(value, { fractionDigits, hideTrailingZeros })}
         {currencySymbol && String.fromCharCode(0xa0) /* &nbsp; */}
         {currencySymbol}

--- a/packages/react-ui/components/CurrencyLabel/__tests__/CurrencyLabel-test.tsx
+++ b/packages/react-ui/components/CurrencyLabel/__tests__/CurrencyLabel-test.tsx
@@ -5,6 +5,12 @@ import { CurrencyLabel, CurrencyLabelDataTids } from '../CurrencyLabel';
 import { MAX_SAFE_DIGITS } from '../../CurrencyInput/constants';
 
 describe('CurrencyLabel', () => {
+  it('has id attribute', () => {
+    const labelId = 'labelId';
+    const result = render(<CurrencyLabel id={labelId} value={12345} />);
+    expect(result.container.querySelector(`#${labelId}`)).not.toBeNull();
+  });
+
   it('should correctly format value', () => {
     render(<CurrencyLabel value={12345} fractionDigits={0} />);
 

--- a/packages/react-ui/components/DateInput/DateInput.tsx
+++ b/packages/react-ui/components/DateInput/DateInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import ReactDOM from 'react-dom';
 import { globalObject } from '@skbkontur/global-object';
 
@@ -37,7 +37,7 @@ export const DateInputDataTids = {
   icon: 'DateInput__icon',
 } as const;
 
-export interface DateInputProps extends CommonProps {
+export interface DateInputProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
   autoFocus?: boolean;
   value?: string;
   /**
@@ -211,6 +211,7 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <FocusControlWrapper onBlurWhenDisabled={this.resetFocus}>
           <InputLikeText
+            id={this.props.id}
             width={width}
             ref={this.inputLikeTextRef}
             size={size}

--- a/packages/react-ui/components/DateInput/__tests__/DateInput-test.tsx
+++ b/packages/react-ui/components/DateInput/__tests__/DateInput-test.tsx
@@ -37,6 +37,12 @@ const render = (
 const getInput = () => screen.getByTestId(InputLikeTextDataTids.input);
 
 describe('DateInput as InputlikeText', () => {
+  it('has id attribute', () => {
+    const dateInputId = 'dateInputId';
+    const result = render({ id: dateInputId, value: '10.02.2017' });
+    expect(result.container.querySelector(`#${dateInputId}`)).not.toBeNull();
+  });
+
   describe('without min/max date', () => {
     it('renders', () => {
       expect(() => render({ value: '10.02.2017' })).not.toThrow();

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 
 import { LocaleContext } from '../../lib/locale';
 import { locale } from '../../lib/locale/decorators';
@@ -46,6 +46,7 @@ export const MIN_WIDTH = 120;
 
 export interface DatePickerProps
   extends Pick<DropdownContainerProps, 'menuPos'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<CalendarProps, 'isHoliday' | 'minDate' | 'maxDate' | 'renderDay' | 'onMonthChange'>,
     CommonProps {
   autoFocus?: boolean;
@@ -349,6 +350,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
         data-tid={DatePickerDataTids.label}
       >
         <DateInput
+          id={this.props.id}
           {...filterProps(props, INPUT_PASS_PROPS)}
           ref={this.getInputRef}
           value={this.props.value || ''}

--- a/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
+++ b/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within, fireEvent } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 
 import { componentsLocales as DateSelectLocalesRu } from '../../../internal/DateSelect/locale/locales/ru';
-import { CalendarDataTids, CalendarDay, CalendarDayProps } from '../../../components/Calendar';
+import { CalendarDataTids, CalendarDay, CalendarDayProps } from '../../Calendar';
 import { MASK_CHAR_EXEMPLAR } from '../../../internal/MaskCharLowLine';
 import { InputLikeTextDataTids } from '../../../internal/InputLikeText';
 import { InternalDate } from '../../../lib/date/InternalDate';
@@ -36,6 +36,12 @@ describe('DatePicker', () => {
     it('should validate by number', () => {
       expect(DatePicker.validate('01.ff.2019')).toBe(false);
     });
+  });
+
+  it('has id attribute', () => {
+    const dateInputId = 'dateInputId';
+    const result = render(<DatePicker id={dateInputId} value="02.07.2017" onValueChange={jest.fn()} />);
+    expect(result.container.querySelector(`#${dateInputId}`)).not.toBeNull();
   });
 
   it('renders', () => {

--- a/packages/react-ui/components/Dropdown/Dropdown.tsx
+++ b/packages/react-ui/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 
 import { filterProps } from '../../lib/filterProps';
@@ -35,11 +35,13 @@ const PASS_PROPS = {
   onMouseLeave: true,
   onMouseOver: true,
   menuPos: true,
+  id: true,
   'aria-describedby': true,
 };
 
 export interface DropdownProps
   extends Pick<AriaAttributes, 'aria-label' | 'aria-describedby'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     CommonProps,
     Pick<DropdownContainerProps, 'menuPos'> {
   /**

--- a/packages/react-ui/components/Dropdown/__tests__/Dropdown-test.tsx
+++ b/packages/react-ui/components/Dropdown/__tests__/Dropdown-test.tsx
@@ -22,6 +22,16 @@ describe('Dropdown', () => {
     expect(screen.getByTestId(DropdownDataTids.root)).toBeInTheDocument();
   });
 
+  it('has id attribute', () => {
+    const dropdownId = 'dropdownId';
+    const result = render(
+      <Dropdown id={dropdownId} caption="button">
+        <MenuItem>Menu item</MenuItem>
+      </Dropdown>,
+    );
+    expect(result.container.querySelector(`button#${dropdownId}`)).not.toBeNull();
+  });
+
   it('Renders caption', () => {
     render(<Dropdown caption={caption}>{menuItem}</Dropdown>);
 

--- a/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react-ui/components/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Nullable } from '../../typings/utility-types';
@@ -13,6 +13,7 @@ import { getDropdownMenuTheme } from './getDropdownMenuTheme';
 
 export interface DropdownMenuProps
   extends Pick<AriaAttributes, 'aria-label'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'popupMenuId' | 'preventIconsOffset'>,
     CommonProps {
   /** Максимальная высота меню */
@@ -104,6 +105,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
         <PopupMenu
+          id={this.props.id}
           aria-label={this.props['aria-label']}
           ref={this.refPopupMenu}
           caption={this.props.caption}

--- a/packages/react-ui/components/DropdownMenu/__tests__/DropdownMenu-test.tsx
+++ b/packages/react-ui/components/DropdownMenu/__tests__/DropdownMenu-test.tsx
@@ -22,6 +22,12 @@ describe('<DropdownMenu />', () => {
     expect(renderDropdownMenu).not.toThrow();
   });
 
+  it('has id attribute', () => {
+    const dropdownMenuId = 'dropdownMenuId';
+    const result = render(<DropdownMenu id={dropdownMenuId} caption={caption} />);
+    expect(result.container.querySelector(`button#${dropdownMenuId}`)).not.toBeNull();
+  });
+
   it('Throw, if caption is not passed', () => {
     const renderNoCaption = () => render(<DropdownMenu caption={undefined} />);
     expect(renderNoCaption).toThrow();

--- a/packages/react-ui/components/Kebab/Kebab.tsx
+++ b/packages/react-ui/components/Kebab/Kebab.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { isElement } from 'react-is';
 import { globalObject } from '@skbkontur/global-object';
@@ -29,6 +29,7 @@ import { KebabIcon } from './KebabIcon';
 
 export interface KebabProps
   extends Pick<AriaAttributes, 'aria-label'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<PopupMenuProps, 'onOpen' | 'onClose' | 'popupMenuId' | 'preventIconsOffset'>,
     CommonProps {
   disabled?: boolean;
@@ -147,6 +148,7 @@ export class Kebab extends React.Component<KebabProps, KebabState> {
               {...getVisualStateDataAttributes({ disabled })}
             >
               <PopupMenu
+                id={this.props.id}
                 popupHasPin={hasPin}
                 preventIconsOffset={this.props.preventIconsOffset}
                 positions={positions}

--- a/packages/react-ui/components/Kebab/__tests__/Kebab-test.tsx
+++ b/packages/react-ui/components/Kebab/__tests__/Kebab-test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
 import { PopupDataTids, PopupIds } from '../../../internal/Popup';
-import { MenuItem } from '../../../components/MenuItem';
+import { MenuItem } from '../../MenuItem';
 import { Kebab, KebabDataTids } from '../Kebab';
 
 describe('Kebab', () => {
@@ -18,6 +18,12 @@ describe('Kebab', () => {
 
     const menu = screen.getByTestId(PopupDataTids.root);
     expect(menu).toHaveAttribute('id', menuId);
+  });
+
+  it('has id attribute', () => {
+    const kebabId = 'kebabId';
+    const result = render(<Kebab id={kebabId} />);
+    expect(result.container.querySelector(`#${kebabId}[role="button"]`)).not.toBeNull();
   });
 
   it('should focus by pressing tab', () => {

--- a/packages/react-ui/components/MenuFooter/MenuFooter.tsx
+++ b/packages/react-ui/components/MenuFooter/MenuFooter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext } from 'react';
+import React, { HTMLAttributes, ReactNode, useContext } from 'react';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
@@ -12,7 +12,7 @@ import { styles } from './MenuFooter.styles';
  */
 export type MenuFooterSize = SizeProp;
 
-export interface MenuFooterProps extends CommonProps {
+export interface MenuFooterProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
   _enableIconPadding?: boolean;
   children: ReactNode;
   /** Размер */
@@ -30,7 +30,7 @@ export const MenuFooterDataTids = {
  *
  * Сущности в которых может быть использован `MenuFooter`: [DropdownMenu](#/Components/DropdownMenu), [Kebab](#/Components/Kebab), [TooltipMenu](#/Components/TooltipMenu) и [Select](#/Components/Select).
  */
-function MenuFooter({ _enableIconPadding = false, children, size = 'small', ...rest }: MenuFooterProps) {
+function MenuFooter({ id, _enableIconPadding = false, children, size = 'small', ...rest }: MenuFooterProps) {
   const theme = useContext(ThemeContext);
 
   function getRootSizeClassName() {
@@ -59,6 +59,7 @@ function MenuFooter({ _enableIconPadding = false, children, size = 'small', ...r
   return (
     <CommonWrapper {...rest}>
       <div
+        id={id}
         data-tid={MenuFooterDataTids.root}
         className={cx(getRootSizeClassName(), {
           [styles.root(theme)]: true,

--- a/packages/react-ui/components/MenuFooter/__tests__/MenuIFooter-test.tsx
+++ b/packages/react-ui/components/MenuFooter/__tests__/MenuIFooter-test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { MenuFooter } from '../MenuFooter';
+
+describe('MenuFooter', () => {
+  it('has id attribute', () => {
+    const menuFooterId = 'menuFooterId';
+    const result = render(<MenuFooter id={menuFooterId}>Footer</MenuFooter>);
+    expect(result.container.querySelector(`#${menuFooterId}`)).not.toBeNull();
+  });
+});

--- a/packages/react-ui/components/MenuHeader/MenuHeader.tsx
+++ b/packages/react-ui/components/MenuHeader/MenuHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext } from 'react';
+import React, { HTMLAttributes, ReactNode, useContext } from 'react';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
@@ -13,7 +13,7 @@ import { styles } from './MenuHeader.styles';
  */
 export type MenuHeaderSize = SizeProp;
 
-export interface MenuHeaderProps extends CommonProps {
+export interface MenuHeaderProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
   _enableIconPadding?: boolean;
   children: ReactNode;
   /** Размер */
@@ -31,7 +31,7 @@ export const MenuHeaderDataTids = {
  *
  * Сущности в которых может быть использован `MenuHeader`: [DropdownMenu](#/Components/DropdownMenu), [Kebab](#/Components/Kebab), [TooltipMenu](#/Components/TooltipMenu) и [Select](#/Components/Select).
  */
-function MenuHeader({ _enableIconPadding = false, children, size = 'small', ...rest }: MenuHeaderProps) {
+function MenuHeader({ id, _enableIconPadding = false, children, size = 'small', ...rest }: MenuHeaderProps) {
   const theme = useContext(ThemeContext);
   const menuContext = useContext(MenuContext);
 
@@ -61,6 +61,7 @@ function MenuHeader({ _enableIconPadding = false, children, size = 'small', ...r
   return (
     <CommonWrapper {...rest}>
       <div
+        id={id}
         data-tid={MenuHeaderDataTids.root}
         className={cx(getRootSizeClassName(), {
           [styles.root(theme)]: true,

--- a/packages/react-ui/components/MenuHeader/__tests__/MenuIHeader-test.tsx
+++ b/packages/react-ui/components/MenuHeader/__tests__/MenuIHeader-test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { MenuHeader } from '../MenuHeader';
+
+describe('MenuHeader', () => {
+  it('has id attribute', () => {
+    const menuHeaderId = 'menuHeaderId';
+    const result = render(<MenuHeader id={menuHeaderId}>Header</MenuHeader>);
+    expect(result.container.querySelector(`#${menuHeaderId}`)).not.toBeNull();
+  });
+});

--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -1,6 +1,6 @@
 // TODO: Enable this rule in functional components.
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 import PropTypes from 'prop-types';
 import { globalObject, isBrowser } from '@skbkontur/global-object';
 
@@ -27,6 +27,7 @@ export type MenuItemState = null | 'hover' | 'selected' | void;
 
 export interface MenuItemProps
   extends Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Omit<CommonProps, 'children'> {
   /**
    * @ignore

--- a/packages/react-ui/components/MenuItem/__tests__/MenuItem-test.tsx
+++ b/packages/react-ui/components/MenuItem/__tests__/MenuItem-test.tsx
@@ -14,6 +14,12 @@ describe('MenuItem', () => {
     expect(screen.getByTestId(MenuItemDataTids.root)).toHaveTextContent('ab');
   });
 
+  it('has id attribute', () => {
+    const menuItemId = 'menuItemId';
+    const result = render(<MenuItem id={menuItemId} />);
+    expect(result.container.querySelector(`#${menuItemId}`)).not.toBeNull();
+  });
+
   it('without href does not has a rel attribute', () => {
     render(<MenuItem rel={'noopener'}>Test</MenuItem>);
     expect(screen.queryByRole('button')).not.toHaveAttribute('rel');

--- a/packages/react-ui/components/Select/Select.tsx
+++ b/packages/react-ui/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, ReactPortal, AriaAttributes } from 'react';
+import React, { ReactNode, ReactPortal, AriaAttributes, HTMLAttributes } from 'react';
 import invariant from 'invariant';
 import { globalObject } from '@skbkontur/global-object';
 import debounce from 'lodash.debounce';
@@ -60,6 +60,7 @@ export interface ButtonParams
 }
 
 const PASS_BUTTON_PROPS = {
+  id: true,
   disabled: true,
   error: true,
   use: true,
@@ -91,6 +92,7 @@ type SelectItem<TValue, TItem> =
 export interface SelectProps<TValue, TItem>
   extends CommonProps,
     Pick<DropdownContainerProps, 'menuPos'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<AriaAttributes, 'aria-describedby' | 'aria-label'> {
   /** @ignore */
   _icon?: React.ReactNode;

--- a/packages/react-ui/components/Select/__tests__/Select-test.tsx
+++ b/packages/react-ui/components/Select/__tests__/Select-test.tsx
@@ -54,6 +54,12 @@ describe('Select', () => {
     expect(selectedMenuItem).toHaveTextContent(currentValueText);
   });
 
+  it('has id attribute', () => {
+    const selectId = 'selectId';
+    const result = render(<Select id={selectId} />);
+    expect(result.container.querySelector(`button#${selectId}`)).not.toBeNull();
+  });
+
   it('calls onKeyDown', () => {
     const onKeyDown = jest.fn();
     render(<Select onKeyDown={onKeyDown} />);

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -3,6 +3,7 @@ import React, {
   ChangeEvent,
   FocusEvent,
   FocusEventHandler,
+  HTMLAttributes,
   KeyboardEvent,
   MouseEventHandler,
   ReactNode,
@@ -27,12 +28,11 @@ import {
 import * as LayoutEvents from '../../lib/LayoutEvents';
 import { Menu } from '../../internal/Menu';
 import { Token, TokenProps, TokenSize } from '../Token';
-import { MenuItemState } from '../MenuItem';
+import { MenuItemState, MenuItem } from '../MenuItem';
 import { AnyObject, emptyHandler, getRandomID } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { locale } from '../../lib/locale/decorators';
-import { MenuItem } from '../MenuItem/MenuItem';
 import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
 import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
@@ -61,7 +61,10 @@ export enum TokenInputType {
 
 export type TokenInputMenuAlign = 'left' | 'cursor';
 
-export interface TokenInputProps<T> extends Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>, CommonProps {
+export interface TokenInputProps<T>
+  extends CommonProps,
+    Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'> {
   /**
    * Выбранные токены, которые будут отображаться в поле ввода
    */
@@ -315,9 +318,13 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
     return { ...propsWithOldDelimiters, delimiters: this.getDelimiters() };
   }
 
+  private get textareaId() {
+    return this.props.id ?? this._textareaId;
+  }
+
   public state: TokenInputState<T> = DefaultState;
 
-  private readonly textareaId: string = getUid();
+  private readonly _textareaId: string = getUid();
   private rootId = PopupIds.root + getRandomID();
   private readonly locale!: TokenInputLocale;
   private theme!: Theme;

--- a/packages/react-ui/components/TokenInput/__tests__/TokenInput-test.tsx
+++ b/packages/react-ui/components/TokenInput/__tests__/TokenInput-test.tsx
@@ -23,6 +23,12 @@ describe('<TokenInput />', () => {
     expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'Placeholder');
   });
 
+  it('has id attribute', () => {
+    const tokenInputId = 'tokenInputId';
+    const result = render(<TokenInput id={tokenInputId} getItems={getItems} selectedItems={[]} />);
+    expect(result.container.querySelector(`textarea#${tokenInputId}`)).not.toBeNull();
+  });
+
   it('should throw error without getItems prop', () => {
     const renderNoGetItems = () => render(<TokenInput />);
     expect(renderNoGetItems).toThrow('Missed getItems for type');

--- a/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
+++ b/packages/react-ui/internal/CustomComboBox/ComboBoxView.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 
 import { getRandomID, isNonNullable } from '../../lib/utils';
 import { DropdownContainer, DropdownContainerProps } from '../DropdownContainer';
@@ -31,6 +31,7 @@ import { getComboBoxTheme } from './getComboBoxTheme';
 
 interface ComboBoxViewProps<T>
   extends Pick<DropdownContainerProps, 'menuPos'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,
     CommonProps {
   align?: 'left' | 'center' | 'right';
@@ -285,6 +286,7 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
     const isMobile = this.isMobileLayout;
 
     const {
+      id,
       align,
       borderless,
       disabled,
@@ -315,6 +317,7 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
     if (editing) {
       return (
         <Input
+          id={id}
           align={align}
           borderless={borderless}
           disabled={disabled}
@@ -344,6 +347,7 @@ export class ComboBoxView<T> extends React.Component<ComboBoxViewProps<T>> {
 
     return (
       <InputLikeText
+        id={id}
         align={align}
         borderless={borderless}
         error={error}

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 import ReactDOM from 'react-dom';
 import { globalObject } from '@skbkontur/global-object';
 
@@ -27,6 +27,7 @@ import { ComboBoxView } from './ComboBoxView';
 
 export interface CustomComboBoxProps<T>
   extends Pick<DropdownContainerProps, 'menuPos'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,
     CommonProps {
   align?: 'left' | 'center' | 'right';
@@ -273,6 +274,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       warning: this.props.warning,
       'aria-describedby': this.props['aria-describedby'],
       'aria-label': this.props['aria-label'],
+      id: this.props.id,
       width: this.props.width,
       maxLength: this.props.maxLength,
       maxMenuHeight: this.props.maxMenuHeight,

--- a/packages/react-ui/internal/PopupMenu/PopupMenu.tsx
+++ b/packages/react-ui/internal/PopupMenu/PopupMenu.tsx
@@ -1,4 +1,4 @@
-import React, { AriaAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 import { globalObject } from '@skbkontur/global-object';
 
 import { getRandomID } from '../../lib/utils';
@@ -15,7 +15,7 @@ import { ThemeFactory } from '../../lib/theming/ThemeFactory';
 import { Popup, PopupIds, PopupPositionsType } from '../Popup';
 import { RenderLayer } from '../RenderLayer';
 import { Nullable } from '../../typings/utility-types';
-import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper } from '../CommonWrapper';
 import { responsiveLayout } from '../../components/ResponsiveLayout/decorator';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
@@ -34,6 +34,7 @@ export interface PopupMenuCaptionProps {
 export interface PopupMenuProps
   extends CommonProps,
     Pick<MenuProps, 'preventIconsOffset'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'>,
     Pick<AriaAttributes, 'aria-label'> {
   children?: React.ReactNode;
   /** Максимальная высота меню */
@@ -224,6 +225,7 @@ export class PopupMenu extends React.Component<PopupMenuProps, PopupMenuState> {
     }
 
     return React.cloneElement(caption as React.ReactElement, {
+      id: this.props.id,
       'aria-controls': this.props.popupMenuId ?? this.rootId,
       'aria-expanded': this.state.menuVisible ? 'true' : 'false',
       'aria-label': this.props['aria-label'],

--- a/packages/react-ui/internal/PopupMenu/__tests__/PopupMenu-test.tsx
+++ b/packages/react-ui/internal/PopupMenu/__tests__/PopupMenu-test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
-import { PopupDataTids, PopupIds } from '../../../internal/Popup/Popup';
+import { PopupDataTids, PopupIds } from '../../Popup';
 import { PopupMenu, PopupMenuCaptionProps } from '../PopupMenu';
 import { MenuItem } from '../../../components/MenuItem';
 
@@ -161,6 +161,12 @@ describe('PopupMenu', () => {
       render(<PopupMenu aria-label={ariaLabel} caption={<button>test</button>} />);
 
       expect(screen.getByRole('button')).toHaveAttribute('aria-label', ariaLabel);
+    });
+
+    it('has id attribute', () => {
+      const popupMenuId = 'popupMenuId';
+      const result = render(<PopupMenu id={popupMenuId} caption={<button>test</button>} />);
+      expect(result.container.querySelector(`button#${popupMenuId}`)).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Проблема

Атрибут id нужен в сценариях доступности и в формах для связывания лейблов с контролами.

## Решение

Добавил id во все компоненты для ввода данных: DatePicker, все Dropdown-like компоненты и остальные по мелочи.
В модальные компоненты вроде Modal и SidePage не добавлял, потому что непонятна применимость. В комментах к задаче IF-1193 есть подробная таблица где id нужен, а где можно обойтись без него.

В Dropdown-like компонентах прокидываю id не на root-элемент, а на интерактивный элемент внутри. Это, как правило, кнопка или инпут. Эта логика для скринридеров, он будет зачитывать значимые элементы и описывать их состояние. Обертки скринридер игнорирует. Важна семантика верстки.

В DatePicker под капотом используется  InputLikeText, он под капотом `span` с `input type=hidden`. Не проверял есть ли какие-то проблемы с ним. Если будут, это тянет на отдельное исследование.

## Ссылки

resolve IF-1193

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
