### PR TITLE
fix(Link): same color styles for different use dont work

### DIFF
--- a/packages/react-ui/components/Link/Link.styles.ts
+++ b/packages/react-ui/components/Link/Link.styles.ts
@@ -50,7 +50,6 @@ export const styles = memoizeStyle({
       }
     `;
   },
-
   lineFocus(t: Theme) {
     return css`
       color: ${t.linkHoverColor};
@@ -102,25 +101,25 @@ export const styles = memoizeStyle({
     `;
   },
 
-  useDefault(t: Theme) {
+  default(t: Theme) {
     return css`
       ${linkUseColorsMixin(t.linkColor, t.linkHoverColor, t.linkActiveColor)};
     `;
   },
 
-  useSuccess(t: Theme) {
+  success(t: Theme) {
     return css`
       ${linkUseColorsMixin(t.linkSuccessColor, t.linkSuccessHoverColor, t.linkSuccessActiveColor)};
     `;
   },
 
-  useDanger(t: Theme) {
+  danger(t: Theme) {
     return css`
       ${linkUseColorsMixin(t.linkDangerColor, t.linkDangerHoverColor, t.linkDangerActiveColor)};
     `;
   },
 
-  useGrayed(t: Theme) {
+  grayed(t: Theme) {
     return css`
       ${linkUseColorsMixin(t.linkGrayedColor, t.linkGrayedHoverColor, t.linkGrayedActiveColor)};
     `;

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -182,15 +182,10 @@ export class Link<C extends ButtonLinkAllowedValues = typeof LINK_DEFAULT_COMPON
 
     const rootProps = {
       ...rest,
-      className: cx({
-        [styles.root(this.theme)]: true,
+      className: cx(styles.root(this.theme), styles[use](this.theme), {
         [resetButton()]: Root === 'button',
         [styles.focus(this.theme)]: isFocused,
         [styles.disabled(this.theme)]: disabled || loading,
-        [styles.useDefault(this.theme)]: use === 'default',
-        [styles.useSuccess(this.theme)]: use === 'success',
-        [styles.useDanger(this.theme)]: use === 'danger',
-        [styles.useGrayed(this.theme)]: use === 'grayed',
         [styles.useGrayedFocus(this.theme)]: use === 'grayed' && focused,
         [styles.button(this.theme)]: !!_button,
         [styles.buttonOpened(this.theme)]: !!_buttonOpened,

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -190,7 +190,7 @@ export class Link<C extends ButtonLinkAllowedValues = typeof LINK_DEFAULT_COMPON
         case 'grayed':
           return styles.grayed(this.theme);
       }
-    }
+    };
     const getUseLineFocusStyles = () => {
       switch (use) {
         case 'default':
@@ -202,14 +202,15 @@ export class Link<C extends ButtonLinkAllowedValues = typeof LINK_DEFAULT_COMPON
         case 'grayed':
           return styles.lineFocusGrayed(this.theme);
       }
-    }
+    };
     const rootProps = {
       ...rest,
-      className: cx(styles.root(this.theme), {
+      className: cx({
+        [styles.root(this.theme)]: true,
         [resetButton()]: Root === 'button',
-        [getUseStyles()]: true,
         [styles.focus(this.theme)]: isFocused,
         [styles.disabled(this.theme)]: disabled || loading,
+        [getUseStyles()]: true,
         [styles.useGrayedFocus(this.theme)]: use === 'grayed' && focused,
         [styles.button(this.theme)]: !!_button,
         [styles.buttonOpened(this.theme)]: !!_buttonOpened,

--- a/packages/react-ui/components/Link/Link.tsx
+++ b/packages/react-ui/components/Link/Link.tsx
@@ -179,11 +179,35 @@ export class Link<C extends ButtonLinkAllowedValues = typeof LINK_DEFAULT_COMPON
       <LinkIcon hasBothIcons={!!icon && !!rightIcon} icon={rightIcon} loading={loading} position="right" />
     );
     const nonInteractive = disabled || loading;
-
+    const getUseStyles = () => {
+      switch (use) {
+        case 'default':
+          return styles.default(this.theme);
+        case 'danger':
+          return styles.danger(this.theme);
+        case 'success':
+          return styles.success(this.theme);
+        case 'grayed':
+          return styles.grayed(this.theme);
+      }
+    }
+    const getUseLineFocusStyles = () => {
+      switch (use) {
+        case 'default':
+          return styles.lineFocus(this.theme);
+        case 'danger':
+          return styles.lineFocusDanger(this.theme);
+        case 'success':
+          return styles.lineFocusSuccess(this.theme);
+        case 'grayed':
+          return styles.lineFocusGrayed(this.theme);
+      }
+    }
     const rootProps = {
       ...rest,
-      className: cx(styles.root(this.theme), styles[use](this.theme), {
+      className: cx(styles.root(this.theme), {
         [resetButton()]: Root === 'button',
+        [getUseStyles()]: true,
         [styles.focus(this.theme)]: isFocused,
         [styles.disabled(this.theme)]: disabled || loading,
         [styles.useGrayedFocus(this.theme)]: use === 'grayed' && focused,
@@ -191,10 +215,7 @@ export class Link<C extends ButtonLinkAllowedValues = typeof LINK_DEFAULT_COMPON
         [styles.buttonOpened(this.theme)]: !!_buttonOpened,
         [styles.warning(this.theme)]: warning,
         [styles.error(this.theme)]: error,
-        [styles.lineFocus(this.theme)]: isFocused && use === 'default',
-        [styles.lineFocusSuccess(this.theme)]: isFocused && use === 'success',
-        [styles.lineFocusDanger(this.theme)]: isFocused && use === 'danger',
-        [styles.lineFocusGrayed(this.theme)]: isFocused && use === 'grayed',
+        [getUseLineFocusStyles()]: isFocused,
       }),
       onClick: this.handleClick,
       onFocus: this.handleFocus,

--- a/packages/react-ui/components/Link/__stories__/Link.stories.tsx
+++ b/packages/react-ui/components/Link/__stories__/Link.stories.tsx
@@ -148,3 +148,34 @@ export const MultilineLink: Story = () => {
     </div>
   );
 };
+
+export const SameColorsInDifferentUse: Story = () => {
+  const differentColorStyles = {
+    linkColor: 'blue',
+    linkHoverColor: 'red',
+    linkActiveColor: 'yellow',
+
+    linkGrayedColor: 'blue',
+    linkGrayedHoverColor: 'red',
+    linkGrayedActiveColor: 'yellow',
+  };
+
+  return (
+    <ThemeContext.Consumer>
+      {(theme) => {
+        return (
+          <Gapped vertical>
+            <ThemeContext.Provider value={ThemeFactory.create(differentColorStyles, theme)}>
+              <Gapped vertical>
+                <Link use="default">Я дефолтная ссылка, закастомленная под серую</Link>
+                <Link use="grayed">Я серая ссылка</Link>
+                <span>Они должны быть одинаковых цветов</span>
+              </Gapped>
+            </ThemeContext.Provider>
+          </Gapped>
+        );
+      }}
+    </ThemeContext.Consumer>
+  );
+};
+SameColorsInDifferentUse.parameters = { creevey: { skip: true } };


### PR DESCRIPTION
## Проблема

При установке одинаковых цветов (обычное состояние, hover, active) для разных use у Link цвет иногда не применяется к Link. 

Выяснилось, что три заданных цвета попадают в миксин
```
export const linkUseColorsMixin = (mainColor: string, hoverColor: string, activeColor: string) => {
  return `
    color: ${mainColor};
    &:hover {
      color: ${hoverColor};
    }
    &:active {
      color: ${activeColor};
    }
  `;
};
```
Он в свою очередь используется в стилях useDefault, useSuccess, useDanger, useGrayed
```
  useDefault(t: Theme) {
    return css`
      ${linkUseColorsMixin(t.linkColor, t.linkHoverColor, t.linkActiveColor)};
    `;
  },

  useSuccess(t: Theme) {
    return css`
      ${linkUseColorsMixin(t.linkSuccessColor, t.linkSuccessHoverColor, t.linkSuccessActiveColor)};
    `;
  },

  useDanger(t: Theme) {
    return css`
      ${linkUseColorsMixin(t.linkDangerColor, t.linkDangerHoverColor, t.linkDangerActiveColor)};
    `;
  },

  useGrayed(t: Theme) {
    return css`
      ${linkUseColorsMixin(t.linkGrayedColor, t.linkGrayedHoverColor, t.linkGrayedActiveColor)};
    `;
  },
```
А они используются в компоненте:
```
className: cx({
    ...
    [styles.useDefault(this.theme)]: use === 'default',
    [styles.useSuccess(this.theme)]: use === 'success',
    [styles.useDanger(this.theme)]: use === 'danger',
    [styles.useGrayed(this.theme)]: use === 'grayed',
    ...
})
```
И когда все три цвета у двух use совпадают, названия для классов стилей совпадают.
Для примера возьмем use = 'default' и use = 'grayed' со всеми тремя одинаковыми цветами. В таком случае styles.useDefault(this.theme) и styles.useGrayed(this.theme) получат одинаковый код (по типу .react-ui-18ozqeu) и при отрисовке <Link use="default" /> в объект со стилями сначала добавится ".react-ui-18ozqeu" : true, а затем ".react-ui-18ozqeu" : false. И в объекте останется только последнее значение.

Оказалось, что проблема масштабнее: классы стилей с одинаковым содержанием, а значит одинаковыми кодами могут возникать во многих компонентах.

## Решение

Так как проблема с use у Button критична для обратившегося пользователя, предлагаю пофиксить этот момент сейчас, а с остального -- завести задачу.

Для вычисления стиля, связанного с use в Link можно использовать механизм как у стилей size в Button:
```
const getUseStyles = () => {
  switch (use) {
    case 'default':
      return styles.default(this.theme);
    case 'danger':
      return styles.danger(this.theme);
    case 'success':
      return styles.success(this.theme);
    case 'grayed':
      return styles.grayed(this.theme);
  }
}
```

Еще был вариант сделать выбор нужного варианта через switch по аналогии с use в Button, то есть ссылаться именно на тот стиль, который по имени совпадает с текущим use: `styles[use](this.theme)`.
Но в таком случае есть определенные ограничения: мы жестко завязаны на имена и, например, если нам почему-то захочется использовать (на нашей стороне) одинаковый стиль для разных use, нам придется дублировать этот стиль в styles.ts. 
К тому же надо обработать следующие условия и так легко это сделать не получится:
```
[styles.lineFocus(this.theme)]: isFocused && use === 'default',
[styles.lineFocusSuccess(this.theme)]: isFocused && use === 'success',
[styles.lineFocusDanger(this.theme)]: isFocused && use === 'danger',
[styles.lineFocusGrayed(this.theme)]: isFocused && use === 'grayed',
```

Поэтому я выбрала первый вариант.

Историю для проверки написала, но заскипала в creevey, так как на мой взгляд кейс с одинаковыми переменными темы не нужно проверять в этом месте, так как здесь сломать что-то маловероятно (а если уж проверять, то надо проверять все подобные кейсы по проекту). В связи с этим предлагаю в будущую большую задачу записать необходимость проверки таких кейсов в различных элементах.

## Ссылки

IF-

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
