### PR TITLE
fix(validations): updating field `level` in prop `validationInfo`

### DIFF
--- a/packages/react-ui-validations/src/ValidationHelper.ts
+++ b/packages/react-ui-validations/src/ValidationHelper.ts
@@ -49,5 +49,12 @@ export function isEqual(a: Nullable<Validation>, b: Nullable<Validation>): boole
   if (a === b) {
     return true;
   }
-  return !!a && !!b && a.behaviour === b.behaviour && a.message === b.message && a.independent === b.independent;
+  return (
+    !!a &&
+    !!b &&
+    a.behaviour === b.behaviour &&
+    a.message === b.message &&
+    a.independent === b.independent &&
+    a.level === b.level
+  );
 }

--- a/packages/react-ui-validations/tests/ValidationWrapper.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationWrapper.test.tsx
@@ -1,35 +1,51 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeFactory } from '@skbkontur/react-ui';
 
-import { ValidationContainer, ValidationWrapper } from '../src';
+import { ValidationContainer, ValidationInfo, ValidationWrapper, text } from '../src';
+import { ThemeContext } from '../src/ReactUiDetection';
+
+function setup(jsx: any) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  };
+}
 
 const InputLike = React.forwardRef<
-  HTMLSpanElement,
+  HTMLInputElement,
   {
     onFocus?: () => void;
     onBlur?: () => void;
     onChange?: () => void;
     onValueChange?: () => void;
+    autoCall?: boolean;
+    'data-tid'?: string;
   }
