### PR TITLE
fix(Autocomplete): add handleBlur for input

### DIFF
--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/blur.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/blur.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c63275a4cf2aa97c4bb46e7c143e483e36135659273d2a6ac0c7a391bef2dfd8
+size 4874

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/focus.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/focus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978afa29d8d68fe82c9327e5eb998d46e99264360825a8044625e78ec1d24ce9
+size 4886

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/idle.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6f32d30981c8c2dedd54e230b1f8c4ec872d22f49f952facc340fe67f41e34
+size 4974

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/input.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on clickOutside/chrome2022/input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:450f357451564ba60c13f90b3edc3763ea832662b264a61ea5823c7b956fa752
+size 9013

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/blur.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/blur.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c63275a4cf2aa97c4bb46e7c143e483e36135659273d2a6ac0c7a391bef2dfd8
+size 4874

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/focus.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/focus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978afa29d8d68fe82c9327e5eb998d46e99264360825a8044625e78ec1d24ce9
+size 4886

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/idle.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6f32d30981c8c2dedd54e230b1f8c4ec872d22f49f952facc340fe67f41e34
+size 4974

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/input.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-blur on input.blur()/chrome2022/input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:450f357451564ba60c13f90b3edc3763ea832662b264a61ea5823c7b956fa752
+size 9013

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/focus.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/focus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978afa29d8d68fe82c9327e5eb998d46e99264360825a8044625e78ec1d24ce9
+size 4886

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/idle.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6f32d30981c8c2dedd54e230b1f8c4ec872d22f49f952facc340fe67f41e34
+size 4974

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/input.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:450f357451564ba60c13f90b3edc3763ea832662b264a61ea5823c7b956fa752
+size 9013

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/select.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on click/chrome2022/select.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c7688fad0a2e6124124e307c90efe3856d8ff47ce7fc423543b272082733662
+size 5335

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/focus.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/focus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:978afa29d8d68fe82c9327e5eb998d46e99264360825a8044625e78ec1d24ce9
+size 4886

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/idle.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6f32d30981c8c2dedd54e230b1f8c4ec872d22f49f952facc340fe67f41e34
+size 4974

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/input.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/input.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:450f357451564ba60c13f90b3edc3763ea832662b264a61ea5823c7b956fa752
+size 9013

--- a/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/select.png
+++ b/packages/react-ui/.creevey/images/Autocomplete/With On Blur On Focus Handlers/idle-focus-input-select(blur) on keys/chrome2022/select.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c7688fad0a2e6124124e307c90efe3856d8ff47ce7fc423543b272082733662
+size 5335

--- a/packages/react-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.tsx
@@ -190,7 +190,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
    * @public
    */
   public blur() {
-    this.handleBlur();
+    this.handleBlurOutside();
   }
 
   public componentDidUpdate(prevProps: AutocompleteProps) {
@@ -246,11 +246,12 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
       onValueChange: this.handleValueChange,
       onKeyDown: this.handleKeyDown,
       onFocus: this.handleFocus,
+      onBlur: this.handleBlurInput,
       ref: this.refInput,
     };
 
     return (
-      <RenderLayer onFocusOutside={this.handleBlur} onClickOutside={this.handleClickOutside} active={focused}>
+      <RenderLayer onFocusOutside={this.handleBlurOutside} onClickOutside={this.handleClickOutside} active={focused}>
         <span
           data-tid={AutocompleteDataTids.root}
           className={cx(styles.root(this.theme), {
@@ -375,7 +376,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
       isMobileOpened: false,
     });
 
-    this.handleBlur();
+    this.handleBlurOutside();
   };
 
   private handleKeyPressMobile = (e: KeyboardEvent) => {
@@ -400,7 +401,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
     }
   };
 
