### PR TITLE
docs: fix font-family, add session storage for code examples

### DIFF
--- a/packages/react-ui-validations/.storybook/Meta.tsx
+++ b/packages/react-ui-validations/.storybook/Meta.tsx
@@ -46,6 +46,8 @@ const styles = {
     cursor: pointer;
     padding: 4px 8px;
     border-radius: 6px;
+    font-size: 16px;
+
     &:hover {
       background: rgba(0, 0, 0, 0.06);
     }

--- a/packages/react-ui-validations/.storybook/preview-head.html
+++ b/packages/react-ui-validations/.storybook/preview-head.html
@@ -79,7 +79,7 @@
     min-height: 100%;
   }
 
-  .dark:not(:has(#storybook-docs)) {
+  .dark:not(:has(.sbdocs-wrapper)) {
     background: #1f1f1f;
     color: rgba(255, 255, 255, 0.865);
   }

--- a/packages/react-ui-validations/.storybook/preview-head.html
+++ b/packages/react-ui-validations/.storybook/preview-head.html
@@ -14,6 +14,51 @@
     padding: 0 !important;
   }
 
+  #storybook-docs h1:first-of-type,
+  #storybook-docs h2:first-of-type,
+  #storybook-docs h3:first-of-type,
+  #storybook-docs h4:first-of-type,
+  #storybook-docs h5:first-of-type,
+  #storybook-docs h6:first-of-type {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  #storybook-docs h1,
+  #storybook-docs h2,
+  #storybook-docs h3,
+  #storybook-docs h4,
+  #storybook-docs h5,
+  #storybook-docs h6 {
+    margin: 20px 0 8px;
+  }
+
+  #storybook-docs h1 {
+    font-size: 32px;
+  }
+
+  #storybook-docs h2 {
+    font-size: 24px;
+    padding-bottom: 4px;
+  }
+
+  #storybook-docs h2:not(:empty) {
+    border-bottom: 1px solid hsla(203, 50%, 30%, 0.15);
+  }
+
+  #storybook-docs h3 {
+    font-size: 20px;
+  }
+
+  #storybook-docs h4 {
+    font-size: 16px;
+  }
+
+  #storybook-docs h5,
+  #storybook-docs h6 {
+    font-size: 14px;
+  }
+
   #storybook-docs .sbdocs-wrapper p,
   #storybook-docs .sbdocs-wrapper li {
     font-size: 16px;
@@ -32,6 +77,11 @@
 
   #root {
     min-height: 100%;
+  }
+
+  .dark:not(:has(#storybook-docs)) {
+    background: #1f1f1f;
+    color: rgba(255, 255, 255, 0.865);
   }
 
   .dark [data-role='code-wrapper'] {
@@ -118,6 +168,10 @@
 
   .toc-list-item.is-active-li:before {
     content: none !important;
+  }
+
+  .docblock-argstable {
+    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
   }
 
   .sbdocs.sbdocs-a,

--- a/packages/react-ui-validations/.storybook/preview-head.html
+++ b/packages/react-ui-validations/.storybook/preview-head.html
@@ -15,13 +15,15 @@
   }
 
   #storybook-docs .sbdocs-wrapper p,
-  #storybook-docs .sbdocs-wrapper li {
+  #storybook-docs .sbdocs-wrapper li,
+  #storybook-docs .sbdocs-wrapper div {
     font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
     font-size: 16px;
     color: rgba(0, 0, 0, 0.87);
   }
 
-  #storybook-docs .sbdocs-wrapper code {
+  #storybook-docs .sbdocs-wrapper code,
+  #storybook-docs .sbdocs-wrapper .live-examples-addon-editor {
     font-family: monospace;
     font-size: 14px;
   }

--- a/packages/react-ui-validations/.storybook/preview-head.html
+++ b/packages/react-ui-validations/.storybook/preview-head.html
@@ -15,15 +15,12 @@
   }
 
   #storybook-docs .sbdocs-wrapper p,
-  #storybook-docs .sbdocs-wrapper li,
-  #storybook-docs .sbdocs-wrapper div {
-    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
+  #storybook-docs .sbdocs-wrapper li {
     font-size: 16px;
     color: rgba(0, 0, 0, 0.87);
   }
 
-  #storybook-docs .sbdocs-wrapper code,
-  #storybook-docs .sbdocs-wrapper .live-examples-addon-editor {
+  #storybook-docs .sbdocs-wrapper code {
     font-family: monospace;
     font-size: 14px;
   }

--- a/packages/react-ui-validations/.storybook/preview.tsx
+++ b/packages/react-ui-validations/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { HandThumbDownIcon } from '@skbkontur/icons/icons/HandThumbDownIcon';
 import { HandThumbUpIcon } from '@skbkontur/icons/icons/HandThumbUpIcon';
 import ThumbUpIcon from '@skbkontur/react-icons/ThumbUp';
