### PR TITLE
fix(SingleToast): use flushSync only in React@18

### DIFF
--- a/packages/react-ui/components/SingleToast/SingleToast.tsx
+++ b/packages/react-ui/components/SingleToast/SingleToast.tsx
@@ -16,7 +16,11 @@ export class SingleToast extends React.Component<ToastProps> {
     SingleToast.ref.current?.push(...args);
   };
   public static close: typeof Toast.close = () => {
-    ReactDOM.flushSync(() => SingleToast.ref.current?.close());
+    if (React.version.search('18') === 0) {
+      ReactDOM.flushSync(() => SingleToast.ref.current?.close());
+    } else {
+      SingleToast.ref.current?.close();
+    }
   };
   render = () => {
     return <Toast ref={SingleToast.ref} {...this.props} />;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
В react 16 при отрисовке тоста через SingleToast.push в useEffect возникает ошибка.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Убрал flushSync 
## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->
Fix [IF-1967](https://yt.skbkontur.ru/issue/IF-1967)
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
