### PR TITLE
fix(Hint): pass data-tid

### DIFF
--- a/packages/react-ui/components/Hint/Hint.tsx
+++ b/packages/react-ui/components/Hint/Hint.tsx
@@ -176,6 +176,7 @@ export class Hint extends React.PureComponent<HintProps, HintState> implements I
           useWrapper={useWrapper}
           ref={this.popupRef}
           withoutMobile
+          data-tid={this.getProps()['data-tid']}
         >
           {this.renderContent()}
         </Popup>

--- a/packages/react-ui/components/Hint/__tests__/Hint-test.tsx
+++ b/packages/react-ui/components/Hint/__tests__/Hint-test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 
 import { Hint } from '../Hint';
+import { delay } from '../../../lib/utils';
 
 describe('Hint', () => {
   it('should render without crash', () => {
@@ -108,5 +109,18 @@ describe('Hint', () => {
     unmount();
 
     expect(clearTimeout).toHaveBeenCalledWith(timer);
+  });
+
+  it('passes data-tid', async () => {
+    const hintChildrenText = 'Базовая';
+    render(
+      <Hint text="Подсказка" data-tid="my-test-id">
+        {hintChildrenText}
+      </Hint>,
+    );
+
+    await userEvent.hover(screen.getByText(hintChildrenText));
+    await delay(500);
+    expect(screen.getByTestId('my-test-id')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Проблема

При прокидывании дата-тида дата-тид не ставится на Hint

## Решение

Прокинула data-tid и написала unit-тест.

## Ссылки

Задача [IF-1959](https://yt.skbkontur.ru/issue/IF-1959)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
