### PR TITLE
chore(docs): Fix banner z-index, disable top swipe in old docs

### DIFF
--- a/packages/react-ui-validations/docs/Common/Notification.tsx
+++ b/packages/react-ui-validations/docs/Common/Notification.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 export const NotificationContainer = styled.div`
   position: sticky;
-  z-index: 2;
+  z-index: 10;
   top: 0;
   left: 0;
   display: flex;

--- a/packages/react-ui-validations/docs/index.tsx
+++ b/packages/react-ui-validations/docs/index.tsx
@@ -12,6 +12,7 @@ import { Validator } from './Pages/Validator';
 import { Concepts } from './Pages/Concepts';
 
 import 'docs/styles/reset.less';
+import 'docs/styles/main.less';
 import 'docs/styles/typography.less';
 
 const App = hot(() => (

--- a/packages/react-ui-validations/docs/styles/main.less
+++ b/packages/react-ui-validations/docs/styles/main.less
@@ -1,0 +1,3 @@
+body {
+  overscroll-behavior: none;
+}

--- a/packages/react-ui-validations/docs/styles/main.less
+++ b/packages/react-ui-validations/docs/styles/main.less
@@ -1,3 +1,3 @@
 body {
-  overscroll-behavior: none;
+  overscroll-behavior-y: none;
 }

--- a/packages/react-ui/.styleguide/components/Notification/Notification.styles.ts
+++ b/packages/react-ui/.styleguide/components/Notification/Notification.styles.ts
@@ -4,7 +4,7 @@ export const styles = memoizeStyle({
   notification() {
     return css`
       position: sticky;
-      z-index: 2;
+      z-index: 10;
       top: 0;
       left: 0;
       display: flex;

--- a/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.tsx
+++ b/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.tsx
@@ -24,6 +24,7 @@ function StyleGuideRenderer({ children, hasSidebar, toc, title, version }: Style
   const [theme, setTheme] = useState(DEFAULT_THEME_WRAPPER);
   document.body.style.fontFamily = 'Lab Grotesque, Roboto, Helvetica Neue, Arial, sans-serif';
   document.body.style.fontSize = '14px';
+  document.body.style.overscrollBehavior = 'none';
 
   const isThemeDark = theme.toLowerCase().includes('dark');
 

--- a/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.tsx
+++ b/packages/react-ui/.styleguide/components/StyleGuideWrapper/StyleGuideWrapper.tsx
@@ -24,7 +24,7 @@ function StyleGuideRenderer({ children, hasSidebar, toc, title, version }: Style
   const [theme, setTheme] = useState(DEFAULT_THEME_WRAPPER);
   document.body.style.fontFamily = 'Lab Grotesque, Roboto, Helvetica Neue, Arial, sans-serif';
   document.body.style.fontSize = '14px';
-  document.body.style.overscrollBehavior = 'none';
+  document.body.style.overscrollBehaviorY = 'none';
 
   const isThemeDark = theme.toLowerCase().includes('dark');
 


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Решение


1. Починил z-index у баннера — календарь оказывался выше

![image](https://github.com/user-attachments/assets/cc4e7435-fa4c-4c2b-88d3-aa1bf5dc5fe8)

2. В macOS и iOS срабатывает свайп вверх — отключил через `overscroll-behavior-y`

https://github.com/user-attachments/assets/1a29fd58-7102-4b25-ba78-9b6b9462ad2f




## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

4. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

5. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

6. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
