### PR TITLE
fix(DateInput): disallow date fragment selection in disabled state

### DIFF
--- a/packages/react-ui/components/DateInput/DateInput.tsx
+++ b/packages/react-ui/components/DateInput/DateInput.tsx
@@ -145,7 +145,7 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
     ) {
       this.updateFromProps(false);
     }
-    this.selectNode();
+    !this.props.disabled && this.selectNode();
   }
 
   public selectNode = () => {

--- a/packages/react-ui/components/DateInput/__tests__/DateInput-test.tsx
+++ b/packages/react-ui/components/DateInput/__tests__/DateInput-test.tsx
@@ -362,4 +362,13 @@ describe('DateInput as InputlikeText', () => {
 
     expect(screen.getByTestId(DateInputDataTids.icon)).toBeInTheDocument();
   });
+
+  it('should not select date fragments in disabled state', async () => {
+    const value = '24.08.2022';
+    const dateFragment = value.slice(0, 2);
+    renderRTL(<DateInput value={value} disabled />);
+    await userEvent.click(screen.getByText(dateFragment));
+    await delay(0);
+    expect(getSelection()?.toString()).toBe('');
+  });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
Если на кликнуть на контролы `DatePicker/DateInput` в состоянии `disabled`, чтобы выделился хотя бы один фрагмент, то после этого на каждый `componentDidUpdate` этот фрагмент продолжит выделяться.
Если что-то вводить после выделения в контролируемом Инпуте, то фокус будет ломаться на каждый ввод.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Вызывать `selectNode` только в незаблокированном состоянии.
## Ссылки
Fix [IF-1954](https://yt.skbkontur.ru/issue/IF-1954)
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