+import { DocsContainer } from '@storybook/blocks';
 
 import * as Validations from '../src/index';
 import * as ReactUI from '../../react-ui/index';
@@ -45,6 +46,15 @@ const preview: Preview = {
   ],
 
   parameters: {
+    docs: {
+      container: ({ children, context }) => (
+        // prevent sb default font-family and other styles
+        // see https://github.com/storybookjs/storybook/blob/c6b8ca7faec9d6b73f71c112100506ef41dde619/code/lib/blocks/src/components/DocsPage.tsx#L19
+        <div className="sb-unstyled">
+          <DocsContainer context={context}>{children}</DocsContainer>
+        </div>
+      ),
+    },
     creevey: {
       captureElement: '#test-element',
     },

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -72,7 +72,7 @@
     "@skbkontur/react-icons": "^5.2.9",
     "@skbkontur/react-props2attrs": "0.1.3",
     "@skbkontur/react-sorge": "0.2.1",
-    "@skbkontur/storybook-addon-live-examples": "0.0.14",
+    "@skbkontur/storybook-addon-live-examples": "0.0.15",
     "@storybook/addon-a11y": "7.6.18",
     "@storybook/addon-controls": "7.6.18",
     "@storybook/addon-essentials": "7.6.18",

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -72,7 +72,7 @@
     "@skbkontur/react-icons": "^5.2.9",
     "@skbkontur/react-props2attrs": "0.1.3",
     "@skbkontur/react-sorge": "0.2.1",
-    "@skbkontur/storybook-addon-live-examples": "0.0.15",
+    "@skbkontur/storybook-addon-live-examples": "0.0.17",
     "@storybook/addon-a11y": "7.6.18",
     "@storybook/addon-controls": "7.6.18",
     "@storybook/addon-essentials": "7.6.18",

--- a/packages/react-ui-validations/package.json
+++ b/packages/react-ui-validations/package.json
@@ -72,7 +72,7 @@
     "@skbkontur/react-icons": "^5.2.9",
     "@skbkontur/react-props2attrs": "0.1.3",
     "@skbkontur/react-sorge": "0.2.1",
-    "@skbkontur/storybook-addon-live-examples": "0.0.11",
+    "@skbkontur/storybook-addon-live-examples": "0.0.14",
     "@storybook/addon-a11y": "7.6.18",
     "@storybook/addon-controls": "7.6.18",
     "@storybook/addon-essentials": "7.6.18",

--- a/packages/react-ui/.storybook/Meta.tsx
+++ b/packages/react-ui/.storybook/Meta.tsx
@@ -51,6 +51,7 @@ const styles = {
     cursor: pointer;
     padding: 4px 8px;
     border-radius: 6px;
+    font-size: 16px;
 
     &:hover {
       background: rgba(0, 0, 0, 0.06);

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -79,7 +79,7 @@
     min-height: 100%;
   }
 
-  .dark:not(:has(#storybook-docs)) {
+  .dark:not(:has(.sbdocs-wrapper)) {
     background: #1f1f1f;
     color: rgba(255, 255, 255, 0.865);
   }

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -15,15 +15,12 @@
   }
 
   #storybook-docs .sbdocs-wrapper p,
-  #storybook-docs .sbdocs-wrapper li,
-  #storybook-docs .sbdocs-wrapper div {
-    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
+  #storybook-docs .sbdocs-wrapper li {
     font-size: 16px;
     color: rgba(0, 0, 0, 0.87);
   }
 
-  #storybook-docs .sbdocs-wrapper code,
-  #storybook-docs .sbdocs-wrapper .live-examples-addon-editor {
+  #storybook-docs .sbdocs-wrapper code {
     font-family: monospace;
     font-size: 14px;
   }
@@ -138,11 +135,11 @@
   .sbdocs.sbdocs-a,
   .toc-list-item > a {
     color: #3c3c3c !important;
-    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
   }
 
   .sbdocs.sbdocs-a,
   .toc-list-item > a {
+    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
     text-decoration: underline;
     text-decoration-color: #adadad;
     text-underline-offset: 0.2em;
@@ -150,7 +147,6 @@
 
   .sbdocs.sbdocs-a:hover,
   .toc-list-item > a:hover {
-    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
     color: #222 !important;
     text-decoration-color: #222 !important;
     transition: text-decoration-color 100ms cubic-bezier(0.5, 1, 0.89, 1);

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -15,13 +15,15 @@
   }
 
   #storybook-docs .sbdocs-wrapper p,
-  #storybook-docs .sbdocs-wrapper li {
+  #storybook-docs .sbdocs-wrapper li,
+  #storybook-docs .sbdocs-wrapper div {
     font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
     font-size: 16px;
     color: rgba(0, 0, 0, 0.87);
   }
 
-  #storybook-docs .sbdocs-wrapper code {
+  #storybook-docs .sbdocs-wrapper code,
+  #storybook-docs .sbdocs-wrapper .live-examples-addon-editor {
     font-family: monospace;
     font-size: 14px;
   }

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -14,6 +14,51 @@
     padding: 0 !important;
   }
 
