### PR TITLE
fix(ZIndex): change document to getRootNode

### DIFF
--- a/packages/react-ui/internal/ZIndex/ZIndex.tsx
+++ b/packages/react-ui/internal/ZIndex/ZIndex.tsx
@@ -189,7 +189,8 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
 
       if (isInstanceOf(portal, globalObject.HTMLElement)) {
         const portalID = portal.getAttribute(PORTAL_OUTLET_ATTR);
-        const noscript = document.querySelector(`noscript[${PORTAL_INLET_ATTR}="${portalID}"]`);
+        const root = element.getRootNode() as HTMLElement;
+        const noscript = root.querySelector(`noscript[${PORTAL_INLET_ATTR}="${portalID}"]`);
         const parent = noscript?.parentElement?.closest('[style*=z-index]');
 
         if (isInstanceOf(parent, globalObject.HTMLElement)) {

--- a/packages/react-ui/internal/ZIndex/ZIndex.tsx
+++ b/packages/react-ui/internal/ZIndex/ZIndex.tsx
@@ -189,8 +189,7 @@ export class ZIndex extends React.Component<ZIndexProps, ZIndexState> {
 
       if (isInstanceOf(portal, globalObject.HTMLElement)) {
         const portalID = portal.getAttribute(PORTAL_OUTLET_ATTR);
-        const root = element.getRootNode() as HTMLElement;
-        const noscript = root.querySelector(`noscript[${PORTAL_INLET_ATTR}="${portalID}"]`);
+        const noscript = globalObject.document?.querySelector(`noscript[${PORTAL_INLET_ATTR}="${portalID}"]`);
         const parent = noscript?.parentElement?.closest('[style*=z-index]');
 
         if (isInstanceOf(parent, globalObject.HTMLElement)) {


### PR DESCRIPTION
## Проблема

При получении контекста через dom есть прямое обращение к `document`. 
Доступ к `document/window` должен быть через `global-object`, либо через html-элементы полученные через ref, иначе `Upgrade.setWindow()` не будет работать ожидаемо.

## Решение

Заменила 
```const noscript = document.querySelector(...); ```
на 
```
const root = element.getRootNode() as HTMLElement;
const noscript = root.querySelector(...);
```

## Ссылки

Задача [IF-1949](https://yt.skbkontur.ru/issue/IF-1949)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