-  private handleBlur = () => {
+  private handleBlurOutside = () => {
     if (!this.state.focused) {
       return;
     }
@@ -411,6 +412,15 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
     if (this.input) {
       this.input.blur();
     }
+  };
+
+  private handleBlurInput = () => {
+    if (!this.state.focused) {
+      return;
+    }
+
+    this.opened = false;
+    this.setState({ items: null, focused: false });
 
     if (this.props.onBlur) {
       this.props.onBlur();
@@ -419,7 +429,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
 
   private handleClickOutside = (e: Event) => {
     fixClickFocusIE(e);
-    this.handleBlur();
+    this.handleBlurOutside();
   };
 
   private handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/react-ui/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-ui/components/Autocomplete/Autocomplete.tsx
@@ -70,8 +70,6 @@ export interface AutocompleteProps
         preventWindowScroll?: boolean;
         /** Вызывается при изменении `value` */
         onValueChange: (value: string) => void;
-        /** onBlur */
-        onBlur?: () => void;
         /** Размер инпута */
         size?: SizeProp;
         /** value */
@@ -190,7 +188,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
    * @public
    */
   public blur() {
-    this.handleBlurOutside();
+    this.input?.blur();
   }
 
   public componentDidUpdate(prevProps: AutocompleteProps) {
@@ -408,23 +406,13 @@ export class Autocomplete extends React.Component<AutocompleteProps, Autocomplet
 
     this.opened = false;
     this.setState({ items: null, focused: false });
-
-    if (this.input) {
-      this.input.blur();
-    }
   };
 
-  private handleBlurInput = () => {
-    if (!this.state.focused) {
-      return;
+  private handleBlurInput = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (!e.relatedTarget) {
+      this.handleBlurOutside();
     }
-
-    this.opened = false;
-    this.setState({ items: null, focused: false });
-
-    if (this.props.onBlur) {
-      this.props.onBlur();
-    }
+    this.props.onBlur?.(e);
   };
 
   private handleClickOutside = (e: Event) => {

--- a/packages/react-ui/components/Autocomplete/__creevey__/Autocomplete.creevey.ts
+++ b/packages/react-ui/components/Autocomplete/__creevey__/Autocomplete.creevey.ts
@@ -224,6 +224,85 @@ kind('Autocomplete', () => {
     });
   });
 
+  story('WithOnBlurOnFocusHandlers', ({ setStoryParameters }) => {
+    setStoryParameters({
+      skip: {
+        'no themes': { in: /^(?!\b(chrome2022)\b)/ },
+      },
+    });
+
+    test('idle-focus-input-select(blur) on keys', async function () {
+      const idle = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.TAB).perform();
+      const focus = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).sendKeys('a').perform();
+      const input = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.ARROW_DOWN).keyDown(this.keys.ENTER).perform();
+      const select = await this.takeScreenshot();
+
+      await this.expect({ idle, focus, input, select }).to.matchImages();
+    });
+
+    test('idle-focus-input-select(blur) on click', async function () {
+      const idle = await this.takeScreenshot();
+
+      await this.browser
+        .actions({ bridge: true })
+        .click(this.browser.findElement({ css: '[data-comp-name~="Autocomplete"]' }))
+        .perform();
+      const focus = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).sendKeys('a').perform();
+      const input = await this.takeScreenshot();
+
+      await this.browser
+        .actions({ bridge: true })
+        .click(this.browser.findElement({ css: '[data-comp-name~="MenuItem"]' }))
+        .perform();
+      const select = await this.takeScreenshot();
+
+      await this.expect({ idle, focus, input, select }).to.matchImages();
+    });
+
+    test('idle-focus-input-blur on clickOutside', async function () {
+      const idle = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.TAB).perform();
+      const focus = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).sendKeys('a').perform();
+      const input = await this.takeScreenshot();
+
+      await this.browser
+        .actions({ bridge: true })
+        .click(this.browser.findElement({ css: 'body' }))
+        .perform();
+      const blur = await this.takeScreenshot();
+
+      await this.expect({ idle, focus, input, blur }).to.matchImages();
+    });
+
+    test('idle-focus-input-blur on input.blur()', async function () {
+      const idle = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).keyDown(this.keys.TAB).perform();
+      const focus = await this.takeScreenshot();
+
+      await this.browser.actions({ bridge: true }).sendKeys('a').perform();
+      const input = await this.takeScreenshot();
+
+      await this.browser.executeScript(() => {
+        document.querySelector('input')?.blur();
+      });
+      const blur = await this.takeScreenshot();
+
+      await this.expect({ idle, focus, input, blur }).to.matchImages();
+    });
+  });
+
   story('Size', () => {
     sizeTests();
   });

