### PR TITLE
feat(creevey): Add creevey's help messages for new contributors

### DIFF
--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -30,7 +30,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:pack": "tsc -p check-dts.tsconfig.json && jest --testMatch ** --testPathPattern=\\\"scripts/check-pack-files.js\\\"",
-    "creevey": "wait-on -t 300000 http-get://localhost:6060/ && creevey -c .creevey/config.js",
+    "creevey": "node ../../scripts/creevey-prepare.js localhost:6060 && creevey -c .creevey/config.js",
     "creevey:update": "creevey -c .creevey/config.js --update",
     "creevey:ui": "yarn creevey --ui"
   },

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -30,7 +30,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:pack": "tsc -p check-dts.tsconfig.json && jest --testMatch ** --testPathPattern=\\\"scripts/check-pack-files.js\\\"",
-    "creevey": "node ../../scripts/creevey-prepare.js localhost:6060 && creevey -c .creevey/config.js",
+    "creevey": "node ../../scripts/creevey-prepare.js .creevey/config.js && creevey -c .creevey/config.js",
     "creevey:update": "creevey -c .creevey/config.js --update",
     "creevey:ui": "yarn creevey --ui"
   },

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -40,7 +40,7 @@
     "fix:prettier": "yarn prettier --write .",
     "test": "jest --detectOpenHandles",
     "test:watch": "yarn test --watch",
-    "creevey": "wait-on -t 300000 http-get://localhost:6060/ && cross-env BABEL_ENV=cjs creevey -c .creevey/config.js",
+    "creevey": "node ../../scripts/creevey-prepare.js localhost:6060 && cross-env BABEL_ENV=cjs creevey -c .creevey/config.js",
     "creevey:update": "cross-env BABEL_ENV=cjs creevey -c .creevey/config.js --update",
     "creevey:ui": "yarn creevey --ui",
     "report:eslint": "yarn eslint -f eslint-html-reporter/reporter.js -o reports/eslint/index.html"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -40,7 +40,7 @@
     "fix:prettier": "yarn prettier --write .",
     "test": "jest --detectOpenHandles",
     "test:watch": "yarn test --watch",
-    "creevey": "node ../../scripts/creevey-prepare.js localhost:6060 && cross-env BABEL_ENV=cjs creevey -c .creevey/config.js",
+    "creevey": "node ../../scripts/creevey-prepare.js .creevey/config.js && cross-env BABEL_ENV=cjs creevey -c .creevey/config.js",
     "creevey:update": "cross-env BABEL_ENV=cjs creevey -c .creevey/config.js --update",
     "creevey:ui": "yarn creevey --ui",
     "report:eslint": "yarn eslint -f eslint-html-reporter/reporter.js -o reports/eslint/index.html"

--- a/scripts/creevey-prepare.js
+++ b/scripts/creevey-prepare.js
@@ -11,8 +11,8 @@ if (!process.env.GRID_URL || !process.env.GET_IP_URL) {
     process.exit(1);
 }
 
