### PR TITLE
fix(Calendar, DatePicker): no click on disabled dates

### DIFF
--- a/packages/react-ui/components/Calendar/DayCellView.tsx
+++ b/packages/react-ui/components/Calendar/DayCellView.tsx
@@ -18,8 +18,12 @@ export const DayCellView = (props: DayCellViewProps) => {
   const { value, minDate, maxDate, isHoliday, renderDay, today, onDateClick } = useContext(CalendarContext);
   const theme = useContext(ThemeContext);
 
+  const isDisabled = !CDS.isBetween(date, minDate, maxDate);
+
   const handleClick = () => {
-    onDateClick?.(date);
+    if (!isDisabled) {
+      onDateClick?.(date);
+    }
   };
 
   const humanDateString = InternalDateTransformer.dateToHumanString(date);
@@ -27,7 +31,7 @@ export const DayCellView = (props: DayCellViewProps) => {
   const dayProps: CalendarDayProps = {
     isToday: Boolean(today && CDS.isEqual(date, today)),
     isSelected: Boolean(value && CDS.isEqual(date, value)),
-    isDisabled: !CDS.isBetween(date, minDate, maxDate),
+    isDisabled,
     isWeekend: isHoliday?.(humanDateString, date.isWeekend) ?? date.isWeekend,
     date: humanDateString,
   };

--- a/packages/react-ui/components/Calendar/DayCellView.tsx
+++ b/packages/react-ui/components/Calendar/DayCellView.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { ReactElement, useContext } from 'react';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { InternalDateTransformer } from '../../lib/date/InternalDateTransformer';
@@ -21,9 +21,7 @@ export const DayCellView = (props: DayCellViewProps) => {
   const isDisabled = !CDS.isBetween(date, minDate, maxDate);
 
   const handleClick = () => {
-    if (!isDisabled) {
-      onDateClick?.(date);
-    }
+    onDateClick?.(date);
   };
 
   const humanDateString = InternalDateTransformer.dateToHumanString(date);
@@ -36,11 +34,14 @@ export const DayCellView = (props: DayCellViewProps) => {
     date: humanDateString,
   };
 
-  const dayElement = renderDay?.(dayProps) ?? <CalendarDay {...dayProps} />;
+  const dayElement: ReactElement<CalendarDayProps> = renderDay?.(dayProps) ?? <CalendarDay {...dayProps} />;
 
-  return (
-    <div onClick={handleClick} className={styles.cell(theme)}>
-      {dayElement}
-    </div>
-  );
+  const dayElementWithClickHandler = React.cloneElement<CalendarDayProps>(dayElement, {
+    onClick: (e) => {
+      dayElement.props.onClick?.(e);
+      handleClick();
+    },
+  });
+
+  return <div className={styles.cell(theme)}>{dayElementWithClickHandler}</div>;
 };

--- a/packages/react-ui/components/Calendar/DayCellView.tsx
+++ b/packages/react-ui/components/Calendar/DayCellView.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useCallback, useContext } from 'react';
 
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { InternalDateTransformer } from '../../lib/date/InternalDateTransformer';
@@ -20,10 +20,6 @@ export const DayCellView = (props: DayCellViewProps) => {
 
   const isDisabled = !CDS.isBetween(date, minDate, maxDate);
 
-  const handleClick = () => {
-    onDateClick?.(date);
-  };
-
   const humanDateString = InternalDateTransformer.dateToHumanString(date);
 
   const dayProps: CalendarDayProps = {
@@ -35,12 +31,18 @@ export const DayCellView = (props: DayCellViewProps) => {
   };
 
   const dayElement: ReactElement<CalendarDayProps> = renderDay?.(dayProps) ?? <CalendarDay {...dayProps} />;
+  const customDayClickHandler = dayElement.props.onClick;
+
+  const dayClickHandler = useCallback<NonNullable<typeof customDayClickHandler>>(
+    (e) => {
+      customDayClickHandler?.(e);
+      onDateClick?.(date);
+    },
+    [customDayClickHandler, onDateClick, date],
+  );
 
   const dayElementWithClickHandler = React.cloneElement<CalendarDayProps>(dayElement, {
-    onClick: (e) => {
-      dayElement.props.onClick?.(e);
-      handleClick();
-    },
+    onClick: dayClickHandler,
   });
 
   return <div className={styles.cell(theme)}>{dayElementWithClickHandler}</div>;

--- a/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
+++ b/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { PointerEventsCheckLevel, userEvent } from '@testing-library/user-event';
 
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { Calendar, CalendarDataTids } from '../Calendar';
 import { componentsLocales as DayCellViewLocalesRu } from '../locale/locales/ru';
 import { componentsLocales as DayCellViewLocalesEn } from '../locale/locales/en';
 import { InternalDate } from '../../../lib/date/InternalDate';
+import { CalendarLocaleHelper } from '../locale';
 
 describe('DayCellView', () => {
   describe('a11y', () => {
@@ -50,5 +52,27 @@ describe('DayCellView', () => {
 
       expect(screen.getAllByTestId(CalendarDataTids.dayCell)[0]).toHaveAttribute('aria-label', ariaLabel);
     });
+  });
+
+  it('should not call onClick when disabled', async () => {
+    const date = '03.11.2021';
+    const minDate = '02.11.2021';
+    const maxDate = '05.11.2021';
+    const onValueChange = jest.fn();
+
+    render(<Calendar value={date} minDate={minDate} maxDate={maxDate} onValueChange={onValueChange} />);
+
+    const button = screen.getByRole('button', {
+      name: `${CalendarLocaleHelper.get(LangCodes.ru_RU).dayCellChooseDateAriaLabel}: ${new InternalDate({
+        langCode: LangCodes.ru_RU,
+        value: '06.11.2021',
+      }).toA11YFormat()}`,
+    });
+
+    await userEvent.click(button, {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
+
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
+++ b/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
@@ -58,19 +58,19 @@ describe('DayCellView', () => {
     const initialDate = '03.11.2021';
     const minDate = '02.11.2021';
     const maxDate = '05.11.2021';
-    const outOfRangeDay = '06.11.2021';
+    const expectedDate = '06.11.2021';
     const onValueChange = jest.fn();
 
     render(<Calendar value={initialDate} minDate={minDate} maxDate={maxDate} onValueChange={onValueChange} />);
 
-    const button = screen.getByRole('button', {
+    const outOfRangeDay = screen.getByRole('button', {
       name: `${CalendarLocaleHelper.get(LangCodes.ru_RU).dayCellChooseDateAriaLabel}: ${new InternalDate({
         langCode: LangCodes.ru_RU,
-        value: outOfRangeDay,
+        value: expectedDate,
       }).toA11YFormat()}`,
     });
 
-    await userEvent.click(button, {
+    await userEvent.click(outOfRangeDay, {
       pointerEventsCheck: PointerEventsCheckLevel.Never,
     });
 

--- a/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
+++ b/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
@@ -55,17 +55,18 @@ describe('DayCellView', () => {
   });
 
   it('should not call onClick when disabled', async () => {
-    const date = '03.11.2021';
+    const initialDate = '03.11.2021';
     const minDate = '02.11.2021';
     const maxDate = '05.11.2021';
+    const outOfRangeDay = '06.11.2021';
     const onValueChange = jest.fn();
 
-    render(<Calendar value={date} minDate={minDate} maxDate={maxDate} onValueChange={onValueChange} />);
+    render(<Calendar value={initialDate} minDate={minDate} maxDate={maxDate} onValueChange={onValueChange} />);
 
     const button = screen.getByRole('button', {
       name: `${CalendarLocaleHelper.get(LangCodes.ru_RU).dayCellChooseDateAriaLabel}: ${new InternalDate({
         langCode: LangCodes.ru_RU,
-        value: '06.11.2021',
+        value: outOfRangeDay,
       }).toA11YFormat()}`,
     });
 

--- a/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
+++ b/packages/react-ui/components/Calendar/__tests__/DayCellView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { PointerEventsCheckLevel, userEvent } from '@testing-library/user-event';
+import { userEvent } from '@testing-library/user-event';
 
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { Calendar, CalendarDataTids } from '../Calendar';
@@ -70,9 +70,7 @@ describe('DayCellView', () => {
       }).toA11YFormat()}`,
     });
 
-    await userEvent.click(outOfRangeDay, {
-      pointerEventsCheck: PointerEventsCheckLevel.Never,
-    });
+    await userEvent.click(outOfRangeDay.parentElement as HTMLElement);
 
     expect(onValueChange).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
`Calendar` позволяет кликом выбирать невалидную дату - день, выходящий за рамки `minDate` или `maxDate`, хотя визуально эта дата остаётся заблокированной.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Запретить клик по заблокированной дате.
## Ссылки
fix [IF-1905](https://yt.skbkontur.ru/issue/IF-1905)
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
