### PR TITLE
refactor(ThemeFactory): disallow arbitrary theme tokens by default

### DIFF
--- a/packages/react-ui/components/Button/getInnerLinkTheme.ts
+++ b/packages/react-ui/components/Button/getInnerLinkTheme.ts
@@ -16,7 +16,6 @@ export const getInnerLinkTheme = (theme: Theme): Theme => {
       linkActiveColor: theme.btnLinkActiveColor,
       linkHoverTextDecoration: theme.btnLinkHoverTextDecoration,
       linkIconMarginRight: theme.btnLinkIconMarginRight,
-      linkBorderRadius: theme.btnLinkBorderRadius,
     },
     theme,
   );

--- a/packages/react-ui/lib/theming/ThemeFactory.ts
+++ b/packages/react-ui/lib/theming/ThemeFactory.ts
@@ -1,12 +1,11 @@
 import { BasicLightTheme } from '../../internal/themes/BasicLightTheme';
-import { isNonNullable } from '../utils';
+import { isNonNullable, NoInfer } from '../utils';
 
 import { Theme, ThemeIn } from './Theme';
 import { findPropertyDescriptor, REACT_UI_THEME_MARKERS } from './ThemeHelpers';
 
 export class ThemeFactory {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-  public static create<T extends unknown>(theme: ThemeIn & T, baseTheme?: Theme): Readonly<Theme & T> {
+  public static create<T>(theme: ThemeIn & NoInfer<T>, baseTheme?: Theme): Readonly<Theme & NoInfer<T>> {
     const base = baseTheme || BasicLightTheme;
     return this.constructTheme(base, theme);
   }

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -21,6 +21,8 @@ export type DefaultizeProps<C, P> = C extends { defaultProps: infer D } ? Defaul
 
 export type AnyObject = Record<string, unknown>;
 
+export type NoInfer<T> = T extends infer U ? U : never;
+
 export const delay = (ms: number) => new Promise((resolve) => globalObject.setTimeout(resolve, ms));
 
 export const emptyHandler = () => {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
Cейчас `ThemeFactory.create` может принимать любое значение отличное от `null (T extends {})`.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Ограничил тип аргумента `theme` до доступных токенов в теме:
- Добавил служебный тип `NoInfer`.
- Обернул аргумент типа метода `create` в `NoInfer`.
- Пофиксил ошибку ТС, возникшую из-за правки.

Пример работы: 
![image](https://github.com/user-attachments/assets/ee7dabae-1849-464d-a06a-e44e7baf94e1)

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->
resolve [IF-283](https://yt.skbkontur.ru/issue/IF-283) Поправить типизацию ThemeFactory.create
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