-info('Waiting Storybook...\n');
-info(`Storybook should be started via \`${STORYBOOK_RUN_COMMAND}\` and be accessible at ${config.storybookUrl}\n`);
+info(`Storybook should be started via \`${STORYBOOK_RUN_COMMAND}\` and be accessible at ${config.storybookUrl}`);
+info('Waiting Storybook...');
 
 waitOn({
     resources: [config.storybookUrl],

--- a/scripts/creevey-prepare.js
+++ b/scripts/creevey-prepare.js
@@ -1,10 +1,9 @@
 require('dotenv').config({ path: '../../.env' });
 const waitOn = require('wait-on');
+const config = require(`${process.cwd()}/${process.argv[2]}`);
 
-const STORYBOOK_USER_NOTICE_TIMEOUT = 3000;
+const STORYBOOK_USER_NOTICE_TIMEOUT = 2000;
 const STORYBOOK_NOT_RESPOND_TIMEOUT = 300000;
-
-const urls = process.argv[2].split(',');
 
 if (!process.env.GRID_URL || !process.env.GET_IP_URL) {
     error('Для запуска Creevey создайте в корне файл .env c переменными GRID_URL= и GET_IP_URL=');
@@ -15,11 +14,13 @@ if (!process.env.GRID_URL || !process.env.GET_IP_URL) {
 info('Waiting Storybook...\n');
 
 setTimeout(() => {
-    info('Check Storybook is running parallel `yarn storybook:test`\n');
+    warn('It looks like Storybook is not running!')
+    warn(`Run Storybook via \`yarn storybook:test\` and check ${config.storybookUrl}\n`);
+    info('Waiting Storybook...');
 }, STORYBOOK_USER_NOTICE_TIMEOUT);
 
 waitOn({
-    resources: urls.map(url => `http-get://${url}`),
+    resources: [config.storybookUrl],
     timeout: STORYBOOK_NOT_RESPOND_TIMEOUT
 }).then(() => {
     info('Storybook connected\n');
@@ -33,6 +34,10 @@ waitOn({
 
 function info(text) {
     console.info(`\x1b[34mINFO\x1b[0m => ${text}`);
+}
+
+function warn(text) {
+    console.info(`\x1b[33mWARNING\x1b[0m => ${text}`);
 }
 
 function error(text) {

--- a/scripts/creevey-prepare.js
+++ b/scripts/creevey-prepare.js
@@ -2,8 +2,8 @@ require('dotenv').config({ path: '../../.env' });
 const waitOn = require('wait-on');
 const config = require(`${process.cwd()}/${process.argv[2]}`);
 
-const STORYBOOK_USER_NOTICE_TIMEOUT = 2000;
 const STORYBOOK_NOT_RESPOND_TIMEOUT = 300000;
+const STORYBOOK_RUN_COMMAND = 'yarn storybook:test';
 
 if (!process.env.GRID_URL || !process.env.GET_IP_URL) {
     error('Для запуска Creevey создайте в корне файл .env c переменными GRID_URL= и GET_IP_URL=');
@@ -12,12 +12,7 @@ if (!process.env.GRID_URL || !process.env.GET_IP_URL) {
 }
 
 info('Waiting Storybook...\n');
-
-setTimeout(() => {
-    warn('It looks like Storybook is not running!')
-    warn(`Run Storybook via \`yarn storybook:test\` and check ${config.storybookUrl}\n`);
-    info('Waiting Storybook...');
-}, STORYBOOK_USER_NOTICE_TIMEOUT);
+info(`Storybook should be started via \`${STORYBOOK_RUN_COMMAND}\` and be accessible at ${config.storybookUrl}\n`);
 
 waitOn({
     resources: [config.storybookUrl],
@@ -27,17 +22,13 @@ waitOn({
     process.exit(0);
 }).catch((err) => {
     error(err);
-    error('Для запуска требуется запущенный Storybook');
+    error(`Для запуска требуется запущенный Storybook через \`${STORYBOOK_RUN_COMMAND}\``);
     error('Подробнее: https://github.com/skbkontur/retail-ui/blob/next/contributing.md#скриншотные-тесты\n');
     process.exit(1);
 });
 
 function info(text) {
     console.info(`\x1b[34mINFO\x1b[0m => ${text}`);
-}
-
-function warn(text) {
-    console.info(`\x1b[33mWARNING\x1b[0m => ${text}`);
 }
 
 function error(text) {

--- a/scripts/creevey-prepare.js
+++ b/scripts/creevey-prepare.js
@@ -1,0 +1,40 @@
+require('dotenv').config({ path: '../../.env' });
+const waitOn = require('wait-on');
+
+const STORYBOOK_USER_NOTICE_TIMEOUT = 3000;
+const STORYBOOK_NOT_RESPOND_TIMEOUT = 300000;
+
+const urls = process.argv[2].split(',');
+
+if (!process.env.GRID_URL || !process.env.GET_IP_URL) {
+    error('Для запуска Creevey создайте в корне файл .env c переменными GRID_URL= и GET_IP_URL=');
+    error('Подробнее: https://github.com/skbkontur/retail-ui/blob/next/contributing.md#скриншотные-тесты\n');
+    process.exit(1);
+}
+
+info('Waiting Storybook...\n');
+
+setTimeout(() => {
+    info('Check Storybook is running parallel `yarn storybook:test`\n');
+}, STORYBOOK_USER_NOTICE_TIMEOUT);
+
+waitOn({
+    resources: urls.map(url => `http-get://${url}`),
+    timeout: STORYBOOK_NOT_RESPOND_TIMEOUT
+}).then(() => {
+    info('Storybook connected\n');
+    process.exit(0);
+}).catch((err) => {
+    error(err);
+    error('Для запуска требуется запущенный Storybook');
+    error('Подробнее: https://github.com/skbkontur/retail-ui/blob/next/contributing.md#скриншотные-тесты\n');
+    process.exit(1);
+});
+
+function info(text) {
+    console.info(`\x1b[34mINFO\x1b[0m => ${text}`);
+}
+
+function error(text) {
+    console.error(`\x1b[31mERROR\x1b[0m => ${text}`);
+}


### PR DESCRIPTION
## Проблема

1. При запуске Creevey контрибьютеры забывают создавать `.env` файл
2. Некоторым контрибьютерам неочевидно, что `yarn creevey:ui` требует параллельного запуска `yarn storybook:test` 
3. В проектах в package.json **дублируются**:
    - URL Storybook (`http://localhost:6060`)
    - Таймаут, если Storybook не отвечает (`-t 300000`) 

## TL:DR

Добавил помощь контрибьютерам, которые впервые вызывают `yarn creevey:ui`

**1. Нет .env файла для прогона скриншотных**

https://github.com/user-attachments/assets/4b6adbdf-5b83-46f1-8f8d-e0f43f53e64f


**2. Не запущен Storybook**


https://github.com/user-attachments/assets/1123abdb-1688-4e41-ad16-ae36b17c5829


**3. Creevey не дождался ответа Storybook**

<img width="864" alt="image" src="https://github.com/user-attachments/assets/22edd2e2-4148-4025-9274-ab74d9854eaa">



## Решение

**Обобщил код перед запуском Creevey**
- Заменил wait-on на `script/creevey-prepare.js` с проверками
- Вместо URL нужно указать путь до конфига

_Было:_
```
"creevey": "wait-on -t 300000 http-get://localhost:6060/ && creevey -c .creevey/config.js"
```

_Стало:_
```
"creevey": "node ../../scripts/creevey-prepare.js .creevey/config.js && creevey -c .creevey/config.js",
```


**Добавил 3 типа ошибок**
- info — информационные сообщения, чтобы показать отклик приложения (Storybook waiting)
- warning — предупреждение, что creevey требует запуска storybook
- error — тексты на русском со ссылками на CONTRIBUTING.md 


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

3. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

5. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
