### PR TITLE
chore(Checkbox, Radio, FileUploader, Paging): unlink vars

### DIFF
--- a/packages/react-ui/.creevey/images/ThemeProvider/Unlink Vars/chrome2022.png
+++ b/packages/react-ui/.creevey/images/ThemeProvider/Unlink Vars/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10370bacf3d7537b45baba2693c11b91c6aa04873c61a461fc0bfc3edd9f46e7
+size 14478

--- a/packages/react-ui/components/Paging/Paging.styles.ts
+++ b/packages/react-ui/components/Paging/Paging.styles.ts
@@ -69,7 +69,7 @@ export const styles = memoizeStyle({
     return css`
       box-sizing: ${t.pagingPageLinkBoxSizing};
       border-radius: ${t.pagingPageLinkBorderRadius};
-      color: ${t.pagingForwardLinkColor};
+      color: ${t.pagingPageLinkColor};
       cursor: pointer;
       display: block;
       margin: ${t.pagingPageLinkMargin};

--- a/packages/react-ui/internal/ThemePlayground/UnlinkVarsPlayground.tsx
+++ b/packages/react-ui/internal/ThemePlayground/UnlinkVarsPlayground.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+import { ThemeContext } from '../../lib/theming/ThemeContext';
+import { ThemeFactory } from '../../lib/theming/ThemeFactory';
+import { Checkbox, CheckboxProps } from '../../components/Checkbox';
+import { Radio } from '../../components/Radio';
+import { FileUploader } from '../../components/FileUploader';
+import { Paging } from '../../components/Paging';
+
+import { getComponentsFromPropsList } from './helpers';
+
+type CheckboxProp = CheckboxProps & { focused?: boolean };
+const propsList: CheckboxProp[] = [
+  { children: 'Semichecked', initialIndeterminate: true },
+  { children: 'Checked', checked: true },
+  { children: 'Checked & Focused', checked: true, focused: true },
+];
+
+export const UnlinkVarsPlayground = () => {
+  const theme = ThemeFactory.create({ borderColorFocus: '#7474DA', linkColor: '#0000cc' });
+  const [active, setActive] = useState(3);
+  return (
+    <ThemeContext.Provider value={theme}>
+      <div style={{ display: 'grid', gap: '10px' }}>
+        {getComponentsFromPropsList(<Checkbox />, propsList)}
+        <Paging activePage={active} pagesCount={5} onPageChange={(num) => setActive(num)} />
+        <FileUploader />
+        <Radio value={'foo'} focused />
+      </div>
+    </ThemeContext.Provider>
+  );
+};

--- a/packages/react-ui/internal/ThemePlayground/__creevey__/ThemeProvider.creevey.ts
+++ b/packages/react-ui/internal/ThemePlayground/__creevey__/ThemeProvider.creevey.ts
@@ -55,4 +55,14 @@ kind('ThemeProvider', () => {
       await this.expect(await this.browser.takeScreenshot()).to.matchImage('theme 2022 dark bottom');
     });
   });
+
+  story('UnlinkVars', ({ setStoryParameters }) => {
+    setStoryParameters({
+      skip: {
+        'themes do not affect logic': {
+          in: ['chrome2022Dark', 'firefox2022', 'firefox2022Dark'],
+        },
+      },
+    });
+  });
 });

--- a/packages/react-ui/internal/ThemePlayground/__stories__/ThemePlayground.stories.tsx
+++ b/packages/react-ui/internal/ThemePlayground/__stories__/ThemePlayground.stories.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 
 import { Story } from '../../../typings/stories';
 import { ThemeContextPlayground } from '../ThemeContextPlayground';
+import { UnlinkVarsPlayground } from '../UnlinkVarsPlayground';
 
 export default { title: 'ThemeProvider' };
 
 export const Playground: Story = () => <ThemeContextPlayground />;
 Playground.storyName = 'playground';
+
+export const UnlinkVars: Story = () => <UnlinkVarsPlayground />;

--- a/packages/react-ui/internal/themes/BasicDarkTheme.ts
+++ b/packages/react-ui/internal/themes/BasicDarkTheme.ts
@@ -262,6 +262,7 @@ export class BasicDarkThemeInternal extends (class {} as typeof BasicLightTheme)
   public static calendarCellSelectedFontColor = 'rgba(255, 255, 255, 0.87)';
   //#endregion Calendar
   //#region Paging
+  public static pagingPageLinkColor = 'rgba(255, 255, 255, 0.87)';
   public static pagingPageLinkHoverBg = 'rgba(255, 255, 255, 0.06)';
   public static pagingPageLinkActiveBg = 'rgba(255, 255, 255, 0.1)';
   public static pagingPageLinkDisabledActiveBg = 'rgba(255, 255, 255, 0.08)';

--- a/packages/react-ui/internal/themes/BasicDarkTheme.ts
+++ b/packages/react-ui/internal/themes/BasicDarkTheme.ts
@@ -32,6 +32,7 @@ export class BasicDarkThemeInternal extends (class {} as typeof BasicLightTheme)
   public static bgDisabled = '#434343';
   public static bgDefault = '#1f1f1f';
   public static bgSecondary = '#333333';
+  public static bgChecked = '#EBEBEB';
   public static outlineColorFocus = '#EBEBEB';
   public static borderColorFocus = '#EBEBEB';
   public static get borderColorError() {
@@ -485,7 +486,9 @@ export class BasicDarkThemeInternal extends (class {} as typeof BasicLightTheme)
     return this.checkboxShadow;
   }
 
-  public static checkboxCheckedBg = '#EBEBEB';
+  public static get checkboxCheckedBg() {
+    return this.bgChecked;
+  }
   public static checkboxCheckedColor = 'rgba(0, 0, 0, 0.87)';
   public static checkboxHoverBg = 'rgba(255, 255, 255, 0.16)';
   public static get checkboxCheckedHoverBg() {

--- a/packages/react-ui/internal/themes/BasicLightTheme.ts
+++ b/packages/react-ui/internal/themes/BasicLightTheme.ts
@@ -72,6 +72,7 @@ export class BasicLightThemeInternal {
   public static specificityLevel = '0';
   public static fixedPanelShadow = 'none';
   public static bgActive = '#141414';
+  public static bgChecked = '#3D3D3D';
   public static borderColorFocus = '#3D3D3D';
   public static get borderColorError() {
     return this.errorMain;
@@ -1042,6 +1043,9 @@ export class BasicLightThemeInternal {
   public static get pagingForwardIconSize() {
     return this.pagingFontSize;
   }
+  public static get pagingPageLinkColor() {
+    return this.textColorDefault;
+  }
   public static pagingPageLinkBoxSizing = 'border-box';
   public static pagingPageLinkPaddingX = '12px';
   public static pagingPageLinkPaddingY = '0.3125em';
@@ -1069,7 +1073,7 @@ export class BasicLightThemeInternal {
   public static pagingPageLinkHintMargin = '4px -20px 0px';
   public static pagingPageLinkMargin = '0px 1px';
   public static get pagingForwardLinkColor() {
-    return this.linkColor;
+    return this.textColorDefault;
   }
   public static get pagingForwardLinkDisabledColor() {
     return this.linkDisabledColor;
@@ -1845,7 +1849,7 @@ export class BasicLightThemeInternal {
     return this.btnDefaultActiveBg;
   }
   public static get checkboxCheckedBg() {
-    return this.borderColorFocus;
+    return this.bgChecked;
   }
   public static get checkboxBgDisabled() {
     return this.bgDisabled;
@@ -2388,7 +2392,7 @@ export class BasicLightThemeInternal {
     return this.borderColorFocus;
   }
   public static get fileUploaderLinkColor() {
-    return this.linkColor;
+    return this.textColorDefault;
   }
   public static fileUploaderAfterLinkColor = '#858585';
   public static fileUploaderIconSize = '14px';


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
У некоторых переменных есть неочевидные для пользователя связи и стили меняются в неожиданных местах.
<!-- Подробно опиши решаемую проблему. -->

## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

- Завёл переменную `pagingPageLinkColor` для `Paging`, эта переменная и `pagingForwardLinkColor` наследуются от `textColorDefault`.
- Завёл переменную `bgChecked`, `checkboxCheckedBg` наследуется от неё. А от неё уже наследуется переменная `radioCheckedBgColor`.
- `fileUploaderLinkColor` теперь наследуется от `textColorDefault`.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->
Close [IF-1993](https://yt.skbkontur.ru/issue/IF-1993) Связь переменных в 5.0
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
