### PR TITLE
fix(PasswordInput):  prevent Input root data-tid override

### DIFF
--- a/packages/react-ui/components/Dropdown/Dropdown.tsx
+++ b/packages/react-ui/components/Dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import { MenuSeparator } from '../MenuSeparator';
 import { Select } from '../Select';
 import { Nullable } from '../../typings/utility-types';
 import { ButtonUse } from '../Button';
-import { CommonWrapper, CommonProps, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { CommonWrapper, CommonProps } from '../../internal/CommonWrapper';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -36,6 +36,7 @@ const PASS_PROPS = {
   menuPos: true,
   id: true,
   'aria-describedby': true,
+  'aria-label': true,
 };
 
 export interface DropdownProps
@@ -191,27 +192,26 @@ export class Dropdown extends React.Component<DropdownProps> {
       <ThemeContext.Consumer>
         {(theme) => {
           this.theme = getDropdownTheme(theme);
-          return <ThemeContext.Provider value={this.theme}>{this.renderMain(this.props)}</ThemeContext.Provider>;
+          return <ThemeContext.Provider value={this.theme}>{this.renderMain()}</ThemeContext.Provider>;
         }}
       </ThemeContext.Consumer>
     );
   }
 
-  public renderMain = ({ caption, icon, ...props }: CommonWrapperRestProps<DropdownProps>) => {
+  public renderMain = () => {
+    const { caption, icon, ...rest } = this.props;
     const items = React.Children.map(this.props.children, (item) => item) || [];
 
     return (
-      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
+      <CommonWrapper rootNodeRef={this.setRootNode} {...rest}>
         <Select<React.ReactNode, React.ReactNode>
           data-tid={DropdownDataTids.root}
           ref={this._refSelect}
-          {...filterProps(props, PASS_PROPS)}
+          {...filterProps(rest, PASS_PROPS)}
           value={caption}
           items={items}
           _icon={icon}
           renderValue={renderValue}
-          size={this.props.size}
-          aria-label={this.props['aria-label']}
         />
       </CommonWrapper>
     );

--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -7,7 +7,7 @@ import { Nullable } from '../../typings/utility-types';
 import { isExternalLink, isFunction, isNonNullable, isReactUIComponent } from '../../lib/utils';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
-import { CommonProps, CommonWrapper, CommonWrapperRestProps } from '../../internal/CommonWrapper';
+import { CommonProps, CommonWrapper } from '../../internal/CommonWrapper';
 import { cx } from '../../lib/theming/Emotion';
 import { rootNode, TSetRootNode } from '../../lib/rootNode';
 import { SizeProp } from '../../lib/types/props';
@@ -159,18 +159,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
       <ThemeContext.Consumer>
         {(theme) => {
           this.theme = theme;
-          return (
-            <CommonWrapper
-              rootNodeRef={this.setRootNode}
-              {...getVisualStateDataAttributes({
-                hover: this.isHover,
-                selected: this.isSelected,
-              })}
-              {...this.props}
-            >
-              {this.renderMain(this.props)}
-            </CommonWrapper>
-          );
+          return this.renderMain();
         }}
       </ThemeContext.Consumer>
     );
@@ -275,7 +264,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
     }
   }
 
