### PR TITLE
fix(HideBodyVerticalScroll): fix disorderly unmount and resize

### DIFF
--- a/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/hide.png
+++ b/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/hide.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db74d04b0a76545fc2d07259f6103e917d7232f62fc7a0d824f430858a79246b
+size 124430

--- a/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/idle.png
+++ b/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/idle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07cba90020c074028047664d0ed550d4dd133773bbb8fed5fcb150db27130d3e
+size 125801

--- a/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/resize.png
+++ b/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/resize.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:809e94b0682ea1f71c73e0ad97eb13b995d591aec620f65297daf9480cd59915
+size 125795

--- a/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/show.png
+++ b/packages/react-ui/.creevey/images/HideBodyVerticalScroll/Disorderly Unmount And Resize/idle, hide, show, resize/chrome2022/show.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0ac7ba400c93057a1e5d523ec8b8b7fbd50efcdc29369bcdc0c315ac05f7e14
+size 125816

--- a/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
+++ b/packages/react-ui/internal/HideBodyVerticalScroll/HideBodyVerticalScroll.tsx
@@ -22,14 +22,14 @@ export class HideBodyVerticalScroll extends React.Component {
     if (counter === 1) {
       this.master = true;
       this.initialScroll = globalObject.document?.documentElement ? globalObject.document.documentElement.scrollTop : 0;
-      this.updateScrollVisibility();
-      globalObject.addEventListener?.('resize', this.updateScrollVisibility);
+      HideBodyVerticalScroll.updateScrollVisibility();
+      globalObject.addEventListener?.('resize', HideBodyVerticalScroll.updateScrollVisibility);
     }
   }
 
   public componentDidUpdate() {
     if (this.master) {
-      this.updateScrollVisibility();
+      HideBodyVerticalScroll.updateScrollVisibility();
     }
   }
 
@@ -37,7 +37,7 @@ export class HideBodyVerticalScroll extends React.Component {
     const counter = VerticalScrollCounter.decrement();
     if (counter === 0) {
       this.restoreStyles();
-      globalObject.removeEventListener?.('resize', this.updateScrollVisibility);
+      globalObject.removeEventListener?.('resize', HideBodyVerticalScroll.updateScrollVisibility);
     }
   }
 
@@ -45,14 +45,14 @@ export class HideBodyVerticalScroll extends React.Component {
     return null;
   }
 
-  private updateScrollVisibility = () => {
+  public static updateScrollVisibility = () => {
     const shouldHide = !disposeDocumentStyle;
     if (shouldHide) {
-      this.hideScroll();
+      HideBodyVerticalScroll.hideScroll();
     }
   };
 
-  private hideScroll = () => {
+  public static hideScroll = () => {
     if (!isBrowser(globalObject)) {
       return;
     }
@@ -64,10 +64,10 @@ export class HideBodyVerticalScroll extends React.Component {
     const documentMargin = parseFloat(documentComputedStyle.marginRight || '');
     const className = generateDocumentStyle(documentMargin + scrollWidth);
 
-    disposeDocumentStyle = this.attachStyle(documentElement, className);
+    disposeDocumentStyle = HideBodyVerticalScroll.attachStyle(documentElement, className);
   };
 
-  private attachStyle = (element: HTMLElement, className: string) => {
+  public static attachStyle = (element: HTMLElement, className: string) => {
     element.classList.add(className);
     return () => {
       element.classList.remove(className);

--- a/packages/react-ui/internal/HideBodyVerticalScroll/__creevey__/HideBodyVerticalScroll.creevey.ts
+++ b/packages/react-ui/internal/HideBodyVerticalScroll/__creevey__/HideBodyVerticalScroll.creevey.ts
@@ -54,4 +54,30 @@ kind('HideBodyVerticalScroll', () => {
     });
     testScrollLockUnlock();
   });
+
+  story('DisorderlyUnmountAndResize', ({ setStoryParameters }) => {
+    setStoryParameters({
+      skip: { 'themes dont affect logic': { in: /^(?!\bchrome2022\b)/ } },
+    });
+    test('idle, hide, show, resize', async function () {
+      const toggle = async (index: number) => {
+        await this.browser.findElement({ css: `div:nth-of-type(${index}) [data-tid~="toggle-lock"]` }).click();
+      };
+
+      const idle = await this.browser.takeScreenshot();
+
+      await toggle(1);
+      await toggle(2);
+      const hide = await this.browser.takeScreenshot();
+
+      await toggle(1);
+      await toggle(2);
+      const show = await this.browser.takeScreenshot();
+
+      await this.browser.findElement({ css: '[data-tid="resize"]' }).click();
+      const resize = await this.browser.takeScreenshot();
+
+      await this.expect({ idle, hide, show, resize }).to.matchImages();
+    });
+  });
 });

--- a/packages/react-ui/internal/HideBodyVerticalScroll/__stories__/HideBodyVerticalScroll.stories.tsx
+++ b/packages/react-ui/internal/HideBodyVerticalScroll/__stories__/HideBodyVerticalScroll.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 
 import { HideBodyVerticalScroll } from '../HideBodyVerticalScroll';
 import { Meta, Story } from '../../../typings/stories';
@@ -7,13 +7,13 @@ export default {
   title: 'HideBodyVerticalScroll',
 } as Meta;
 
-const SampleLockScroll = () => {
+const SampleLockScroll = ({ style }: { style?: React.CSSProperties }) => {
   const [locked, setLocked] = useState(false);
   const toggle = () => setLocked((prev) => !prev);
   const status = locked ? 'on page' : 'not mounted';
 
   return (
-    <div style={{ position: 'fixed', margin: 10, padding: 10, background: '#eee' }}>
+    <div style={{ position: 'fixed', margin: 10, padding: 10, background: '#eee', ...style }}>
       <div>
         <button onClick={toggle} data-tid="toggle-lock">
           toggle
@@ -42,9 +42,9 @@ const renderScrollableContent = () => (
 export const WithScrollableContent: Story = () => renderScrollableContent();
 
 export const WithHTMLOverflowYScroll: Story = () => {
-  document.documentElement.style.overflowY = 'scroll';
+  useLayoutEffect(() => {
+    document.documentElement.style.overflowY = 'scroll';
 
-  useEffect(() => {
     return () => {
       document.documentElement.style.overflowY = '';
     };
@@ -63,5 +63,16 @@ export const Multiple_WithScrollableContent: Story = () => (
   <>
     <HideBodyVerticalScroll />
     {renderScrollableContent()}
+  </>
+);
+
+export const DisorderlyUnmountAndResize: Story = () => (
+  <>
+    <button data-tid="resize" onClick={() => window.dispatchEvent(new Event('resize'))}>
+      window.dispatchEvent(new Event('resize'))
+    </button>
+    <SampleLockScroll key="1" />
+    <SampleLockScroll key="2" style={{ top: 60 }} />
+    <div>{'s c r o l l . '.repeat(1000)}</div>
   </>
 );


### PR DESCRIPTION
## Проблема

Компонент `HideBodyVerticalScroll` может блокировать скролл при ресайзе.

Если кратко то проблема в обработчике события `resize`, который является методом одного из экземпляров `HideBodyVerticalScroll`. 
При размонтировании компонента из обработчиков "удаляется" метод другого экземпляра `HideBodyVerticalScroll`, из-за чего фактически обработчик остаётся.

Детально причины описаны тут https://github.com/skbkontur/retail-ui/pull/3121#discussion_r1135875204

## Решение

Сделал обработчик статическим методом, чтобы все экземпляры ссылались на один.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
