### PR TITLE
fix(DatePicker): scrolling to today

### DIFF
--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -407,7 +407,9 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
           aria-label={this.locale.todayAriaLabel}
           data-tid={DatePickerDataTids.pickerTodayWrapper}
           width="100%"
-          onClick={() => {this.handleSelect(today)}}
+          onClick={() => {
+            this.handleSelect(today);
+          }}
           icon={<ArrowAUpIcon16Light />}
         >
           {this.locale.today}

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -407,7 +407,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
           aria-label={this.locale.todayAriaLabel}
           data-tid={DatePickerDataTids.pickerTodayWrapper}
           width="100%"
-          onClick={this.handleSelectToday(today)}
+          onClick={() => {this.handleSelect(today)}}
           icon={<ArrowAUpIcon16Light />}
         >
           {this.locale.today}
@@ -415,10 +415,6 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
       </div>
     );
   }
-
-  private handleSelectToday = (today: string) => () => {
-    this.handleSelect(today);
-  };
 
   public getParent = () => {
     return getRootNode(this);

--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -23,7 +23,7 @@ import { Calendar, CalendarDateShape, CalendarProps } from '../Calendar';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
 import { Button } from '../Button';
-import { getMonthInHumanFormat, getTodayDate } from '../Calendar/CalendarUtils';
+import { getTodayDate } from '../Calendar/CalendarUtils';
 import { SizeProp } from '../../lib/types/props';
 import { responsiveLayout } from '../ResponsiveLayout/decorator';
 import { getMenuPositions } from '../../lib/getMenuPositions';
@@ -176,7 +176,6 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
 
   private getProps = createPropsGetter(DatePicker.defaultProps);
   private theme!: Theme;
-  private calendar: Calendar | null = null;
   private readonly locale!: DatePickerLocale;
 
   public static validate = (value: Nullable<string>, range: { minDate?: string; maxDate?: string } = {}) => {
@@ -331,7 +330,6 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
                 onMouseDown={(e) => e.preventDefault()}
               >
                 <Calendar
-                  ref={(c) => (this.calendar = c)}
                   maxDate={this.parseValueToDate(maxDate)}
                   minDate={this.parseValueToDate(minDate)}
                   onValueChange={this.handleValueChange}
@@ -420,12 +418,6 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
 
   private handleSelectToday = (today: string) => () => {
     this.handleSelect(today);
-
-    if (this.calendar) {
-      const { month: monthNative, year } = this.state.today;
-      const month = getMonthInHumanFormat(monthNative);
-      this.calendar.scrollToMonth(month, year);
-    }
   };
 
   public getParent = () => {

--- a/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
+++ b/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
@@ -323,24 +323,3 @@ export const WithManualPosition: Story = () => {
   );
 };
 WithManualPosition.storyName = 'with manual position';
-
-export const TEST: Story = () => {
-  const [date, setDate] = useState('01.09.2024');
-
-  return (
-    <DatePicker
-      width={200}
-      value={date}
-      onValueChange={(date) => {
-        setDate(date);
-      }}
-      onMonthChange={(changeInfo) => console.log(changeInfo)}
-      enableTodayLink
-    />
-  );
-};
-TEST.parameters = {
-  creevey: {
-    skip: true,
-  },
-};

--- a/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
+++ b/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
@@ -339,3 +339,8 @@ export const TEST: Story = () => {
     />
   );
 };
+TEST.parameters = {
+  creevey: {
+    skip: true,
+  },
+};

--- a/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
+++ b/packages/react-ui/components/DatePicker/__stories__/DatePicker.stories.tsx
@@ -323,3 +323,19 @@ export const WithManualPosition: Story = () => {
   );
 };
 WithManualPosition.storyName = 'with manual position';
+
+export const TEST: Story = () => {
+  const [date, setDate] = useState('01.09.2024');
+
+  return (
+    <DatePicker
+      width={200}
+      value={date}
+      onValueChange={(date) => {
+        setDate(date);
+      }}
+      onMonthChange={(changeInfo) => console.log(changeInfo)}
+      enableTodayLink
+    />
+  );
+};


### PR DESCRIPTION
## Проблема

При использовании пропа onMonthChange в DatePicker при нажатии "Сегодня" возникает ошибка.

## Решение

Оказалось, что перемотка календаря вызывалась дважды: первая еще не заканчивалась, а вторая уже начиналась и календарь листался слишком сильно, пролистывая текущую дату и месяц, из-за чего возникала ошибка.

Я оставила лишь один вызов метода, который вызывает перемотку календаря.
Создала историю с названием TEST, с помощью которой легко проверить, что всё правильно работает. Для этого нужно выбрать дату позже 01.01.2024 или раньше 01.07.2024 и нажать "Сегодня". Раньше выкидывалась ошибка, теперь же всё работает правильно.
Тестовую историю планирую убрать после ревью, так как считаю, что это поведение постоянно проверять не нужно.

## Ссылки

Задача [IF-1992](https://yt.skbkontur.ru/issue/IF-1992)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