--- a/packages/react-ui/components/Autocomplete/__stories__/Autocomplete.stories.tsx
+++ b/packages/react-ui/components/Autocomplete/__stories__/Autocomplete.stories.tsx
@@ -74,13 +74,6 @@ export const WithFixedMenuSize = () => (
 WithFixedMenuSize.storyName = 'with fixed menu size';
 
 export const WithOnBlurOnFocusHandlers = () => <WithBlurFocusHandlersExample />;
-WithOnBlurOnFocusHandlers.storyName = 'with onBlur/onFocus handlers';
-
-WithOnBlurOnFocusHandlers.parameters = {
-  creevey: {
-    skip: true,
-  },
-};
 
 interface UncontrolledAutocompleteState {
   value: string;

--- a/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
+++ b/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 
 import { InputDataTids } from '../../../components/Input';
 import { Autocomplete, AutocompleteProps, AutocompleteIds, AutocompleteDataTids } from '../Autocomplete';
-import { delay, clickOutside } from '../../../lib/utils';
+import { delay } from '../../../lib/utils';
 
 describe('<Autocomplete />', () => {
   it('renders with given value', () => {
@@ -385,31 +385,16 @@ describe('<Autocomplete />', () => {
 
   it(`don't call handleBlur() method when is no focus`, () => {
     const handleBlur = jest.fn();
-    render(<Autocomplete value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />);
-
-    clickOutside();
-
-    expect(handleBlur).not.toHaveBeenCalled();
-  });
-
-  it(`call onBlur once by click outside`, () => {
-    const handleBlur = jest.fn();
-    render(<Autocomplete autoFocus value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />);
-
-    act(() => clickOutside());
-
-    expect(handleBlur).toHaveBeenCalledTimes(1);
-  });
-
-  it(`call onBlur once by input.blur()`, () => {
-    const handleBlur = jest.fn();
     const { getByRole } = render(
-      <Autocomplete autoFocus value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />,
+      <>
+        <Autocomplete value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />
+        <button />
+      </>,
     );
 
-    act(() => getByRole('textbox').blur());
+    act(() => getByRole('button').focus());
 
-    expect(handleBlur).toHaveBeenCalledTimes(1);
+    expect(handleBlur).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
+++ b/packages/react-ui/components/Autocomplete/__tests__/Autocomplete-test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import OkIcon from '@skbkontur/react-icons/Ok';
 import userEvent from '@testing-library/user-event';
 import { mount } from 'enzyme';
@@ -382,6 +382,35 @@ describe('<Autocomplete />', () => {
 
     expect(screen.getByRole('textbox')).toHaveAttribute('aria-label', ariaLabel);
   });
+
+  it(`don't call handleBlur() method when is no focus`, () => {
+    const handleBlur = jest.fn();
+    render(<Autocomplete value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />);
+
+    clickOutside();
+
+    expect(handleBlur).not.toHaveBeenCalled();
+  });
+
+  it(`call onBlur once by click outside`, () => {
+    const handleBlur = jest.fn();
+    render(<Autocomplete autoFocus value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />);
+
+    act(() => clickOutside());
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it(`call onBlur once by input.blur()`, () => {
+    const handleBlur = jest.fn();
+    const { getByRole } = render(
+      <Autocomplete autoFocus value="" source={[]} onValueChange={() => ''} onBlur={handleBlur} />,
+    );
+
+    act(() => getByRole('textbox').blur());
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('<Autocomplete Enzyme/>', () => {
@@ -397,20 +426,6 @@ describe('<Autocomplete Enzyme/>', () => {
     const inputProps = wrapper.find('Input').props();
 
     expect(inputProps).toMatchObject(props);
-  });
-
-  //TODO: Придумать как перевести на RTL
-  it(`don't call handleBlur() method when where is no focus`, () => {
-    const handleBlur = jest.fn();
-    const props = { value: '', source: [], onValueChange: () => '' };
-    const wrapper = mount<Autocomplete>(<Autocomplete {...props} />);
-
-    // @ts-expect-error: Use of private property.
-    wrapper.instance().handleBlur = handleBlur;
-
-    clickOutside();
-
-    expect(handleBlur).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Проблема

Если попробовать блюрить компонент через внутренний input.blur(), то наблюдаются такие проблемы
1. Событие onBlur не вызывается и выпадающий список не закрывается
2. onBlur вызовется и список закроется по фокусировке в любом другом месте (если кликнуть где-угодно)

## Решение

Разделил обработку блюра на 2 метода
- `handleBlurOutside`
   Содержит логику блюра для самого компонента. не вызывает onBlur без события
- `handleBlurInput`
   Вешается на внутренний инпут, позволяет всегда вызывать onBlur с событием.
   Если фокус был утерян в не пользу другого компонента `!e.relatedTarget`, т.е. при вызове `blur()`, или по внешнему клику, то дополнительно вызовется `handleBlurOutside`.
   Если фокус утерян в пользу другого элемента, то эти случаи обрабатывается в `RenderLayer`.
   Метод `handleBlurOutside` можем вызываться несколько раз, но отрабатывает только первый раз.

Добавил скриншотных тестов для фокусов/блюров.

Переписал 1 тест с `enzyme` на `rtl`

## Ссылки

`IF-2096`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
