### PR TITLE
fix(Input): crash on focus after page translation

### DIFF
--- a/packages/react-ui/internal/InternalMaskedInput/InternalMaskedInput.tsx
+++ b/packages/react-ui/internal/InternalMaskedInput/InternalMaskedInput.tsx
@@ -133,7 +133,7 @@ export class InternalMaskedInput extends React.PureComponent<InternalMaskedInput
           style={{ ...style }}
         />
         {this.isMaskVisible() && (
-          <span className={cx(styles.inputMask(this.theme), leftClass)}>
+          <span className={cx(styles.inputMask(this.theme), leftClass)} translate="no">
             {leftHelper}
             {rightHelper}
           </span>


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
После перевода страницы, при фокусе на Инпут с маской, приложение падает с ошибкой.
<!-- Подробно опиши решаемую проблему. -->

## Решение
Добавить спану, в котором лежат символы маски, атрибут `translate='no'`
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки
Fix [IF-2120](https://yt.skbkontur.ru/issue/IF-2120)
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
