### PR TITLE
Corrected clear method for quick cleaning of input field in Input.cs

### DIFF
--- a/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
@@ -1,5 +1,4 @@
 ﻿using JetBrains.Annotations;
-
 using Kontur.Selone.Properties;
 
 using OpenQA.Selenium;

--- a/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
@@ -1,5 +1,7 @@
 ﻿using JetBrains.Annotations;
+
 using Kontur.Selone.Properties;
+
 using OpenQA.Selenium;
 
 namespace SKBKontur.SeleniumTesting.Controls

--- a/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
@@ -1,7 +1,5 @@
 ﻿using JetBrains.Annotations;
-
 using Kontur.Selone.Properties;
-
 using OpenQA.Selenium;
 
 namespace SKBKontur.SeleniumTesting.Controls

--- a/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
@@ -43,13 +43,8 @@ namespace SKBKontur.SeleniumTesting.Controls
                 x =>
                     {
                         var inputElement = x.FindElement(By.CssSelector("input"));
-                        inputElement.SendKeys(Keys.End);
-                        var length = inputElement.GetAttribute("value").Length;
-                        while(length > 0)
-                        {
-                            inputElement.SendKeys(Keys.Backspace);
-                            length--;
-                        }
+                        inputElement.SendKeys(Keys.Control + "a");
+                        inputElement.SendKeys(Keys.Delete);
                     },
                 "Clear");
         }

--- a/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
+++ b/packages/react-ui-testing/SeleniumTesting/Controls/Input.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+
 using Kontur.Selone.Properties;
 
 using OpenQA.Selenium;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Имелась проблема медленной очистки поля input, а именно посимвольно. В проекте использовались поля, где вводились значения длинной 20 символов и более. И метод clear довольно долго отрабатывал.

## Решение

Заменил посимвольное удаление на "выделить всё сразу и удалить" через Keys.Control + "a" и Keys.Delete

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
