### PR TITLE
chore: remove props2attrs from docs

### DIFF
--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { setFilter } from '@skbkontur/react-props2attrs';
-import { findAmongParents } from '@skbkontur/react-sorge/lib';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { Preview } from '@storybook/react';
 import { addons } from '@storybook/manager-api';
@@ -71,19 +69,6 @@ const customViewports = {
     type: 'mobile',
   },
 };
-
-setFilter((fiber) => {
-  // Транслируем все пропы только для контролов
-  const isControlComponent = !!findAmongParents(
-    fiber,
-    (fiberParent) => fiberParent.type && typeof fiberParent.type.__KONTUR_REACT_UI__ === 'string',
-  );
-  if (isTestEnv && isControlComponent) {
-    return null;
-  }
-  // Для остальных компонентов ограничиваемся тестовыми идентификаторами
-  return ['data-tid', 'data-testid'];
-});
 
 const MOBILE_REGEXP = /Mobile.*/i;
 

--- a/packages/react-ui/.storybook/scripts/props2attrs.ts
+++ b/packages/react-ui/.storybook/scripts/props2attrs.ts
@@ -1,0 +1,17 @@
+import { setFilter } from '@skbkontur/react-props2attrs';
+import { findAmongParents } from '@skbkontur/react-sorge/lib';
+
+import { isTestEnv } from '../../lib/currentEnvironment';
+
+setFilter((fiber) => {
+  // Транслируем все пропы только для контролов
+  const isControlComponent = !!findAmongParents(
+    fiber,
+    (fiberParent) => fiberParent.type && typeof fiberParent.type.__KONTUR_REACT_UI__ === 'string',
+  );
+  if (isTestEnv && isControlComponent) {
+    return null;
+  }
+  // Для остальных компонентов ограничиваемся тестовыми идентификаторами
+  return ['data-tid', 'data-testid'];
+});

--- a/packages/react-ui/.storybook/webpack.config.js
+++ b/packages/react-ui/.storybook/webpack.config.js
@@ -6,7 +6,7 @@ const isDocsEnv = Boolean(process.env.STORYBOOK_REACT_UI_DOCS);
 
 module.exports = async ({ config }) => {
   if (isTestEnv) {
-    config.entry.unshift('@skbkontur/react-props2attrs');
+    config.entry.unshift(path.join(__dirname, './scripts/props2attrs'));
   }
 
   config.devtool = isDocsEnv ? false : 'eval-source-map';


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

В нашем сторибуке для тестов используется пакет props2attrs. Он добавляет в html атрибуты `data-comp-name`, которые мы используем в скриншотных тестах.

Это фича замедляет работу сторибука и не нужна в новой доке, которая построена на нем же. Но полностью отключить пакет внутри preview.tsx не получается из-за его статического импорта там.

## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Вынести подключение и настройку props2attrs в отдельный entry в конфиге вебпака сторибука, который легко отключить для доки.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
