### PR TITLE
fix(Toast): restore root data-tid

### DIFF
--- a/packages/react-ui/components/Toast/ToastView.tsx
+++ b/packages/react-ui/components/Toast/ToastView.tsx
@@ -6,7 +6,7 @@ import { Nullable } from '../../typings/utility-types';
 import { ZIndex } from '../../internal/ZIndex';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
-import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { CloseButtonIcon } from '../../internal/CloseButtonIcon/CloseButtonIcon';
 
@@ -55,14 +55,14 @@ export class ToastView extends React.Component<ToastViewProps> {
       <ThemeContext.Consumer>
         {(theme) => {
           this.theme = theme;
-          return <CommonWrapper {...this.props}>{this.renderMain(this.props)}</CommonWrapper>;
+          return this.renderMain();
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  private renderMain = (props: CommonWrapperRestProps<ToastViewProps>) => {
-    const { action, onClose, ...rest } = props;
+  private renderMain = () => {
+    const { action, onClose, onMouseEnter, onMouseLeave } = this.props;
 
     const link = action ? (
       <button
@@ -91,13 +91,21 @@ export class ToastView extends React.Component<ToastViewProps> {
     ) : null;
 
     return (
-      <ZIndex priority="Toast" className={styles.wrapper(this.theme)}>
-        <div data-tid={ToastDataTids.toastView} {...rest} className={styles.root(this.theme)} ref={this.setRootNode}>
-          <span>{this.props.children}</span>
-          {link}
-          {close}
-        </div>
-      </ZIndex>
+      <CommonWrapper {...this.props}>
+        <ZIndex priority="Toast" className={styles.wrapper(this.theme)}>
+          <div
+            data-tid={ToastDataTids.toastView}
+            className={styles.root(this.theme)}
+            ref={this.setRootNode}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+          >
+            <span>{this.props.children}</span>
+            {link}
+            {close}
+          </div>
+        </ZIndex>
+      </CommonWrapper>
     );
   };
 }

--- a/packages/react-ui/components/Toast/__tests__/Toast-test.tsx
+++ b/packages/react-ui/components/Toast/__tests__/Toast-test.tsx
@@ -100,4 +100,17 @@ describe('Toast', () => {
     });
     expect(handler).toHaveBeenCalled();
   });
+
+  it('has correct data-tids', () => {
+    const toastRef = React.createRef<Toast>();
+    const customDataTid = 'custom-data-tid';
+    render(<Toast data-tid={customDataTid} ref={toastRef} />);
+
+    act(() => {
+      toastRef.current?.push('message');
+    });
+
+    expect(screen.getByTestId(customDataTid)).toBeInTheDocument();
+    expect(screen.getByTestId(ToastDataTids.toastView)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Во время обновления зависимостей (#3400) почему-то сломалась типизация, которую "полечили" неправильным использованием `CommonWrapper`. Из-за этого `ToastDataTids.toastView` стал перезатираться.

<details>
<summary>Неправильное использование, проблема с пропами</summary>

![image](https://github.com/user-attachments/assets/43d6ce4f-89e6-4a0c-8ecc-9830b7b6c11c)

</details>

<details>
<summary>Правильное использование, проблема с типами</summary>

![image](https://github.com/user-attachments/assets/8a826345-3317-4ab5-b782-d99e5c3e7376)

</details>

<!-- Подробно опиши решаемую проблему. -->

## Решение

Проблему с типами решить пока не удалось. Поэтому переделал использование `CommonWrapper` и проброс пропов по другому, но корректно.

Старый проброс `...rest` в `div` посчитал излишним, т.к. список возможных пропов там ограничен. Это позволило упростить решение.

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

IF-1990

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
