### PR TITLE
DatePicker. Исправил flushSync и onBlur - ПР не надо сквошить, т.к. тут 2 фикса

### DIFF
--- a/packages/react-ui/components/DatePicker/DatePicker.tsx
+++ b/packages/react-ui/components/DatePicker/DatePicker.tsx
@@ -221,11 +221,15 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
     }
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(prevProps: DatePickerProps, prevState: DatePickerState) {
     const { disabled } = this.props;
     const { opened } = this.state;
     if (disabled && opened) {
       this.close();
+    }
+
+    if (prevState.opened && !opened && this.isMobileLayout) {
+      this.handleBlur();
     }
   }
 
@@ -295,7 +299,7 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
             onValueChange={this.props.onValueChange}
             enableTodayLink={this.props.enableTodayLink}
             isHoliday={this.props.isHoliday}
-            onCloseRequest={this.handleBlur}
+            onCloseRequest={this.handleMobileCloseRequest}
             renderDay={props.renderDay}
             onMonthChange={props.onMonthChange}
           />
@@ -471,5 +475,9 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
     if (this.props.onValueChange) {
       this.props.onValueChange(value);
     }
+  };
+
+  private handleMobileCloseRequest = () => {
+    this.close();
   };
 }

--- a/packages/react-ui/components/DatePicker/MobilePicker.tsx
+++ b/packages/react-ui/components/DatePicker/MobilePicker.tsx
@@ -52,7 +52,10 @@ export const MobilePicker: React.FC<MobilePickerProps> = (props) => {
   };
 
   useLayoutEffect(() => {
-    setTimeout(() => inputRef.current?.focus());
+    // fix DateInput flushSync warning in React 18
+    setTimeout(() => {
+      inputRef.current?.focus();
+    });
   }, []);
 
   const onTodayClick = () => {

--- a/packages/react-ui/components/DatePicker/MobilePicker.tsx
+++ b/packages/react-ui/components/DatePicker/MobilePicker.tsx
@@ -38,8 +38,13 @@ export interface MobilePickerProps
 
 export const MobilePicker: React.FC<MobilePickerProps> = (props) => {
   const locale = useLocaleForControl('DatePicker', DatePickerLocaleHelper);
-
   const theme = getMobilePickerTheme(useContext(ThemeContext));
+
+  const calendarRef = useRef<Calendar>(null);
+  const inputRef = useRef<DateInput>(null);
+
+  const [{ month: monthNative, year }] = useState(() => getTodayDate());
+  const month = getMonthInHumanFormat(monthNative);
 
   const onValueChange = (date: string) => {
     if (props.onValueChange) {
@@ -50,16 +55,9 @@ export const MobilePicker: React.FC<MobilePickerProps> = (props) => {
     }
   };
 
-  const inputRef = useRef<DateInput>(null);
   useLayoutEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.focus();
-    }
+    setTimeout(() => inputRef.current?.focus());
   }, []);
-
-  const calendarRef = useRef<Calendar>(null);
-  const [{ month: monthNative, year }] = useState(() => getTodayDate());
-  const month = getMonthInHumanFormat(monthNative);
 
   const onTodayClick = () => {
     if (calendarRef.current) {

--- a/packages/react-ui/components/DatePicker/MobilePicker.tsx
+++ b/packages/react-ui/components/DatePicker/MobilePicker.tsx
@@ -48,7 +48,7 @@ export const MobilePicker: React.FC<MobilePickerProps> = (props) => {
 
   const onValueChange = (date: string) => {
     props.onValueChange?.(date);
-    setTimeout(() => props.onCloseRequest?.());
+    props.onCloseRequest?.();
   };
 
   useLayoutEffect(() => {

--- a/packages/react-ui/components/DatePicker/MobilePicker.tsx
+++ b/packages/react-ui/components/DatePicker/MobilePicker.tsx
@@ -47,12 +47,8 @@ export const MobilePicker: React.FC<MobilePickerProps> = (props) => {
   const month = getMonthInHumanFormat(monthNative);
 
   const onValueChange = (date: string) => {
-    if (props.onValueChange) {
-      props.onValueChange(date);
-    }
-    if (props.onCloseRequest) {
-      props.onCloseRequest();
-    }
+    props.onValueChange?.(date);
+    setTimeout(() => props.onCloseRequest?.());
   };
 
   useLayoutEffect(() => {

--- a/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
+++ b/packages/react-ui/components/DatePicker/__tests__/DatePicker-test.tsx
@@ -15,6 +15,7 @@ import { LIGHT_THEME } from '../../../lib/theming/themes/LightTheme';
 import { MobilePickerDataTids } from '../MobilePicker';
 import { DateSelectDataTids } from '../../../internal/DateSelect';
 import { MenuDataTids } from '../../../internal/Menu';
+import { componentsLocales as DayCellViewLocalesRu } from '../../Calendar/locale/locales/ru';
 
 describe('DatePicker', () => {
   describe('validate', () => {
@@ -552,6 +553,32 @@ describe('DatePicker', () => {
 
       const input = within(screen.getByTestId(DatePickerDataTids.input)).getByTestId(InputLikeTextDataTids.input);
       expect(input).toHaveTextContent(expectedDate);
+    });
+
+    it('should call onBlur after value was changed when date picked on click', async () => {
+      const initialDate = '10.10.2010';
+      const expectedDate = '20.10.2010';
+      let blurredDate = '';
+      const MobilePickerWithOnBlur = () => {
+        const [date, setDate] = useState(initialDate);
+        const handleBlur = () => {
+          blurredDate = date;
+        };
+        return (
+          <DatePicker enableTodayLink width="auto" value={date || null} onValueChange={setDate} onBlur={handleBlur} />
+        );
+      };
+      render(<MobilePickerWithOnBlur />);
+      await userEvent.click(screen.getByTestId(DatePickerDataTids.input));
+
+      const ariaLabel = `${DayCellViewLocalesRu.dayCellChooseDateAriaLabel}: ${new InternalDate({
+        value: expectedDate,
+      }).toA11YFormat()}`;
+
+      const expectedDateButton = screen.getByLabelText(ariaLabel);
+      await userEvent.click(expectedDateButton);
+
+      expect(blurredDate).toBe(expectedDate);
     });
   });
 });


### PR DESCRIPTION
## Проблемы

1. Вызов flushSync для Реакта 18 вызывает ошибки на в мобильном прежставлении ДатаПикера
2. onBlur вызывается до обновления value через onValueChange

## Решение

Добавил костыль в виде `setTimeout` в обоих случаях.

По хорошему этот компонент надо переписать, т.к. flushSync тоже костыль.

## Ссылки

`IF-2098`, `IF-2099`


## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

3. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

4. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

5. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ❌ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
