### PR TITLE
fix(TokenInput): forward prop `size` to menu items

### DIFF
--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022/0.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022/0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54a8908c7c42a7fc8828ebebd769f4a4974452180564404910289a19280861b4
+size 14859

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022/1.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c7d5cefbcb50ef0d7eca0e2fe5416d5722e76d29b17acc8551e416972dc4780
+size 15019

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022/2.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022/2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2da8ff2c4afa7d24136bcf9f3dfca63c64de0c2e6c6d361e4432be57a6a57688
+size 15691

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022Dark/0.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022Dark/0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:178ffd1aa08c4467ba55bb2c835f391177cab957164edde4edd19acc1975fb7e
+size 14185

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022Dark/1.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022Dark/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26359735b77a8281ccc74c292df52a5bd9a07e4e4299b609c532d7cc1803927d
+size 13987

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022Dark/2.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/chrome2022Dark/2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39700d1b85cd50ea2f87f760c6f32726b8a85796dee756e1cfb8d9f201b54e82
+size 14748

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022/0.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022/0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ddb9a8b54dec0f317b764259b1dd0815ac0fe63d20cec7a568fc8ccc686a267
+size 17741

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022/1.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:050fff8986cdd3f41a087b0722dd93447238e633c9c7bc2e3f3ac19dfcbf2d60
+size 18053

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022/2.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022/2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f9116ae07bf4c4457ff5ab18b5e7aa2589fc2d4a809dded135364b426bf60e7
+size 19329

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022Dark/0.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022Dark/0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98a361f5537b2d221222805bdef1a3dd5e77a78f53ef54a027d222cd582c2950
+size 16516

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022Dark/1.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022Dark/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32dbeb4204c7bdd73263145143a0f91f3839b8a505836d17d12857b09facfe86
+size 16431

--- a/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022Dark/2.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/MenuItem inherits size/firefox2022Dark/2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cee712aeb48aacb288bf1e427902d8468665622a5f2d92067f0e46a92e635a0c
+size 17765

--- a/packages/react-ui/.creevey/images/TokenInput/size/chrome2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/chrome2022.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:405fb26ccc2a7c385b0a8c5bcd1fe4800754ae1844d757abfcdf5655c11ba711
-size 12091

--- a/packages/react-ui/.creevey/images/TokenInput/size/chrome2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/chrome2022Dark.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cba6b6a01c7bc7138321beacdf826f540b27a1566ca41eb2ac194ddd26cbf569
-size 12137

--- a/packages/react-ui/.creevey/images/TokenInput/size/firefox2022.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/firefox2022.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be8b75dfbe9e2afb23b95cbe8b78fe8568d1cfbedf295abdbbecf59b1972d074
-size 14509

--- a/packages/react-ui/.creevey/images/TokenInput/size/firefox2022Dark.png
+++ b/packages/react-ui/.creevey/images/TokenInput/size/firefox2022Dark.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af35e22b8550cca20d6f7cb1105b33d12f1af459ecd2d336a86c0d2c0e8e5eed
-size 14249

--- a/packages/react-ui/components/TokenInput/TokenInput.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInput.tsx
@@ -537,6 +537,7 @@ export class TokenInput<T = string> extends React.PureComponent<TokenInputProps<
                 menuAlign={menuAlign}
                 renderTotalCount={renderTotalCount}
                 totalCount={totalCount}
+                size={this.getProps().size}
               />
             )}
             {this.renderTokensEnd()}

--- a/packages/react-ui/components/TokenInput/TokenInputMenu.tsx
+++ b/packages/react-ui/components/TokenInput/TokenInputMenu.tsx
@@ -104,6 +104,7 @@ export class TokenInputMenu<T = string> extends React.Component<TokenInputMenuPr
         withoutMobile
       >
         <ComboBoxMenu
+          size={this.props.size}
           items={items}
           loading={loading}
           hasMargin={false}

--- a/packages/react-ui/components/TokenInput/__creevey__/TokenInput.creevey.ts
+++ b/packages/react-ui/components/TokenInput/__creevey__/TokenInput.creevey.ts
@@ -391,4 +391,23 @@ kind('TokenInput', () => {
       await this.expect(await this.takeScreenshot()).to.matchImage();
     });
   });
+
+  story('Size', ({ setStoryParameters }) => {
+    setStoryParameters({
+      captureElement: '[data-tid="Gapped__vertical"]',
+    });
+
+    test('MenuItem inherits size', async function () {
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.TAB).perform();
+      const tab1 = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.TAB).perform();
+      const tab2 = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.TAB).perform();
+      const tab3 = await this.takeScreenshot();
+
+      await this.expect([tab1, tab2, tab3]).to.matchImages();
+    });
+  });
 });

--- a/packages/react-ui/components/TokenInput/__stories__/TokenInput.stories.tsx
+++ b/packages/react-ui/components/TokenInput/__stories__/TokenInput.stories.tsx
@@ -293,7 +293,7 @@ CustomRenderTotalCount.storyName = 'custom render total count';
 
 export const Size = () => {
   return (
-    <Gapped vertical gap={10}>
+    <Gapped vertical gap={10} style={{ padding: '10px 10px 120px' }}>
       <Wrapper numberItems={5} getItems={getItems} size="small" />
       <Wrapper numberItems={5} getItems={getItems} size="medium" />
       <Wrapper numberItems={5} getItems={getItems} size="large" />


### PR DESCRIPTION
## Проблема

TokenInput не прокидывает `size` до пунктов меню. Легко проверить в доке.
![image](https://github.com/user-attachments/assets/db2253dd-585a-437c-8819-5e59f7815ae3)

## Решение

- Прокинул проп
- Обновил скриншотные тесты для `size`, чтобы ловить такие случаи

![image](https://github.com/user-attachments/assets/aacc6d10-83f2-4355-9a5f-ddecf6d3a09f)


## Ссылки

Задачу на заводил

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
