### PR TITLE
chore(TokenInput): remove mention of whitespace from default locale

### DIFF
--- a/packages/react-ui/.creevey/images/TokenInput/[combined] filled/editToken/chrome2022/editToken.png
+++ b/packages/react-ui/.creevey/images/TokenInput/[combined] filled/editToken/chrome2022/editToken.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea690729c6d67380783e04d6c28979488026ba9c74f9c48c3bee0bef9e78d267
-size 11542
+oid sha256:82fedcd03b54274e370d9bb1e328b03401866c8ed2d1c71ac3d995fa67b8ef57
+size 10756

--- a/packages/react-ui/.creevey/images/TokenInput/[combined] filled/editToken/chrome2022Dark/editToken.png
+++ b/packages/react-ui/.creevey/images/TokenInput/[combined] filled/editToken/chrome2022Dark/editToken.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7bca39b2f0a0b7622ce1ef9864c637c8680c29881c2612d2b7c1a4443e7b6cef
-size 9936
+oid sha256:3915008d457c9aa6a416923d5687e42bf3dee5a65af7513f63d508eb3ae3a08a
+size 9364

--- a/packages/react-ui/.creevey/images/TokenInput/[combined] filled/selectAndType/chrome2022/typed.png
+++ b/packages/react-ui/.creevey/images/TokenInput/[combined] filled/selectAndType/chrome2022/typed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0d1b16fb82ded9bfbba77fce5b9f7c74d8e95c04cdbf5862cda837182e5fe50
-size 13105
+oid sha256:791b279a8aba88ddcdccf9d126b090b446910398291d541c29e0d718d243e969
+size 12166

--- a/packages/react-ui/.creevey/images/TokenInput/[combined] filled/selectAndType/chrome2022Dark/typed.png
+++ b/packages/react-ui/.creevey/images/TokenInput/[combined] filled/selectAndType/chrome2022Dark/typed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc0377eb7adac3b0cd8790aa9961517dbf5fbf105c5980e8a98a02c6b927c99d
-size 11698
+oid sha256:5213ba5ba2bdbf62377c33c07ad227300000f825b3b4be5f9334981affadb4a8
+size 10812

--- a/packages/react-ui/.creevey/images/TokenInput/empty combined/selectFirst/chrome2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/empty combined/selectFirst/chrome2022.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc979e2492e58a8d3aac40c2b51baf658f92b5a1cc401ad863e49ca54cac1520
-size 9585
+oid sha256:fd7df6f93471706b8bf911bd001bc380138f04b4af2b5365acff05b9285149ef
+size 8497

--- a/packages/react-ui/.creevey/images/TokenInput/empty combined/selectFirst/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/empty combined/selectFirst/chrome2022Dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2faf3cda39d0c8a972ac39337578511719a5679f053702d92264be18f85d421
-size 8177
+oid sha256:035112a6c98f1cccf4f71e02ab817e5a98e489311db09235ceabafc0c181d137
+size 7137

--- a/packages/react-ui/components/TokenInput/TokenInput.md
+++ b/packages/react-ui/components/TokenInput/TokenInput.md
@@ -295,12 +295,12 @@ interface TokenInputLocale {
 }
 
 const ru_RU = {
-  addButtonComment: 'Нажмите запятую или пробел',
+  addButtonComment: 'Нажмите запятую',
   addButtonTitle: 'Добавить',
 };
 
 const en_GB = {
-  addButtonComment: 'Type comma or space',
+  addButtonComment: 'Type comma',
   addButtonTitle: 'Add',
 };
 ```

--- a/packages/react-ui/components/TokenInput/locale/locales/en.ts
+++ b/packages/react-ui/components/TokenInput/locale/locales/en.ts
@@ -1,6 +1,6 @@
 import { TokenInputLocale } from '../types';
 
 export const componentsLocales: TokenInputLocale = {
-  addButtonComment: 'Type comma or space',
+  addButtonComment: 'Type comma',
   addButtonTitle: 'Add',
 };

--- a/packages/react-ui/components/TokenInput/locale/locales/ru.ts
+++ b/packages/react-ui/components/TokenInput/locale/locales/ru.ts
@@ -1,6 +1,6 @@
 import { TokenInputLocale } from '../types';
 
 export const componentsLocales: TokenInputLocale = {
-  addButtonComment: 'Нажмите запятую или пробел',
+  addButtonComment: 'Нажмите запятую',
   addButtonTitle: 'Добавить',
 };


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
После [отключения](https://github.com/skbkontur/retail-ui/pull/3434) фиче флагов не убрали из локали упоминание пробела в качестве одного из разделителей по умолчанию.
## Решение
Убрал из локали и доки локали упоминание пробела.
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ✅ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