+  #storybook-docs h1:first-of-type,
+  #storybook-docs h2:first-of-type,
+  #storybook-docs h3:first-of-type,
+  #storybook-docs h4:first-of-type,
+  #storybook-docs h5:first-of-type,
+  #storybook-docs h6:first-of-type {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  #storybook-docs h1,
+  #storybook-docs h2,
+  #storybook-docs h3,
+  #storybook-docs h4,
+  #storybook-docs h5,
+  #storybook-docs h6 {
+    margin: 20px 0 8px;
+  }
+
+  #storybook-docs h1 {
+    font-size: 32px;
+  }
+
+  #storybook-docs h2 {
+    font-size: 24px;
+    padding-bottom: 4px;
+  }
+
+  #storybook-docs h2:not(:empty) {
+    border-bottom: 1px solid hsla(203, 50%, 30%, 0.15);
+  }
+
+  #storybook-docs h3 {
+    font-size: 20px;
+  }
+
+  #storybook-docs h4 {
+    font-size: 16px;
+  }
+
+  #storybook-docs h5,
+  #storybook-docs h6 {
+    font-size: 14px;
+  }
+
   #storybook-docs .sbdocs-wrapper p,
   #storybook-docs .sbdocs-wrapper li {
     font-size: 16px;
@@ -34,7 +79,7 @@
     min-height: 100%;
   }
 
