### PR TITLE
refactor(Button, Link): return user select

### DIFF
--- a/packages/react-ui/components/Button/Button.styles.ts
+++ b/packages/react-ui/components/Button/Button.styles.ts
@@ -1,6 +1,6 @@
 import { css, memoizeStyle, prefix } from '../../lib/theming/Emotion';
 import { Theme } from '../../lib/theming/Theme';
-import { resetButton, resetText, disableTextSelect } from '../../lib/styles/Mixins';
+import { resetButton, resetText } from '../../lib/styles/Mixins';
 
 import {
   buttonUseMixin,
@@ -24,7 +24,6 @@ export const styles = memoizeStyle({
     return css`
       ${resetButton()};
       ${resetText()};
-      ${disableTextSelect()};
 
       transition: background-color ${t.transitionDuration} ${t.transitionTimingFunction}
         ${t.btnBorderColorTransition ? `, ${t.btnBorderColorTransition}` : ''};

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { globalObject } from '@skbkontur/global-object';
 
 import { ButtonLinkAllowedValues } from '../../lib/types/button-link';
-import { resetButton, disableTextSelect } from '../../lib/styles/Mixins';
+import { resetButton } from '../../lib/styles/Mixins';
 import { PolymorphicPropsWithoutRef } from '../../lib/types/polymorphic-component';
 import { keyListener } from '../../lib/events/keyListener';
 import { Theme, ThemeIn } from '../../lib/theming/Theme';
@@ -185,7 +185,6 @@ export class Link<C extends ButtonLinkAllowedValues = typeof LINK_DEFAULT_COMPON
       className: cx({
         [styles.root(this.theme)]: true,
         [resetButton()]: Root === 'button',
-        [disableTextSelect()]: disabled || loading,
         [styles.focus(this.theme)]: isFocused,
         [styles.disabled(this.theme)]: disabled || loading,
         [styles.useDefault(this.theme)]: use === 'default',

--- a/packages/react-ui/lib/styles/Mixins.ts
+++ b/packages/react-ui/lib/styles/Mixins.ts
@@ -49,15 +49,3 @@ export const resetText = () => {
     text-shadow: none;
   `;
 };
-
-export const disableTextSelect = () => {
-  return css`
-    -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-    -khtml-user-select: none; /* Konqueror HTML */
-    -moz-user-select: none; /* Old versions of Firefox */
-    -ms-user-select: none; /* Internet Explorer/Edge */
-    user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome, Edge, Opera and Firefox */
-  `;
-};


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
В https://github.com/skbkontur/retail-ui/pull/3521 убрали возможность выделения текста. Но оказалось, что для пользователей это важный сценарий.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Убрал стиль с `user-select: none` у `Button` и `Link`. У `Button component=a`  появилось выделение текста при двойном клике, из-за чего я изначально убирал выделение. Это можно через js убрать, но кажется, что не очень важно.
## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
