### PR TITLE
docs: add ability to update Storybook globals in composition mode

### DIFF
--- a/packages/react-ui/.storybook/composite-checker/manager.ts
+++ b/packages/react-ui/.storybook/composite-checker/manager.ts
@@ -1,0 +1,24 @@
+import { useGlobals, addons, types } from '@storybook/manager-api';
+import { useEffect } from 'react';
+
+// NOTE: Because storybook addons are not loaded in composite mode, this simple addon only runs in non-composite mode and resets the `isComposite` flag
+const Render = () => {
+  const [globals, updateGlobals] = useGlobals();
+
+  useEffect(() => {
+    if (globals.isComposite) {
+      updateGlobals({ isComposite: false });
+    }
+  }, [globals.isComposite])
+
+  return null;
+}
+
+addons.register('Checker addon', () => {
+  addons.add('Checker tool', {
+    type: types.TOOL,
+    title: 'Composite checker',
+    match: () => true,
+    render: Render,
+  });
+});

--- a/packages/react-ui/.storybook/main.ts
+++ b/packages/react-ui/.storybook/main.ts
@@ -12,6 +12,7 @@ const config: StorybookConfig = {
         docs: false,
       },
     },
+    './composite-checker',
   ],
   framework: {
     name: '@storybook/react-webpack5',

--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { global } from '@storybook/global';
 import { setFilter } from '@skbkontur/react-props2attrs';
 import { findAmongParents } from '@skbkontur/react-sorge/lib';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
@@ -10,6 +11,7 @@ import { LIGHT_THEME_MOBILE } from '../lib/theming/themes/LightThemeMobile';
 import { LIGHT_THEME } from '../lib/theming/themes/LightTheme';
 import { DARK_THEME } from '../lib/theming/themes/DarkTheme';
 import { ThemeFactory } from '../lib/theming/ThemeFactory';
+import { Button } from '../components/Button';
 
 const customViewports = {
   iphone: {
@@ -51,7 +53,24 @@ setFilter((fiber) => {
 
 const MOBILE_REGEXP = /Mobile.*/i;
 
+const useGlobals = global.__STORYBOOK_MODULE_CLIENT_API__.useGlobals
+
 export const decorators: Meta['decorators'] = [
+  (Story) => {
+    const [globals, updateGlobals] = useGlobals()
+
+    return (
+      <>
+        {globals.isComposite && (
+          <>
+            <Button onClick={() => updateGlobals({ theme: 'THEME_2022' })}>LIGHT_THEME</Button>
+            <Button onClick={() => updateGlobals({ theme: 'DARK_THEME' })}>DARK_THEME</Button>
+          </>
+        )}
+        <Story />
+      </>
+    )
+  },
   (Story, context) => {
     const storybookTheme = themes[context.globals.theme] || LIGHT_THEME;
     if ([DARK_THEME].includes(storybookTheme)) {
@@ -120,6 +139,12 @@ export const parameters: Meta['parameters'] = {
 };
 
 export const globalTypes = {
+  // NOTE: We always think that we are in composite mode and switch to non-composite mode only by `composite-checker` addon
+  isComposite: {
+    name: 'Composite',
+    description: 'Composite mode',
+    defaultValue: true,
+  },
   theme: {
     name: 'Theme',
     description: 'React UI Theme',


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Storybook doesn't share globals between various instances in composition mode, so user can't play with stories through switching theme or other parameters, which are usually available in toolbar in non-composition mode. 

## Решение

I added `isComposite` flag in globalTypes which is `true` by default and also added a simple addon that disables the flag. Because Storybook doesn't support addons in composition mode. When user opens storybook instance directly the addon disables the flag and we don't show globals switchers in story canvas. But otherwise the addon isn't run and flag wouldn't be reseted so we show our own tool bar for switching globals 

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
