### PR TITLE
fix(ComboBox): restore comboBoxAllowValueChangeInEditingState feature flag

### DIFF
--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -14,6 +14,11 @@ import { responsiveLayout } from '../../components/ResponsiveLayout/decorator';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { ComboBoxExtendedItem } from '../../components/ComboBox';
 import { SizeProp } from '../../lib/types/props';
+import {
+  ReactUIFeatureFlags,
+  ReactUIFeatureFlagsContext,
+  getFullReactUIFlagsContext,
+} from '../../lib/featureFlagsContext';
 
 import { ComboBoxRequestStatus } from './CustomComboBoxTypes';
 import { CustomComboBoxAction, CustomComboBoxEffect, reducer } from './CustomComboBoxReducer';
@@ -120,6 +125,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
   private focused = false;
   private cancelationToken: Nullable<(reason?: Error) => void> = null;
   private isMobileLayout!: boolean;
+  private featureFlags!: ReactUIFeatureFlags;
 
   private reducer = reducer;
   public cancelLoaderDelay: () => void = () => null;
@@ -314,9 +320,16 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
     };
 
     return (
-      <CommonWrapper {...this.props}>
-        <ComboBoxView {...viewProps} size={this.props.size} ref={this.setRootNode} />
-      </CommonWrapper>
+      <ReactUIFeatureFlagsContext.Consumer>
+        {(flags) => {
+          this.featureFlags = getFullReactUIFlagsContext(flags);
+          return (
+            <CommonWrapper {...this.props}>
+              <ComboBoxView {...viewProps} size={this.props.size} ref={this.setRootNode} />
+            </CommonWrapper>
+          );
+        }}
+      </ReactUIFeatureFlagsContext.Consumer>
     );
   }
 
@@ -336,6 +349,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
         type: 'DidUpdate',
         prevProps,
         prevState,
+        fixValueChange: this.featureFlags.comboBoxAllowValueChangeInEditingState,
       },
       false,
     );

--- a/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
+++ b/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
@@ -4,7 +4,7 @@
 
 ```typescript static
 export interface ReactUIFeatureFlags {
-  textareaUseSafari17Workaround?: boolean;
+  comboBoxAllowValueChangeInEditingState?: boolean;
 }
 ```
 
@@ -20,28 +20,39 @@ import { ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
 
 ## Использование
 
-### textareaUseSafari17Workaround
+### comboBoxAllowValueChangeInEditingState
 
-В браузере Safari версии 17.* возник баг в реактовом элементе `<textarea />`. Баг не позволяет нормально вводить текст в пустые строки.
-Но только если эти пустые строки были при монтировании элемента.
-Если пустые строки добавить сразу после монтирования, то проблема не наблюдается.
+Этот флаг позволяет менять значение value в Combobox в режиме редактирования. Теперь при изменении value в этом режиме, Combobox примет и корректно отрисует новое значение. А в случае, если при этом было открыто выпадающее меню, данные в нём тоже будут обновлены без принудительного закрытия.
 
-Мы можем купировать этот баг на своей стороне, но только в рамках контрола `Textarea`.
-Также баг могут поправить на стороне Safari или React, из-за чего уже наше обходное решение может вызвать другой баг.
-Поэтому лучше добавить возможность выключить в любой момент наше обходное решение.
+В примере ниже, при нажатии на кнопку "Обновить" после редактирования текста без флага, в функции handleValueChange приходилось бы дополнительно вызывать метод Combobox'a reset.
 
-Обходное решение само отслеживает Safari версии 17.*, и применяется только для него.
+В React UI 5.0 фича будет применена по умолчанию.
 
 ```jsx harmony
-import { Textarea, ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
+import { Button, ComboBox, ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
 
-const [value, setValue] = React.useState('1\n\n\n\n2');
+const [value, setValue] = React.useState({ value: '', label: '' });
 
-<ReactUIFeatureFlagsContext.Provider value={{ textareaUseSafari17Workaround: true }}>
-  <Textarea
+const handleValueChange = () => {
+  setValue({ value: `Update ${new Date().toLocaleString()}`, label: `Update ${new Date().toLocaleString()}` });
+};
+
+const getItems = () =>
+  Promise.resolve([
+    { value: 'Первый', label: 'Первый' },
+    { value: 'Второй', label: 'Второй' },
+  ]);
+
+<ReactUIFeatureFlagsContext.Provider value={{ comboBoxAllowValueChangeInEditingState: true }}>
+  <Button onClick={handleValueChange}>Обновить</Button>
+  <ComboBox
     value={value}
-    onValueChange={setValue}
-    rows={5}
+    searchOnFocus={false}
+    getItems={getItems}
+    onValueChange={(value) => setValue(value)}
+    onInputValueChange={(value) => {
+      setValue({ value, label: value });
+     }}
   />
 </ReactUIFeatureFlagsContext.Provider>
 ```

--- a/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
+++ b/packages/react-ui/lib/featureFlagsContext/FEATUREFLAGSCONTEXT.md
@@ -26,8 +26,6 @@ import { ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
 
 В примере ниже, при нажатии на кнопку "Обновить" после редактирования текста без флага, в функции handleValueChange приходилось бы дополнительно вызывать метод Combobox'a reset.
 
-В React UI 5.0 фича будет применена по умолчанию.
-
 ```jsx harmony
 import { Button, ComboBox, ReactUIFeatureFlagsContext } from '@skbkontur/react-ui';
 

--- a/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
+++ b/packages/react-ui/lib/featureFlagsContext/ReactUIFeatureFlagsContext.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 
-export interface ReactUIFeatureFlags {}
+export interface ReactUIFeatureFlags {
+  comboBoxAllowValueChangeInEditingState?: boolean;
+}
 
-export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {};
+export const reactUIFeatureFlagsDefault: ReactUIFeatureFlags = {
+  comboBoxAllowValueChangeInEditingState: false,
+};
 
 export const ReactUIFeatureFlagsContext = React.createContext<ReactUIFeatureFlags>(reactUIFeatureFlagsDefault);
 


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
После удаления флага появились баги в Фиас и в самом Комбобоксе. Решили вернуть фичефлаг.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

- Вернул фичефлаг, убрал поведение под него. 
- Вернул тесты поведения под фичефлагом.
- Удалил упоминание фичефлага для Textarea из документации, т.к. он не используется нигде.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->
fix [IF-1988](https://yt.skbkontur.ru/issue/IF-1988)
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
