### PR TITLE
fix(): desktop view on some mobiles

### DIFF
--- a/packages/react-ui/internal/themes/BasicLightTheme.ts
+++ b/packages/react-ui/internal/themes/BasicLightTheme.ts
@@ -83,7 +83,7 @@ export class BasicLightThemeInternal {
   public static controlHeightSmall = '32px';
   public static controlHeightMedium = '40px';
   public static controlHeightLarge = '48px';
-  public static mobileMediaQuery = '(max-width: 576px) and (hover: none) and (pointer: coarse)';
+  public static mobileMediaQuery = '(max-width: 576px) and (pointer: coarse)';
 
   public static transitionDuration = '100ms';
   public static transitionTimingFunction = 'cubic-bezier(0.5, 1, 0.89, 1)';


### PR DESCRIPTION
## Проблема

На некоторых мобильных устройствах некоторые контролы отображаются десктопными.

Конкретный [пример из старой доки](https://tech.skbkontur.ru/react-ui/#/Components/SidePage/SidePage): SidePage в неправильно открывается на некоторых телефонах. SidePage должен выглядеть как на первом скрине. На нескольких телефонах он так и выглядит, но на нескольких других — SidePage рендерится большим, будто на десктопе.
![image](https://github.com/user-attachments/assets/f858702a-9864-460b-97fc-2e8bb46086ad)
![image](https://github.com/user-attachments/assets/5d19c541-a986-4660-931e-424191587d96)

## Решение

Взяли несколько телефонов андроид:
- Honor Magic 6, браузер chrome 131.0 -- всё правильно,
- Xiaomi 13T, браузер chrome 131.0 -- неправильная отрисовка
- Poco, браузер duckduckgo -- всё правильно
- Samsung Galaxy A71, встроенный самсунговский браузер -- неправильная отрисовка

Проверили, что флаг "Версия для ПК" везде выключен, масштаб экрана не влияет, отрисовка не зависит от браузера и его версии.

Дело в том, как у нас вычисляется мобилка это или нет. На данный момент мы смотрим на 3 параметра:
- max-width: 576px
- **hover: none**
- pointer: coarse

Оказалось, что согласно [doka.guide](https://doka.guide/css/media/?ysclid=m5p3tz3arl569499821#vzaimodeystvie) некоторые девайсы могут эмулировать ховер. 
![image](https://github.com/user-attachments/assets/060141a7-5ef6-4003-8cb2-a17e61cfd0e9)
Это действительно так, мы убедились благодаря тесту: https://codepen.io/SchwJ/pen/OPLvLZN 
![image](https://github.com/user-attachments/assets/690e938b-53e9-4191-841a-5f7f090b14f6)
![image](https://github.com/user-attachments/assets/b072cf11-f3d0-47d8-a245-31425502a99d)

Удаление условия **hover: none** всё сработало. (Можно удостовериться по 2 скринам обратившихся)
![image](https://github.com/user-attachments/assets/1324681d-5671-4e1a-8747-780e1b48e9ad)
![image](https://github.com/user-attachments/assets/70996595-1263-4e0e-aa69-a97c6d3e4e34)

Предлагаю также удалить **coarse**, так как оно препятствует тому, что на маленьких экранах с мышкой экран остается десктопным, а прокрутить иногда не представляется возможным (тот же пример с SidePage). Таким образом будем определять мобилка или нет только по ширине экрана. Про это же говорили во внутреннем фронтендерском чатике 09.01.2025.

## Ссылки

[Обращение в MatterMost](https://chat.skbkontur.ru/kontur/pl/yy7fnfc3r3gx5pk558y6sk4kke)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