->(function InputLike({ onFocus, onBlur, onChange, onValueChange }, ref) {
-  onFocus?.();
-  onBlur?.();
-  onChange?.();
-  onValueChange?.();
+>(function InputLike({ onFocus, onBlur, onChange, onValueChange, autoCall }, ref) {
+  autoCall && onFocus?.();
+  autoCall && onBlur?.();
+  autoCall && onChange?.();
+  autoCall && onValueChange?.();
 
-  return <span ref={ref} />;
+  return <input ref={ref} {...{ onFocus, onBlur, onChange }} />;
 });
 
-const ComboBoxLike: React.FunctionComponent<{
-  onInputValueChange: () => string;
-}> & { __KONTUR_REACT_UI__: string } = ({ onInputValueChange }) => {
+const ComboBoxLike = React.forwardRef<
+  HTMLSpanElement,
+  {
+    onInputValueChange: () => string;
+  }
+>(function ComboBoxLike({ onInputValueChange }, ref) {
   const [value, setValue] = React.useState<string>('');
   React.useEffect(() => {
     setValue(onInputValueChange());
   }, [value]);
 
-  return <span>{value}</span>;
-};
+  return <span ref={ref}>{value}</span>;
+});
+// @ts-expect-error: required to detect ComboBox
 ComboBoxLike.__KONTUR_REACT_UI__ = 'ComboBox';
 
 describe('ValidationWrapper', () => {
@@ -44,7 +60,7 @@ describe('ValidationWrapper', () => {
       render(
         <ValidationContainer>
           <ValidationWrapper validationInfo={null}>
-            <InputLike {...{ [propName]: propValue }} />
+            <InputLike {...{ [propName]: propValue }} autoCall />
           </ValidationWrapper>
         </ValidationContainer>,
       );
@@ -53,20 +69,20 @@ describe('ValidationWrapper', () => {
     });
 
     it('should work when `ref` is hook', async () => {
-      let spanRef: React.RefObject<HTMLSpanElement>;
+      let inputLikeRef: React.RefObject<HTMLInputElement>;
       const InputLikeUseRef = () => {
-        spanRef = React.useRef<HTMLSpanElement>(null);
+        inputLikeRef = React.useRef<HTMLInputElement>(null);
         return (
           <ValidationContainer>
             <ValidationWrapper validationInfo={null}>
-              <InputLike ref={spanRef} />
+              <InputLike ref={inputLikeRef} />
             </ValidationWrapper>
           </ValidationContainer>
         );
       };
       render(<InputLikeUseRef />);
       // @ts-expect-error: Variable 'spanRef' is used before being assigned
-      expect(spanRef.current).toBeInTheDocument();
+      expect(inputLikeRef.current).toBeInTheDocument();
     });
 
     it('should return value of `onInputValueChange` method in ComboBox', async () => {
@@ -80,6 +96,162 @@ describe('ValidationWrapper', () => {
         </ValidationContainer>,
       );
       expect(screen.queryByText(inputValue)).toBeInTheDocument();
+    });
+  });
+
+  describe('update `validationInfo` prop', () => {
+    const ValidationInfoUpdater = ({
+      initialValidationInfo,
+      nextValidationInfo,
+      children,
+    }: React.PropsWithChildren<{
+      initialValidationInfo: ValidationInfo;
+      nextValidationInfo: ValidationInfo;
+    }>) => {
+      const [validationInfo, setValidationInfo] = React.useState<ValidationInfo>(initialValidationInfo);
+      const inputLikeRef = React.useRef<HTMLInputElement>(null);
+
+      return (
+        <ThemeContext.Provider
+          value={ThemeFactory.create({
+            validationsTextColorWarning: 'orange',
+            validationsTextColorError: 'red',
+          })}
+        >
+          <ValidationContainer>
+            <ValidationWrapper validationInfo={validationInfo} renderMessage={text('bottom')}>
+              <InputLike ref={inputLikeRef} />
+            </ValidationWrapper>
+            {children}
+          </ValidationContainer>
+          <button
+            data-tid="update-validation-info"
+            onClick={() => {
+              setValidationInfo(nextValidationInfo);
+            }}
+          >
+            button
+          </button>
+        </ThemeContext.Provider>
+      );
+    };
+
+    it('should change `level`', async () => {
+      const validationInfo: ValidationInfo = {
+        type: 'immediate',
+        level: 'error',
+        message: 'message',
+      };
+
+      render(
+        <ValidationInfoUpdater
+          initialValidationInfo={validationInfo}
+          nextValidationInfo={{
+            ...validationInfo,
+            level: 'warning',
+          }}
+        />,
+      );
+
+      expect(screen.queryByText('message')).toHaveStyle('color: red');
+
+      act(() => {
+        screen.getByTestId('update-validation-info').click();
+      });
+
+      expect(screen.queryByText('message')).toHaveStyle('color: orange');
+    });
+
+    it('should change `type`', async () => {
+      const validationInfo: ValidationInfo = {
+        type: 'submit',
+        message: 'message',
+      };
+
+      render(
+        <ValidationInfoUpdater
+          initialValidationInfo={validationInfo}
+          nextValidationInfo={{
+            ...validationInfo,
+            type: 'immediate',
+          }}
+        />,
+      );
+
+      expect(screen.queryByText('message')).not.toBeInTheDocument();
+
+      act(() => {
+        screen.getByRole('button').click();
+      });
+
+      expect(screen.queryByText('message')).toBeInTheDocument();
+    });
+
+    it('should change `message`', async () => {
+      const validationInfo: ValidationInfo = {
+        type: 'immediate',
+        message: 'message 1',
+      };
+      render(
+        <ValidationInfoUpdater
+          initialValidationInfo={validationInfo}
+          nextValidationInfo={{
+            ...validationInfo,
+            message: 'message 2',
+          }}
+        />,
+      );
+
+      expect(screen.queryByText('message 1')).toBeInTheDocument();
+      expect(screen.queryByText('message 2')).not.toBeInTheDocument();
+
+      act(() => {
+        screen.getByRole('button').click();
+      });
+
+      expect(screen.queryByText('message 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('message 2')).toBeInTheDocument();
+    });
+
+    it('should change `independent`', async () => {
+      const validationInfo: ValidationInfo = {
+        type: 'lostfocus',
+        message: 'message 1',
+        independent: true,
+      };
+      const { user } = setup(
+        <ValidationInfoUpdater
+          initialValidationInfo={validationInfo}
+          nextValidationInfo={{
+            ...validationInfo,
+            independent: false,
+          }}
+        >
+          <ValidationWrapper
+            validationInfo={{
+              ...validationInfo,
+              message: 'message 2',
+              independent: false,
+            }}
+            renderMessage={text('bottom')}
+          >
+            <InputLike />
+          </ValidationWrapper>
+        </ValidationInfoUpdater>,
+      );
+
+      screen.getAllByRole('textbox').at(0)?.focus();
+      await user.click(document.body);
+
+      expect(screen.queryByText('message 1')).toBeInTheDocument();
+      expect(screen.queryByText('message 2')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button'));
+      screen.getAllByRole('textbox').at(0)?.focus();
+      await user.click(document.body);
+
+      expect(screen.queryByText('message 1')).toBeInTheDocument();
+      expect(screen.queryByText('message 2')).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-ui-validations/tests/ValidationWrapper.test.tsx
+++ b/packages/react-ui-validations/tests/ValidationWrapper.test.tsx
@@ -240,7 +240,7 @@ describe('ValidationWrapper', () => {
         </ValidationInfoUpdater>,
       );
 
-      screen.getAllByRole('textbox').at(0)?.focus();
+      screen.getAllByRole('textbox')[0]?.focus();
       await user.click(document.body);
 
       expect(screen.queryByText('message 1')).toBeInTheDocument();


### PR DESCRIPTION
## Проблема

`ValidationWrapper` при изменении поля `level` в пропе `validationInfo` ничего не меняется.

## Решение

Добавил поле `level` в функцию, которая сравнивает старый и новый проп `validationInfo`.
Добавил тестов для всех полей этого пропа.

## Ссылки

`IF-2084`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
