### PR TITLE
refactor(Button): rename root data-tid

### DIFF
--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -474,8 +474,8 @@ export class Button extends React.Component<ButtonProps, ButtonState> {
 
     return (
       <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
-        <span {...wrapProps} data-tid={ButtonDataTids.rootElement}>
-          <button id={id} data-tid={ButtonDataTids.root} ref={this._ref} {...rootProps}>
+        <span {...wrapProps} data-tid={ButtonDataTids.root}>
+          <button id={id} data-tid={ButtonDataTids.rootElement} ref={this._ref} {...rootProps}>
             {innerShadowNode}
             {outlineNode}
             {arrowNode}

--- a/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
+++ b/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
@@ -13,7 +13,6 @@ import { DatePickerLocaleHelper } from '../locale';
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { DEFAULT_THEME } from '../../../lib/theming/themes/DefaultTheme';
 import { MobilePickerDataTids } from '../MobilePicker';
-import { ButtonDataTids } from '../../../components/Button';
 import { DateSelectDataTids } from '../../../internal/DateSelect';
 import { MenuDataTids } from '../../../internal/Menu';
 
@@ -460,7 +459,7 @@ describe('DatePicker', () => {
       render(<MobilePicker />);
       await userEvent.click(screen.getByTestId(DatePickerDataTids.input));
 
-      await userEvent.click(within(screen.getByTestId(MobilePickerDataTids.today)).getByTestId(ButtonDataTids.root));
+      await userEvent.click(within(screen.getByTestId(MobilePickerDataTids.today)).getByRole('button'));
 
       const today = new Date();
       const todayMonth = today.getMonth();

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -87,7 +87,7 @@ export const PagingDataTids = {
 } as const;
 
 type DefaultProps = Required<
-  Pick<PagingProps, 'component' | 'shouldBeVisibleWithLessThanTwoPages' | 'useGlobalListener' | 'data-tid'>
+  Pick<PagingProps, 'component' | 'shouldBeVisibleWithLessThanTwoPages' | 'useGlobalListener'>
 >;
 
 @rootNode
@@ -100,7 +100,6 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
     component: PagingDefaultComponent,
     shouldBeVisibleWithLessThanTwoPages: true,
     useGlobalListener: false,
-    'data-tid': PagingDataTids.root,
   };
 
   private getProps = createPropsGetter(Paging.defaultProps);
@@ -167,7 +166,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
   }
 
   private renderMain() {
-    const { 'data-tid': dataTid, useGlobalListener } = this.getProps();
+    const { useGlobalListener } = this.getProps();
     return (
       <CommonWrapper
         rootNodeRef={this.setRootNode}
@@ -176,7 +175,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
       >
         <span
           tabIndex={this.props.disabled ? -1 : 0}
-          data-tid={dataTid}
+          data-tid={PagingDataTids.root}
           className={cx({ [styles.paging(this.theme)]: true, [styles.pagingDisabled()]: this.props.disabled })}
           onKeyDown={useGlobalListener ? undefined : this.handleKeyDown}
           onFocus={this.handleFocus}

--- a/packages/react-ui/components/Select/__tests__/Select-test.tsx
+++ b/packages/react-ui/components/Select/__tests__/Select-test.tsx
@@ -4,7 +4,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { MenuItemDataTids } from '../../MenuItem';
 import { MenuDataTids } from '../../../internal/Menu';
-import { ButtonDataTids } from '../../Button';
 import { defaultLangCode } from '../../../lib/locale/constants';
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { SelectLocaleHelper } from '../locale';
@@ -57,7 +56,7 @@ describe('Select', () => {
     );
     const currentValueText = currentValue.name;
 
-    await userEvent.click(screen.getByTestId(ButtonDataTids.root));
+    await userEvent.click(screen.getByRole('button'));
     expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
 
     const menuItems = screen.getAllByTestId(MenuItemDataTids.root);
@@ -86,7 +85,7 @@ describe('Select', () => {
     const onFocus = jest.fn();
     render(<Select onFocus={onFocus} />);
 
-    await userEvent.click(screen.getByTestId(ButtonDataTids.root));
+    await userEvent.click(screen.getByRole('button'));
 
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
@@ -95,7 +94,7 @@ describe('Select', () => {
     const onBlur = jest.fn();
     render(<Select onFocus={onBlur} />);
 
-    await userEvent.click(screen.getByTestId(ButtonDataTids.root));
+    await userEvent.click(screen.getByRole('button'));
 
     expect(onBlur).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
В рамках мажора решили переименовать корневой дататид `Button` в `root`, по аналогии с остальными компонентами.
<!-- Подробно опиши решаемую проблему. -->

## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
- Поменял местами дататиды кнопки `root` и `rootElement`.  `rootElement` не стал менять, так как потом там может быть не только кнопка, но и ссылка и ещё что-то.
- Отрефакторил прокидывания дататида в `Paging`, сделал как в других компонентах. 
## Ссылки
resolve [IF-1742](https://yt.skbkontur.ru/issue/IF-1742)
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
