### PR TITLE
refactor(react-ui): remove deprecated entities

### DIFF
--- a/packages/react-ui-codemod/react-ui-5.0/renameThemeVars.ts
+++ b/packages/react-ui-codemod/react-ui-5.0/renameThemeVars.ts
@@ -72,6 +72,15 @@ const RENAMED_VARS: Record<string, string> = {
   fileUploaderPaddingY:'fileUploaderPaddingYSmall',
   pickerBg: 'calendarBg',
   pickerBorderRadius: 'calendarBorderRadius',
+  tokenDefaultIdleBg: 'tokenBg',
+  tokenDefaultIdleColor: 'tokenColor',
+  tokenDefaultIdleBorderColor: 'tokenBorderColor',
+  tokenDefaultIdleBgHover: 'tokenBgHover',
+  tokenDefaultIdleColorHover: 'tokenColorHover',
+  tokenDefaultIdleBorderColorHover: 'tokenBorderColorHover',
+  tokenDefaultActiveBg: 'tokenBgActive',
+  tokenDefaultActiveColor: 'tokenColorActive',
+  tokenDefaultActiveBorderColor: 'tokenBorderColorActive'
 };
 
 export default function transform(file: FileInfo, api: API) {

--- a/packages/react-ui-testing/Tests/PagingTests/PagingTest.cs
+++ b/packages/react-ui-testing/Tests/PagingTests/PagingTest.cs
@@ -22,7 +22,7 @@ namespace SKBKontur.SeleniumTesting.Tests.PagingTests
         [Test]
         public void TestPresence()
         {
-            page.Paging1.IsPresent.Wait().That(Is.True);
+            page.Paging1.IsPresent.Wait().That(Is.False);
         }
 
         [Test]

--- a/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/chrome2022/afterScroll.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/chrome2022/afterScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdb20edc65007bf89fdbde8161dfd4cd9b7331f4b5ea29627b4af55b9dd7bbc6
-size 3829

--- a/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/chrome2022/beforeScroll.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/chrome2022/beforeScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:195bb57396896a8ffebff756da0faf30eda0d1d0145111a6617a42604517175d
-size 3285

--- a/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/chrome2022/duringScroll.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/chrome2022/duringScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab458ff5adc40fdb047886dc0c4845584b6e18d726169c1d7f60fc22433e372f
-size 3790

--- a/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/firefox2022/afterScroll.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/firefox2022/afterScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:947a7358f55a516bc2fbf91320eff17dc35a0305049d0f927ecd7f8feb2b6198
-size 3681

--- a/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/firefox2022/beforeScroll.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/firefox2022/beforeScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a377b3f6b84371cae9dadf60c79599d5ee104cefd1a4a15b3f5cdbe0db1e420
-size 3431

--- a/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/firefox2022/duringScroll.png
+++ b/packages/react-ui/.creevey/images/ScrollContainer/Hide Scroll Bar/hideScroll/firefox2022/duringScroll.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6963393c94bb1fd788eb8e3590f3d098ad8cc528542484d4234dcb2abd981ca8
-size 3745

--- a/packages/react-ui/components/Button/Button.tsx
+++ b/packages/react-ui/components/Button/Button.tsx
@@ -21,10 +21,6 @@ import { useButtonArrow } from './ButtonArrow';
 import { getInnerLinkTheme } from './getInnerLinkTheme';
 import { LoadingButtonIcon } from './LoadingButtonIcon';
 
-/**
- * @deprecated use SizeProp
- */
-export type ButtonSize = SizeProp;
 export type ButtonType = 'button' | 'submit' | 'reset';
 export type ButtonUse = 'default' | 'primary' | 'success' | 'danger' | 'pay' | 'link' | 'text' | 'backless';
 

--- a/packages/react-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/react-ui/components/Checkbox/Checkbox.tsx
@@ -19,11 +19,6 @@ import { styles, globalClasses } from './Checkbox.styles';
 import { CheckedIcon } from './CheckedIcon';
 import { IndeterminateIcon } from './IndeterminateIcon';
 
-/**
- * @deprecated use SizeProp
- */
-export type CheckboxSize = SizeProp;
-
 export interface CheckboxProps
   extends CommonProps,
     Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,

--- a/packages/react-ui/components/FileUploader/FileUploader.tsx
+++ b/packages/react-ui/components/FileUploader/FileUploader.tsx
@@ -28,11 +28,6 @@ import { globalClasses, jsStyles } from './FileUploader.styles';
 
 const stopPropagation: React.ReactEventHandler = (e) => e.stopPropagation();
 
-/**
- * @deprecated use SizeProp
- */
-export type FileUploaderSize = SizeProp;
-
 type FileUploaderOverriddenProps = 'size';
 
 interface _FileUploaderProps

--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -25,10 +25,6 @@ import { PolyfillPlaceholder } from './InputLayout/PolyfillPlaceholder';
 
 export const inputTypes = ['password', 'text', 'number', 'tel', 'search', 'time', 'date', 'url', 'email'] as const;
 
-/**
- * @deprecated use SizeProp
- */
-export type InputSize = SizeProp;
 export type InputAlign = 'left' | 'center' | 'right';
 export type InputType = (typeof inputTypes)[number];
 export type InputIconType = React.ReactNode | (() => React.ReactNode);

--- a/packages/react-ui/components/MenuFooter/MenuFooter.tsx
+++ b/packages/react-ui/components/MenuFooter/MenuFooter.tsx
@@ -7,11 +7,6 @@ import { SizeProp } from '../../lib/types/props';
 
 import { styles } from './MenuFooter.styles';
 
-/**
- * @deprecated use SizeProp
- */
-export type MenuFooterSize = SizeProp;
-
 export interface MenuFooterProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
   _enableIconPadding?: boolean;
   children: ReactNode;

--- a/packages/react-ui/components/MenuHeader/MenuHeader.tsx
+++ b/packages/react-ui/components/MenuHeader/MenuHeader.tsx
@@ -8,11 +8,6 @@ import { MenuContext } from '../../internal/Menu/MenuContext';
 
 import { styles } from './MenuHeader.styles';
 
-/**
- * @deprecated use SizeProp
- */
-export type MenuHeaderSize = SizeProp;
-
 export interface MenuHeaderProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
   _enableIconPadding?: boolean;
   children: ReactNode;

--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -15,11 +15,6 @@ import { getVisualStateDataAttributes } from '../../internal/CommonWrapper/utils
 
 import { styles } from './MenuItem.styles';
 
-/**
- * @deprecated use SizeProp
- */
-export type MenuItemSize = SizeProp;
-
 export type MenuItemState = null | 'hover' | 'selected' | void;
 
 export interface MenuItemProps

--- a/packages/react-ui/components/Paging/Paging.tsx
+++ b/packages/react-ui/components/Paging/Paging.tsx
@@ -59,15 +59,6 @@ export interface PagingProps extends CommonProps {
    * на каждом из них. Такие случаи лучше обрабатывать отдельно.
    */
   useGlobalListener?: boolean;
-  /**
-   * Определяет, нужно ли показывать `Paging` когда страница всего одна.
-   *
-   * Этот проп будет удалён в 5-ой версии библиотеки,
-   * так как поведение со скрытием `Paging`'а станет поведением по умолчанию.
-   *
-   * @default false
-   */
-  shouldBeVisibleWithLessThanTwoPages?: boolean; // TODO Delete in 5.0
 }
 
 export interface PagingState {
@@ -86,9 +77,7 @@ export const PagingDataTids = {
   pageLink: 'Paging__pageLink',
 } as const;
 
-type DefaultProps = Required<
-  Pick<PagingProps, 'component' | 'shouldBeVisibleWithLessThanTwoPages' | 'useGlobalListener'>
->;
+type DefaultProps = Required<Pick<PagingProps, 'component' | 'useGlobalListener'>>;
 
 @rootNode
 @locale('Paging', PagingLocaleHelper)
@@ -98,7 +87,6 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
 
   public static defaultProps: DefaultProps = {
     component: PagingDefaultComponent,
-    shouldBeVisibleWithLessThanTwoPages: true,
     useGlobalListener: false,
   };
 
@@ -151,7 +139,7 @@ export class Paging extends React.PureComponent<PagingProps, PagingState> {
   }
 
   public render() {
-    if (this.props.pagesCount < 2 && !this.getProps().shouldBeVisibleWithLessThanTwoPages) {
+    if (this.props.pagesCount < 2) {
       return null;
     }
 

--- a/packages/react-ui/components/Paging/__tests__/Paging-test.tsx
+++ b/packages/react-ui/components/Paging/__tests__/Paging-test.tsx
@@ -23,25 +23,16 @@ describe('Paging', () => {
     expect(screen.getAllByTestId(PagingDataTids.pageLink)).toHaveLength(5);
   });
 
-  it('should not be rendered when only one page is presented and the flag is enabled', () => {
+  it('should not be rendered when pagesCount < 2', () => {
     const callback = jest.fn();
-    render(
-      <Paging pagesCount={1} activePage={1} onPageChange={callback} shouldBeVisibleWithLessThanTwoPages={false} />,
-    );
+    render(<Paging pagesCount={1} activePage={1} onPageChange={callback} />);
 
     expect(screen.queryByTestId(PagingDataTids.root)).not.toBeInTheDocument();
   });
 
-  it('should be rendered when only one page is presented and the flag is disabled', () => {
+  it('should be rendered when pagesCount >= 2', () => {
     const callback = jest.fn();
-    render(<Paging pagesCount={1} activePage={1} onPageChange={callback} />);
-
-    expect(screen.getByTestId(PagingDataTids.root)).toBeInTheDocument();
-  });
-
-  it('should be rendered when two or more pages are presented and the flag is enabled', () => {
-    const callback = jest.fn();
-    render(<Paging pagesCount={2} activePage={1} onPageChange={callback} shouldBeVisibleWithLessThanTwoPages />);
+    render(<Paging pagesCount={2} activePage={1} onPageChange={callback} />);
 
     expect(screen.getByTestId(PagingDataTids.root)).toBeInTheDocument();
   });

--- a/packages/react-ui/components/Radio/Radio.tsx
+++ b/packages/react-ui/components/Radio/Radio.tsx
@@ -17,11 +17,6 @@ import { FocusControlWrapper } from '../../internal/FocusControlWrapper';
 
 import { styles, globalClasses } from './Radio.styles';
 
-/**
- * @deprecated use SizeProp
- */
-export type RadioSize = SizeProp;
-
 export interface RadioProps<T>
   extends Pick<AriaAttributes, 'aria-label'>,
     CommonProps,

--- a/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/react-ui/components/ScrollContainer/ScrollContainer.tsx
@@ -65,17 +65,13 @@ export interface ScrollContainerProps extends CommonProps {
    * Смещение горизонтального скроллбара
    */
   offsetX?: Partial<Record<OffsetCSSPropsX, React.CSSProperties[OffsetCSSPropsX]>>;
-  /**
-   * Скрывать скроллбар при отсутствии активности пользователя
-   * @deprecated use showScrollBar
-   */
-  hideScrollBar?: boolean;
+
   /**
    * Показывать скроллбар
    */
   showScrollBar?: 'always' | 'scroll' | 'hover' | 'never';
   /**
-   * Задержка перед скрытием скроллбара, ms. Работает только если `hideScrollBar = true` или `showScrollBar = 'scroll' | 'hover'`
+   * Задержка перед скрытием скроллбара, ms. Работает только `showScrollBar = 'scroll' | 'hover'`
    */
   hideScrollBarDelay?: number;
   /**
@@ -93,13 +89,7 @@ export const ScrollContainerDataTids = {
 type DefaultProps = Required<
   Pick<
     ScrollContainerProps,
-    | 'invert'
-    | 'scrollBehaviour'
-    | 'preventWindowScroll'
-    | 'hideScrollBar'
-    | 'disableAnimations'
-    | 'hideScrollBarDelay'
-    | 'showScrollBar'
+    'invert' | 'scrollBehaviour' | 'preventWindowScroll' | 'disableAnimations' | 'hideScrollBarDelay' | 'showScrollBar'
   >
 >;
 
@@ -129,7 +119,6 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
     invert: false,
     scrollBehaviour: 'auto',
     preventWindowScroll: false,
-    hideScrollBar: false,
     disableAnimations: isTestEnv,
     hideScrollBarDelay: 500,
     showScrollBar: 'always',
@@ -140,7 +129,7 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
   private scrollX: Nullable<ScrollBar>;
   private scrollY: Nullable<ScrollBar>;
   private setRootNode!: TSetRootNode;
-  private initialIsScrollBarVisible = !this.getProps().hideScrollBar && this.getProps().showScrollBar === 'always';
+  private initialIsScrollBarVisible = this.getProps().showScrollBar === 'always';
 
   public state: ScrollContainerState = {
     isScrollBarXVisible: this.initialIsScrollBarVisible,
@@ -326,8 +315,8 @@ export class ScrollContainer extends React.Component<ScrollContainerProps, Scrol
     if (scrollState !== prevScrollState) {
       this.handleScrollStateChange(scrollState, axis);
     }
-    const { hideScrollBar, showScrollBar } = this.getProps();
-    (hideScrollBar || showScrollBar === 'scroll') && this.showScrollBarOnMouseWheel(axis);
+    const { showScrollBar } = this.getProps();
+    showScrollBar === 'scroll' && this.showScrollBarOnMouseWheel(axis);
   };
 
   private refScrollBarY = (scrollbar: Nullable<ScrollBar>) => {

--- a/packages/react-ui/components/ScrollContainer/__creevey__/ScrollContainer.creevey.ts
+++ b/packages/react-ui/components/ScrollContainer/__creevey__/ScrollContainer.creevey.ts
@@ -160,30 +160,6 @@ kind('ScrollContainer', () => {
     });
   });
 
-  story('HideScrollBar', ({ setStoryParameters }) => {
-    setStoryParameters({ skip: { 'themes dont affect logic': { in: /^(?!\b(firefox2022|chrome2022)\b)/ } } });
-
-    test('hideScroll', async function () {
-      const beforeScroll = await this.takeScreenshot();
-      await this.browser.executeScript(function () {
-        const scrollContainer = window.document.querySelector('[data-tid~="ScrollContainer__inner"]');
-        if (scrollContainer) {
-          scrollContainer.scrollTop = 500;
-        }
-      });
-      this.browser
-        .actions({
-          bridge: true,
-        })
-        .move({ origin: this.browser.findElement({ css: 'body' }) });
-      await delay(200);
-      const duringScroll = await this.takeScreenshot();
-      await delay(3000);
-      const afterScroll = await this.takeScreenshot();
-      await this.expect({ beforeScroll, duringScroll, afterScroll }).to.matchImages();
-    });
-  });
-
   story('ScrollBarVisibleAfterTogglingDisabled', ({ setStoryParameters }) => {
     setStoryParameters({ skip: { 'themes dont affect logic': { in: /^(?!\bchrome2022\b)/ } } });
 

--- a/packages/react-ui/components/ScrollContainer/__stories__/ScrollContainer.stories.tsx
+++ b/packages/react-ui/components/ScrollContainer/__stories__/ScrollContainer.stories.tsx
@@ -328,27 +328,6 @@ export const OffsetYAndX: Story = () => (
   </div>
 );
 
-export const HideScrollBar: Story = () => (
-  <div style={wrapperStyle}>
-    <ScrollContainer
-      hideScrollBar
-      // Magic delay to capture the scrollbar
-      hideScrollBarDelay={2000}
-      disableAnimations
-    >
-      <div style={{ width: 300 }}>
-        {Array(30)
-          .fill(null)
-          .map((_, i) => (
-            <div style={{ width: 200 }} key={i}>
-              {i}
-            </div>
-          ))}
-      </div>
-    </ScrollContainer>
-  </div>
-);
-
 export const ScrollBarVisibleAfterTogglingDisabled: Story = () => {
   const [isDisabled, setIsDisabled] = useState(false);
 

--- a/packages/react-ui/components/Switcher/Switcher.tsx
+++ b/packages/react-ui/components/Switcher/Switcher.tsx
@@ -16,10 +16,6 @@ import { styles } from './Switcher.styles';
 import { getSwitcherTheme } from './switcherTheme';
 import { mod } from './helpers';
 
-/**
- * @deprecated use SizeProp
- */
-export type SwitcherSize = SizeProp;
 export type SwitcherItems = string | SwitcherItem;
 
 export const SwitcherDataTids = {

--- a/packages/react-ui/components/Tabs/Tab.tsx
+++ b/packages/react-ui/components/Tabs/Tab.tsx
@@ -13,7 +13,6 @@ import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { createPropsGetter } from '../../lib/createPropsGetter';
-import { SizeProp } from '../../lib/types/props';
 import { getVisualStateDataAttributes } from '../../internal/CommonWrapper/utils/getVisualStateDataAttributes';
 
 import { TabsContext, TabsContextDefaultValue, TabsContextType } from './TabsContext';
@@ -30,11 +29,6 @@ export interface TabIndicators {
 export const TabDataTids = {
   root: 'Tab__root',
 } as const;
-
-/**
- * @deprecated use SizeProp
- */
-export type TabSize = SizeProp;
 
 export interface TabProps<T extends string = string>
   extends Pick<AriaAttributes, 'aria-label' | 'aria-describedby'>,

--- a/packages/react-ui/components/Textarea/Textarea.tsx
+++ b/packages/react-ui/components/Textarea/Textarea.tsx
@@ -24,11 +24,6 @@ import { styles } from './Textarea.styles';
 import { TextareaCounter, TextareaCounterRef } from './TextareaCounter';
 import { TextareaWithSafari17Workaround } from './TextareaWithSafari17Workaround';
 
-/**
- * @deprecated use SizeProp
- */
-export type TextareaSize = SizeProp;
-
 const DEFAULT_WIDTH = 250;
 const AUTORESIZE_THROTTLE_DEFAULT_WAIT = 100;
 

--- a/packages/react-ui/components/Toggle/Toggle.tsx
+++ b/packages/react-ui/components/Toggle/Toggle.tsx
@@ -1,6 +1,5 @@
 import React, { AriaAttributes } from 'react';
 import PropTypes from 'prop-types';
-import warning from 'warning';
 
 import { keyListener } from '../../lib/events/keyListener';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
@@ -14,8 +13,6 @@ import { SizeProp } from '../../lib/types/props';
 import { FocusControlWrapper } from '../../internal/FocusControlWrapper';
 
 import { styles, globalClasses } from './Toggle.styles';
-
-let colorWarningShown = false;
 
 export interface ToggleProps extends Pick<AriaAttributes, 'aria-label' | 'aria-describedby'>, CommonProps {
   children?: React.ReactNode;
@@ -74,10 +71,6 @@ export interface ToggleProps extends Pick<AriaAttributes, 'aria-label' | 'aria-d
    */
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   /**
-   * @deprecated используйте переменную темы `toggleBgChecked` вместо этого пропа.
-   */
-  color?: React.CSSProperties['color'];
-  /**
    * HTML-атрибут `id` для передачи во внутренний `<input />`.
    */
   id?: string;
@@ -116,12 +109,6 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
     loading: PropTypes.bool,
     warning: PropTypes.bool,
     onValueChange: PropTypes.func,
-    color: (props: ToggleProps) => {
-      if (props.color && !colorWarningShown) {
-        warning(false, `[Toggle]: prop 'color' is deprecated. Please, use theme variable 'toggleBgChecked' instead. `);
-        colorWarningShown = true;
-      }
-    },
   };
 
   public static defaultProps: DefaultProps = {
@@ -248,15 +235,7 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
   }
 
   private renderMain() {
-    const {
-      children,
-      warning,
-      error,
-      color,
-      id,
-      'aria-describedby': ariaDescribedby,
-      'aria-label': ariaLabel,
-    } = this.props;
+    const { children, warning, error, id, 'aria-describedby': ariaDescribedby, 'aria-label': ariaLabel } = this.props;
     const { loading, captionPosition, disableAnimations } = this.getProps();
     const disabled = this.getProps().disabled || loading;
     const checked = this.isUncontrolled() ? this.state.checked : this.props.checked;
@@ -315,17 +294,7 @@ export class Toggle extends React.Component<ToggleProps, ToggleState> {
                 aria-describedby={ariaDescribedby}
               />
             </FocusControlWrapper>
-            <div
-              className={containerClassNames}
-              style={
-                checked && color && !disabled
-                  ? {
-                      backgroundColor: color,
-                      boxShadow: `inset 0 0 0 1px ${color}`,
-                    }
-                  : undefined
-              }
-            />
+            <div className={containerClassNames} />
             <div
               className={cx(this.getHandleSizeClassName(), globalClasses.handle, {
                 [styles.handle(this.theme)]: true,

--- a/packages/react-ui/components/Toggle/Toggle.tsx
+++ b/packages/react-ui/components/Toggle/Toggle.tsx
@@ -15,11 +15,6 @@ import { FocusControlWrapper } from '../../internal/FocusControlWrapper';
 
 import { styles, globalClasses } from './Toggle.styles';
 
-/**
- * @deprecated use SizeProp
- */
-export type ToggleSize = SizeProp;
-
 let colorWarningShown = false;
 
 export interface ToggleProps extends Pick<AriaAttributes, 'aria-label' | 'aria-describedby'>, CommonProps {

--- a/packages/react-ui/components/Toggle/__stories__/Toggle.stories.tsx
+++ b/packages/react-ui/components/Toggle/__stories__/Toggle.stories.tsx
@@ -89,16 +89,15 @@ class Playground extends React.Component {
                   checked={this.state.checked}
                   onValueChange={this.toggle.bind(this)}
                   loading={this.state.loading}
-                  color="#28bf4f"
                 />{' '}
                 {this.state.checked ? 'On' : 'Off'}
               </div>
               <div>
-                <Toggle checked={false} disabled color="#28bf4f" />
+                <Toggle checked={false} disabled />
                 {' Off disabled'}
               </div>
               <div>
-                <Toggle checked disabled color="#28bf4f" />
+                <Toggle checked disabled />
                 {' On disabled'}
               </div>
             </Gapped>

--- a/packages/react-ui/components/Token/Token.styles.ts
+++ b/packages/react-ui/components/Token/Token.styles.ts
@@ -63,30 +63,30 @@ export const styles = memoizeStyle({
     `;
   },
 
-  tokenDefaultIdle(t: Theme) {
+  tokenIdle(t: Theme) {
     return css`
-      color: ${t.tokenDefaultIdleColor};
-      background: ${t.tokenDefaultIdleBg};
-      border-color: ${t.tokenDefaultIdleBorderColor};
+      color: ${t.tokenColor};
+      background: ${t.tokenBg};
+      border-color: ${t.tokenBorderColor};
       background-clip: border-box;
     `;
   },
 
-  tokenDefaultIdleHovering(t: Theme) {
+  tokenHover(t: Theme) {
     return css`
       &:hover {
-        color: ${t.tokenDefaultIdleColorHover};
-        background: ${t.tokenDefaultIdleBgHover};
-        border: solid ${t.tokenBorderWidth} ${t.tokenDefaultIdleBorderColorHover};
+        color: ${t.tokenColorHover};
+        background: ${t.tokenBgHover};
+        border: solid ${t.tokenBorderWidth} ${t.tokenBorderColorHover};
       }
     `;
   },
 
-  tokenDefaultActive(t: Theme) {
+  tokenActive(t: Theme) {
     return css`
-      color: ${t.tokenDefaultActiveColor};
-      background: ${t.tokenDefaultActiveBg};
-      border: solid ${t.tokenBorderWidth} ${t.tokenDefaultActiveBorderColor};
+      color: ${t.tokenColorActive};
+      background: ${t.tokenBgActive};
+      border: solid ${t.tokenBorderWidth} ${t.tokenBorderColorActive};
     `;
   },
 

--- a/packages/react-ui/components/Token/Token.tsx
+++ b/packages/react-ui/components/Token/Token.tsx
@@ -100,9 +100,9 @@ export class Token extends React.Component<TokenProps> {
     );
 
     const classNames = cx(
-      styles.tokenDefaultIdle(theme),
-      !isActive && !warning && !error && !disabled && styles.tokenDefaultIdleHovering(theme),
-      isActive && styles.tokenDefaultActive(theme),
+      styles.tokenIdle(theme),
+      !isActive && !warning && !error && !disabled && styles.tokenHover(theme),
+      isActive && styles.tokenActive(theme),
       warning && styles.tokenWarning(theme),
       error && styles.tokenError(theme),
       disabled && styles.tokenDisabled(theme),

--- a/packages/react-ui/internal/themes/BasicDarkTheme.ts
+++ b/packages/react-ui/internal/themes/BasicDarkTheme.ts
@@ -367,15 +367,15 @@ export class BasicDarkThemeInternal extends (class {} as typeof BasicLightTheme)
     return this.textColorDisabled;
   }
 
-  public static tokenDefaultIdleColor = 'rgba(255, 255, 255, 0.865)';
-  public static tokenDefaultIdleBg = 'rgba(255, 255, 255, 0.1)';
-  public static tokenDefaultIdleBorderColor = 'rgba(255, 255, 255, 0.06)';
-  public static tokenDefaultIdleColorHover = 'rgba(255, 255, 255, 0.87)';
-  public static tokenDefaultIdleBgHover = 'rgba(255, 255, 255, 0.16)';
-  public static tokenDefaultIdleBorderColorHover = 'rgba(255, 255, 255, 0.06)';
-  public static tokenDefaultActiveColor = 'rgba(0, 0, 0, 0.87)';
-  public static tokenDefaultActiveBg = '#EBEBEB';
-  public static tokenDefaultActiveBorderColor = 'transparent';
+  public static tokenColor = 'rgba(255, 255, 255, 0.865)';
+  public static tokenBg = 'rgba(255, 255, 255, 0.1)';
+  public static tokenBorderColor = 'rgba(255, 255, 255, 0.06)';
+  public static tokenColorHover = 'rgba(255, 255, 255, 0.87)';
+  public static tokenBgHover = 'rgba(255, 255, 255, 0.16)';
+  public static tokenBorderColorHover = 'rgba(255, 255, 255, 0.06)';
+  public static tokenColorActive = 'rgba(0, 0, 0, 0.87)';
+  public static tokenBgActive = '#EBEBEB';
+  public static tokenBorderColorActive = 'transparent';
   //#endregion Token
   //#region Input
   public static inputBg = 'rgba(255, 255, 255, 0.1)';

--- a/packages/react-ui/internal/themes/BasicLightTheme.ts
+++ b/packages/react-ui/internal/themes/BasicLightTheme.ts
@@ -201,46 +201,6 @@ export class BasicLightThemeInternal {
   public static tokenBorderRadius = '2px';
   public static tokenBorderWidth = '1px';
   public static tokenBorderColorDisabled = 'transparent';
-  public static get tokenDefaultIdle() {
-    return this.grayXLight;
-  }
-  public static tokenDefaultActive = '#323232';
-  public static get tokenGrayIdle() {
-    return this.grayXLight;
-  }
-  public static get tokenGrayActive() {
-    return this.grayDark;
-  }
-  public static get tokenBlueIdle() {
-    return this.blueLight;
-  }
-  public static get tokenBlueActive() {
-    return this.blue;
-  }
-  public static get tokenGreenIdle() {
-    return this.greenXxLight;
-  }
-  public static get tokenGreenActive() {
-    return this.greenDark;
-  }
-  public static get tokenYellowIdle() {
-    return this.yellowXxLight;
-  }
-  public static get tokenYellowActive() {
-    return this.yellowDark;
-  }
-  public static get tokenRedIdle() {
-    return this.redXxLight;
-  }
-  public static get tokenRedActive() {
-    return this.redDark;
-  }
-  public static get tokenWhite() {
-    return this.white;
-  }
-  public static get tokenBlack() {
-    return this.black;
-  }
   public static get tokenBorderColorWarning() {
     return this.borderColorWarning;
   }

--- a/packages/react-ui/internal/themes/BasicLightTheme.ts
+++ b/packages/react-ui/internal/themes/BasicLightTheme.ts
@@ -226,15 +226,15 @@ export class BasicLightThemeInternal {
 
   public static tokenShadowDisabled = '';
 
-  public static tokenDefaultIdleBg = 'rgba(0, 0, 0, 0.1)';
-  public static tokenDefaultIdleColor = '#222222';
-  public static tokenDefaultIdleBorderColor = 'rgba(0, 0, 0, 0.16)';
-  public static tokenDefaultIdleBgHover = 'rgba(0, 0, 0, 0.16)';
-  public static tokenDefaultIdleColorHover = '#222222';
-  public static tokenDefaultIdleBorderColorHover = 'rgba(0, 0, 0, 0.16)';
-  public static tokenDefaultActiveBg = '#3D3D3D';
-  public static tokenDefaultActiveColor = '#FFFFFF';
-  public static tokenDefaultActiveBorderColor = 'transparent';
+  public static tokenBg = 'rgba(0, 0, 0, 0.1)';
+  public static tokenColor = '#222222';
+  public static tokenBorderColor = 'rgba(0, 0, 0, 0.16)';
+  public static tokenBgHover = 'rgba(0, 0, 0, 0.16)';
+  public static tokenColorHover = '#222222';
+  public static tokenBorderColorHover = 'rgba(0, 0, 0, 0.16)';
+  public static tokenBgActive = '#3D3D3D';
+  public static tokenColorActive = '#FFFFFF';
+  public static tokenBorderColorActive = 'transparent';
 
   //#endregion Token
   //#region TokenInput


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
Для 5.0 осталось удалить все устаревшие сущности, которые так или иначе помечены deprecated. Кроме пропа `mask` в `Input` и всего, что с ним связано. Его мы решили пока оставить.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
- Удалил проп `hideScrollBar` в `ScrollContainer`.
- Удалил проп `Color` в `Toggle`.
- Удалил проп `shouldBeVisibledWithLessThanTwoPages` в `Paging`.
- Удалил устаревшие типы размера в ряде компонентов.
- Переменные `color` в `Token` - `Token[use](Idle|Active)`, `tokenWhite`, `tokenBlack`
- Переименовал некоторые переменные и стили `Token`, убрал из названия цвет и привёл названия к принятому стилю наименования.

## Ссылки
resolve IF-1960
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