-  .dark {
+  .dark:not(:has(#storybook-docs)) {
     background: #1f1f1f;
     color: rgba(255, 255, 255, 0.865);
   }
@@ -135,6 +180,10 @@
   .sbdocs.sbdocs-a,
   .toc-list-item > a {
     color: #3c3c3c !important;
+  }
+
+  .docblock-argstable {
+    font-family: 'Lab Grotesque', 'Helvetica Neue', Roboto, Arial, sans-serif;
   }
 
   .sbdocs.sbdocs-a,

--- a/packages/react-ui/.storybook/preview.tsx
+++ b/packages/react-ui/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { Preview } from '@storybook/react';
 import { addons } from '@storybook/manager-api';
+import { DocsContainer } from '@storybook/blocks';
 import { CopyIcon16Regular } from '@skbkontur/icons/icons/CopyIcon/CopyIcon16Regular';
 import SearchIcon from '@skbkontur/react-icons/Search';
 import MenuIcon from '@skbkontur/react-icons/Menu';
@@ -84,6 +85,13 @@ const preview: Preview = {
       controls: {
         sort: 'alpha',
       },
+      container: ({ children, context }) => (
+        // prevent sb default font-family and other styles
+        // see https://github.com/storybookjs/storybook/blob/c6b8ca7faec9d6b73f71c112100506ef41dde619/code/lib/blocks/src/components/DocsPage.tsx#L19
+        <div className="sb-unstyled">
+          <DocsContainer context={context}>{children}</DocsContainer>
+        </div>
+      ),
     },
     creevey: {
       captureElement: '#test-element',

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -83,7 +83,7 @@
     "@skbkontur/react-icons": "5.2.9",
     "@skbkontur/react-props2attrs": "0.1.3",
     "@skbkontur/react-sorge": "0.2.1",
-    "@skbkontur/storybook-addon-live-examples": "0.0.14",
+    "@skbkontur/storybook-addon-live-examples": "0.0.15",
     "@storybook/addon-a11y": "7.6.18",
     "@storybook/addon-controls": "7.6.18",
     "@storybook/addon-docs": "7.6.18",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -83,7 +83,7 @@
     "@skbkontur/react-icons": "5.2.9",
     "@skbkontur/react-props2attrs": "0.1.3",
     "@skbkontur/react-sorge": "0.2.1",
-    "@skbkontur/storybook-addon-live-examples": "0.0.11",
+    "@skbkontur/storybook-addon-live-examples": "0.0.14",
     "@storybook/addon-a11y": "7.6.18",
     "@storybook/addon-controls": "7.6.18",
     "@storybook/addon-docs": "7.6.18",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -83,7 +83,7 @@
     "@skbkontur/react-icons": "5.2.9",
     "@skbkontur/react-props2attrs": "0.1.3",
     "@skbkontur/react-sorge": "0.2.1",
-    "@skbkontur/storybook-addon-live-examples": "0.0.15",
+    "@skbkontur/storybook-addon-live-examples": "0.0.17",
     "@storybook/addon-a11y": "7.6.18",
     "@storybook/addon-controls": "7.6.18",
     "@storybook/addon-docs": "7.6.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5145,10 +5145,10 @@
   dependencies:
     semver "7.3.5"
 
-"@skbkontur/storybook-addon-live-examples@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.npmjs.org/@skbkontur/storybook-addon-live-examples/-/storybook-addon-live-examples-0.0.11.tgz#9aef2fe82274ead36710cbe058a8637da6f56dac"
-  integrity sha512-h0W35sI8NmC9+T99ikZPS9xISWs1yY9aYK+l+094ZDzPOF2nO532u1rdyHDzJkntu3nwtRl1Q6BPw8DyTuvqLQ==
+"@skbkontur/storybook-addon-live-examples@0.0.14":
+  version "0.0.14"
+  resolved "https://registry.npmjs.org/@skbkontur/storybook-addon-live-examples/-/storybook-addon-live-examples-0.0.14.tgz#38d5d196a543a42d13bb8c5a776cf100ec67e043"
+  integrity sha512-KoH9L4kWK35Ox139xrpdMPQNJ5QKGTEXfAHOmA4l0AJ+KcaYijWw26Po1LvUJaN8LiQyYd4Omeuh/hPTQtaMJQ==
   dependencies:
     "@storybook/icons" "^1.2.12"
     prettier "^3.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5145,10 +5145,10 @@
   dependencies:
     semver "7.3.5"
 
-"@skbkontur/storybook-addon-live-examples@0.0.15":
-  version "0.0.15"
-  resolved "https://registry.npmjs.org/@skbkontur/storybook-addon-live-examples/-/storybook-addon-live-examples-0.0.15.tgz#5df45feeafadb583dd31778c07317081453f304a"
-  integrity sha512-XEVgPIvcIVFjqioZkYC2GQbIMS1P5AV/XJrIZqxr82j822LxSsjbXmHokd7Dq+vsI7LwI9KyzpOhOagvQU7odg==
+"@skbkontur/storybook-addon-live-examples@0.0.17":
+  version "0.0.17"
+  resolved "https://registry.npmjs.org/@skbkontur/storybook-addon-live-examples/-/storybook-addon-live-examples-0.0.17.tgz#2e244703e4f9ae4140904948ef6c191dfa47c963"
+  integrity sha512-RE3Zmjp+UcnUakm7To2Ow8q4nLzWXgdt1zmJ0cW6YjZI1/+sV64wOd9qccktt5C1g1l/gSCEII80Ia6mFV2Krg==
   dependencies:
     "@storybook/icons" "^1.2.12"
     prettier "^3.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5145,10 +5145,10 @@
   dependencies:
     semver "7.3.5"
 
-"@skbkontur/storybook-addon-live-examples@0.0.14":
-  version "0.0.14"
-  resolved "https://registry.npmjs.org/@skbkontur/storybook-addon-live-examples/-/storybook-addon-live-examples-0.0.14.tgz#38d5d196a543a42d13bb8c5a776cf100ec67e043"
-  integrity sha512-KoH9L4kWK35Ox139xrpdMPQNJ5QKGTEXfAHOmA4l0AJ+KcaYijWw26Po1LvUJaN8LiQyYd4Omeuh/hPTQtaMJQ==
+"@skbkontur/storybook-addon-live-examples@0.0.15":
+  version "0.0.15"
+  resolved "https://registry.npmjs.org/@skbkontur/storybook-addon-live-examples/-/storybook-addon-live-examples-0.0.15.tgz#5df45feeafadb583dd31778c07317081453f304a"
+  integrity sha512-XEVgPIvcIVFjqioZkYC2GQbIMS1P5AV/XJrIZqxr82j822LxSsjbXmHokd7Dq+vsI7LwI9KyzpOhOagvQU7odg==
   dependencies:
     "@storybook/icons" "^1.2.12"
     prettier "^3.2.5"


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

1. В новой доке кое-где был дефолтный сторибучный шрифт, который сложно переопределялся стилями
2. Код примеров сбрасывался при перерисовках страницы с докой, например после переключения контекстов  или ресайза до мобильного вида сторибука

<!-- Подробно опиши решаемую проблему. -->

## Решение

1. Нашел достаточно надежный [способ](https://github.com/storybookjs/storybook/blob/c6b8ca7faec9d6b73f71c112100506ef41dde619/code/lib/blocks/src/components/DocsPage.tsx#L19) отключить дефолтные шрифты через обертку с классом `sb-unstyled`.
2. Добавил сохранение отредактированного кода примера в sessionStorge. Реализовано внутри аддона для живых примеров.

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

[Демо](https://ui.gitlab-pages.kontur.host/docs/storybook/react-ui/live-code-storage/?path=/docs/input-data-input--docs).

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

3. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ✅ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ⬜ нерелевантно

4. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

5. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
