### PR TITLE
fix(ComboBox): fix menuAlign

### DIFF
--- a/packages/react-ui/.creevey/images/ComboBox/With Menu Align And Menu Pos/chrome2022.png
+++ b/packages/react-ui/.creevey/images/ComboBox/With Menu Align And Menu Pos/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71d7e3d98346508a6dc4761701e5435eca0b60a1e9efb78a14396f47c4fffe98
+size 34229

--- a/packages/react-ui/.creevey/images/ComboBox/With Menu Align And Menu Pos/chrome2022.png
+++ b/packages/react-ui/.creevey/images/ComboBox/With Menu Align And Menu Pos/chrome2022.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71d7e3d98346508a6dc4761701e5435eca0b60a1e9efb78a14396f47c4fffe98
-size 34229
+oid sha256:d8b65db365561bb4862e3f35564bba3439ec742db6878ab624bf9cbcf954d0da
+size 34296

--- a/packages/react-ui/.creevey/images/Select/With Menu Align And Various Width/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Select/With Menu Align And Various Width/chrome2022.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65fdf358896ca6c16b7e71668eda363900eb61aafbbb82fafca9e61530003779
-size 37806
+oid sha256:f5ba33c8d5faa989aaf6c968201c8d71c0489addb8aedc78a77598f2ad6daa28
+size 37795

--- a/packages/react-ui/.creevey/images/Select/With Menu Align And Various Width/chrome2022.png
+++ b/packages/react-ui/.creevey/images/Select/With Menu Align And Various Width/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65fdf358896ca6c16b7e71668eda363900eb61aafbbb82fafca9e61530003779
+size 37806

--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -910,3 +910,44 @@ export const Size: Story = () => {
 };
 
 Size.storyName = 'size';
+
+export const WithMenuAlignAndMenuPos: Story = () => {
+  const row: Array<Partial<ComboBoxProps<any>>> = [
+    { menuPos: 'bottom', value: { label: 'bottom' }, getItems: async () => [{ label: 'short value' }] },
+    { menuPos: 'bottom', value: { label: 'bottom' }, getItems: async () => [{ label: 'looooooong value' }] },
+    {
+      menuPos: 'top',
+      value: { label: 'top' },
+      getItems: async () => [{ label: 'short value' }],
+      style: { marginTop: 40 },
+    },
+    { menuPos: 'top', value: { label: 'top' }, getItems: async () => [{ label: 'looooooong value' }] },
+  ];
+  const col: Array<Partial<ComboBoxProps<any>>> = [
+    { menuAlign: 'right', disablePortal: false },
+    { menuAlign: 'right', disablePortal: true },
+    { menuAlign: 'left', disablePortal: false },
+    { menuAlign: 'left', disablePortal: true },
+  ];
+  const renderSelect = (props: Partial<ComboBoxProps<any>>) => (
+    <ComboBox ref={(el) => el?.search('')} width={100} getItems={async () => []} {...props} />
+  );
+
+  return (
+    <div style={{ padding: '0 50px' }}>
+      <div style={{ marginBottom: 10, display: 'flex', justifyContent: 'space-between', width: 550 }}>
+        {col.map((props, i) => (
+          <code key={i}>portal: {String(!props.disablePortal)}</code>
+        ))}
+      </div>
+      {row.map((props1, key) => (
+        <div key={key} style={{ marginBottom: 50, display: 'flex', justifyContent: 'space-between', width: 550 }}>
+          {col.map((props2) => renderSelect({ ...props1, ...props2 }))}
+        </div>
+      ))}
+    </div>
+  );
+};
+WithMenuAlignAndMenuPos.parameters = {
+  creevey: { skip: { 'no themes': { in: /^(?!\b(chrome2022)\b)/ } } },
+};

--- a/packages/react-ui/components/Select/__creevey__/Select.creevey.ts
+++ b/packages/react-ui/components/Select/__creevey__/Select.creevey.ts
@@ -212,16 +212,6 @@ kind('Select', () => {
     });
   });
 
-  story('WithMenuAlignAndVariousWidth', ({ setStoryParameters }) => {
-    setStoryParameters({ skip: { 'no themes': { in: /^(?!\b(chrome)\b)/ } } });
-
-    test('open', async function () {
-      const root = await this.browser.findElement({ css: '#test-element' });
-      await delay(1000);
-      await this.expect(await root.takeScreenshot()).to.matchImage();
-    });
-  });
-
   story('WithManualPosition', ({ setStoryParameters }) => {
     setStoryParameters({ skip: { 'no themes': { in: /^(?!\b(chrome2022|firefox2022)\b)/ } } });
 

--- a/packages/react-ui/components/Select/__stories__/Select.stories.tsx
+++ b/packages/react-ui/components/Select/__stories__/Select.stories.tsx
@@ -433,6 +433,9 @@ export const WithMenuAlignAndVariousWidth: Story = () => {
     </div>
   );
 };
+WithMenuAlignAndVariousWidth.parameters = {
+  creevey: { skip: { 'no themes': { in: /^(?!\b(chrome2022)\b)/ } } },
+};
 
 export default {
   title: 'Select',

--- a/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
+++ b/packages/react-ui/internal/CustomComboBox/CustomComboBox.tsx
@@ -267,6 +267,7 @@ export class CustomComboBox<T> extends React.PureComponent<CustomComboBoxProps<T
       opened: this.state.opened,
       drawArrow: this.props.drawArrow,
       menuPos: this.props.menuPos,
+      menuAlign: this.props.menuAlign,
       placeholder: this.props.placeholder,
       size: this.props.size,
       textValue: this.state.textValue,


### PR DESCRIPTION
## Проблема

В `ComboBox` с `5.0` сломался проп `menuAlign` со значением `right`.

## Решение

При избавлении от `DropdownContainer` потеряли проброс пропа `menuAlign`. Значение `left` работало т.к. умолчательное
https://github.com/skbkontur/retail-ui/commit/723ec43470bec9f0dd89b5f899ffffb90004a538#diff-e0e7a85c99ee1a5128183657766ce12f6c35c467bc8fb3f2f6bed591d68ad74cL258

Попутно расскипал стори в `Select`, где тестировалось выравнивание меню. По аналогии сделал стори для `ComboBox`

## Ссылки

`IF-2085`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