-  private renderMain = (props: CommonWrapperRestProps<MenuItemProps>) => {
+  private renderMain = () => {
     const {
       link,
       comment,
@@ -291,10 +280,11 @@ export class MenuItem extends React.Component<MenuItemProps> {
       href,
       disabled,
       scrollIntoView,
-      rel = this.props.href && isExternalLink(this.props.href) ? 'noopener noreferrer' : this.props.rel,
+      rel = href && isExternalLink(href) ? 'noopener noreferrer' : this.props.rel,
       isNotSelectable,
+      children,
       ...rest
-    } = props;
+    } = this.props;
 
     let iconElement = null;
     if (icon) {
@@ -320,55 +310,62 @@ export class MenuItem extends React.Component<MenuItemProps> {
       [styles.selected(this.theme)]: this.isSelected,
       [styles.link(this.theme)]: !!link,
       [this.getWithIconSizeClassName()]: Boolean(iconElement) || !!_enableIconPadding || this.context.enableIconPadding,
-      [styles.disabled(this.theme)]: !!this.props.disabled,
+      [styles.disabled(this.theme)]: !!disabled,
     });
-
-    const { children } = this.props;
 
     let content = children;
     if (isFunction(children)) {
-      content = children(this.props.state);
+      content = children(state);
     }
 
     const Component = this.getComponent();
 
     return (
-      <Component
-        ref={this.setRootRef}
-        data-tid={MenuItemDataTids.root}
+      <CommonWrapper
+        rootNodeRef={this.setRootNode}
+        {...getVisualStateDataAttributes({
+          hover: this.isHover,
+          selected: this.isSelected,
+        })}
         {...rest}
-        disabled={disabled}
-        state={this.activeState}
-        onMouseOver={this.handleMouseEnterFix}
-        onMouseLeave={this.handleMouseLeave}
-        onClick={this.handleClick}
-        className={className}
-        href={href}
-        rel={href ? rel : undefined}
-        tabIndex={-1}
       >
-        {iconElement}
-        <span
-          className={cx({
-            [styles.mobileContentWithIcon()]: isMobile && isNonNullable(icon),
-          })}
-          ref={this.contentRef}
-          data-tid={MenuItemDataTids.content}
+        <Component
+          ref={this.setRootRef}
+          data-tid={MenuItemDataTids.root}
+          {...rest}
+          disabled={disabled}
+          state={this.activeState}
+          onMouseOver={this.handleMouseEnterFix}
+          onMouseLeave={this.handleMouseLeave}
+          onClick={this.handleClick}
+          className={className}
+          href={href}
+          rel={href ? rel : undefined}
+          tabIndex={-1}
         >
-          {typeof content === 'function' ? content() : content}
-        </span>
-        {this.props.comment && (
-          <div
-            data-tid={MenuItemDataTids.comment}
+          {iconElement}
+          <span
             className={cx({
-              [styles.comment(this.theme)]: true,
-              [styles.commentHover(this.theme)]: this.isHover,
+              [styles.mobileContentWithIcon()]: isMobile && isNonNullable(icon),
             })}
+            ref={this.contentRef}
+            data-tid={MenuItemDataTids.content}
           >
-            {comment}
-          </div>
-        )}
-      </Component>
+            {typeof content === 'function' ? content() : content}
+          </span>
+          {comment && (
+            <div
+              data-tid={MenuItemDataTids.comment}
+              className={cx({
+                [styles.comment(this.theme)]: true,
+                [styles.commentHover(this.theme)]: this.isHover,
+              })}
+            >
+              {comment}
+            </div>
+          )}
+        </Component>
+      </CommonWrapper>
     );
   };
 

--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -283,6 +283,9 @@ export class MenuItem extends React.Component<MenuItemProps> {
       rel = href && isExternalLink(href) ? 'noopener noreferrer' : this.props.rel,
       isNotSelectable,
       children,
+      className: unusedClasses,
+      style,
+      'data-tid': dataTid,
       ...rest
     } = this.props;
 
@@ -327,7 +330,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
           hover: this.isHover,
           selected: this.isSelected,
         })}
-        {...rest}
+        {...this.props}
       >
         <Component
           ref={this.setRootRef}

--- a/packages/react-ui/components/MenuItem/__tests__/MenuItem-test.tsx
+++ b/packages/react-ui/components/MenuItem/__tests__/MenuItem-test.tsx
@@ -84,6 +84,13 @@ describe('MenuItem', () => {
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
+  it('has correct data-tid', () => {
+    const customDataTid = 'custom-data-tid';
+    render(<MenuItem data-tid={customDataTid} />);
+
+    expect(screen.getByTestId(customDataTid)).toBeInTheDocument();
+  });
+
   describe('a11y', () => {
     it('props aria-describedby applied correctly', () => {
       render(

--- a/packages/react-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-ui/components/PasswordInput/PasswordInput.tsx
@@ -98,8 +98,8 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
         {(theme) => {
           this.theme = theme;
           return (
-            <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
-              {this.renderMain(this.props)}
+            <CommonWrapper rootNodeRef={this.setRootNode} {...this.getProps()}>
+              {this.renderMain}
             </CommonWrapper>
           );
         }}

--- a/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
+++ b/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { mount } from 'enzyme';
 
+import { InputDataTids } from '../../Input';
 import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { PasswordInput, PasswordInputDataTids } from '../PasswordInput';
 import { componentsLocales as PasswordInputLocaleEn } from '../locale/locales/en';
@@ -140,6 +141,14 @@ describe('PasswordInput', () => {
     render(<PasswordInput value={'input'} />);
 
     expect(screen.getByTestId(PasswordInputDataTids.eyeIcon)).toHaveAttribute('type', 'button');
+  });
+
+  it('has correct data-tids', () => {
+    const customDataTid = 'custom-data-tid';
+    render(<PasswordInput data-tid={customDataTid} />);
+
+    expect(screen.getByTestId(customDataTid)).toBeInTheDocument();
+    expect(screen.getByTestId(InputDataTids.root)).toBeInTheDocument();
   });
 
   describe('a11y', () => {


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
Из-за неправильного использования `CommonWrapper` для лечения ошибки типов в (https://github.com/skbkontur/retail-ui/pull/3400) стал перетираться  `InputDataTids.root` вместе с `PasswordInputDataTids.root`, хотя не должен.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->
Поправил использование `CommonWrapper`, ошибку типов полечил, прокинув `this.getProps()` вместо `this.props`.
## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
