### PR TITLE
fix(PasswordInput): add correct activation RenderLayer

### DIFF
--- a/packages/react-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-ui/components/PasswordInput/PasswordInput.tsx
@@ -125,7 +125,9 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
    * @public
    */
   public blur = () => {
-    this.handleBlur();
+    if (this.input) {
+      this.input.blur();
+    }
   };
 
   private handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -164,10 +166,10 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
   };
 
   private handleToggleVisibility = () => {
-    this.setState((prevState) => ({ visible: !prevState.visible }), this.handleFocusOnInput);
+    this.setState((prevState) => ({ visible: !prevState.visible }), this.focusOnInput);
   };
 
-  private handleFocusOnInput = () => {
+  private focusOnInput = () => {
     if (this.input) {
       this.input.focus();
     }
@@ -185,9 +187,11 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
     }
   };
 
-  private handleBlur = () => {
-    if (this.input) {
-      this.input.blur();
+  private handleFocusOutside = () => {
+    this.hideSymbols();
+
+    if (this.state.focused) {
+      this.setState({ focused: false });
     }
   };
 
@@ -234,10 +238,6 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
 
   private hideSymbols = () => {
     this.setState({ visible: false });
-
-    if (this.state.focused) {
-      this.setState({ focused: false });
-    }
   };
 
   private renderMain = (props: CommonWrapperRestProps<PasswordInputProps>) => {
@@ -251,7 +251,11 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
     };
 
     return (
-      <RenderLayer active={this.state.focused} onFocusOutside={this.hideSymbols} onClickOutside={this.hideSymbols}>
+      <RenderLayer
+        active={this.state.focused}
+        onFocusOutside={this.handleFocusOutside}
+        onClickOutside={this.handleFocusOutside}
+      >
         <div data-tid={PasswordInputDataTids.root} className={styles.root()}>
           <Input ref={this.refInput} type={this.state.visible ? 'text' : 'password'} {...inputProps} />
         </div>

--- a/packages/react-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-ui/components/PasswordInput/PasswordInput.tsx
@@ -28,6 +28,7 @@ export interface PasswordInputProps extends Pick<AriaAttributes, 'aria-label'>, 
 
 export interface PasswordInputState {
   visible: boolean;
+  focused: boolean;
   capsLockEnabled?: boolean | null;
 }
 
@@ -65,6 +66,7 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
 
   public state: PasswordInputState = {
     visible: false,
+    focused: false,
     capsLockEnabled: false,
   };
 
@@ -162,12 +164,24 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
   };
 
   private handleToggleVisibility = () => {
-    this.setState((prevState) => ({ visible: !prevState.visible }), this.handleFocus);
+    this.setState((prevState) => ({ visible: !prevState.visible }), this.handleFocusOnInput);
   };
 
-  private handleFocus = () => {
+  private handleFocusOnInput = () => {
     if (this.input) {
       this.input.focus();
+    }
+  };
+
+  private handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (this.state.focused) {
+      return;
+    }
+
+    this.setState({ focused: true });
+
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
     }
   };
 
@@ -220,6 +234,10 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
 
   private hideSymbols = () => {
     this.setState({ visible: false });
+
+    if (this.state.focused) {
+      this.setState({ focused: false });
+    }
   };
 
   private renderMain = (props: CommonWrapperRestProps<PasswordInputProps>) => {
@@ -229,10 +247,11 @@ export class PasswordInput extends React.PureComponent<PasswordInputProps, Passw
       onKeyDown: this.handleKeydown,
       onKeyPress: this.handleKeyPress,
       rightIcon: this.renderEye(),
+      onFocus: this.handleFocus,
     };
 
     return (
-      <RenderLayer onFocusOutside={this.hideSymbols} onClickOutside={this.hideSymbols}>
+      <RenderLayer active={this.state.focused} onFocusOutside={this.hideSymbols} onClickOutside={this.hideSymbols}>
         <div data-tid={PasswordInputDataTids.root} className={styles.root()}>
           <Input ref={this.refInput} type={this.state.visible ? 'text' : 'password'} {...inputProps} />
         </div>

--- a/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
+++ b/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
@@ -201,4 +201,12 @@ describe('PasswordInput', () => {
       expect(screen.getByRole('button')).toHaveAttribute('aria-label', customAriaLabel);
     });
   });
+
+  it('RenderLayer not listen blur in default view', async () => {
+    const addEventListenerSpy = jest.spyOn(global, 'addEventListener');
+
+    render(<PasswordInput />);
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('blur', expect.any(Function));
+  });
 });

--- a/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
+++ b/packages/react-ui/components/PasswordInput/__tests__/PasswordInput-test.tsx
@@ -7,6 +7,7 @@ import { LangCodes, LocaleContext } from '../../../lib/locale';
 import { PasswordInput, PasswordInputDataTids } from '../PasswordInput';
 import { componentsLocales as PasswordInputLocaleEn } from '../locale/locales/en';
 import { componentsLocales as PasswordInputLocaleRu } from '../locale/locales/ru';
+import * as listenFocusOutside from '../../../lib/listenFocusOutside';
 
 describe('PasswordInput', () => {
   it('should change icon after clicking on the toggle button', async () => {
@@ -203,10 +204,10 @@ describe('PasswordInput', () => {
   });
 
   it('RenderLayer not listen blur in default view', async () => {
-    const addEventListenerSpy = jest.spyOn(global, 'addEventListener');
+    const focusOutsideListener = jest.spyOn(listenFocusOutside, 'listen');
 
     render(<PasswordInput />);
 
-    expect(addEventListenerSpy).not.toHaveBeenCalledWith('blur', expect.any(Function));
+    expect(focusOutsideListener).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-ui/internal/RenderLayer/__tests__/RenderLayer-test.tsx
+++ b/packages/react-ui/internal/RenderLayer/__tests__/RenderLayer-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { RenderLayer } from '../RenderLayer';
@@ -13,7 +13,7 @@ describe('<RenderLayer />', () => {
     jest.clearAllMocks();
   });
 
-  it('active enabled by default', () => {
+  it('active enabled by default, not breaking render without props', () => {
     const { container } = render(
       <RenderLayer>
         <div>Тестовый контент</div>
@@ -37,21 +37,20 @@ describe('<RenderLayer />', () => {
     expect(mockOnClickOutside).toHaveBeenCalled();
   });
 
-  it.skip('call onFocusOutside on lost focus', async () => {
+  it('call onFocusOutside on lost focus', async () => {
     render(
-      <RenderLayer onFocusOutside={mockOnFocusOutside}>
-        <input type="text" />
-      </RenderLayer>,
+      <div>
+        <input data-tid="outer-input" type="text" />
+        <RenderLayer onFocusOutside={mockOnFocusOutside}>
+          <input data-tid="inner-input" type="text" />
+        </RenderLayer>
+      </div>,
     );
 
-    const input = screen.getByRole('textbox');
-    fireEvent.focus(input);
-    fireEvent.click(document.body);
+    await userEvent.click(screen.getByTestId('inner-input'));
+    await userEvent.click(screen.getByTestId('outer-input'));
 
-    await waitFor(() => {
-      // mockOnFocusOutside никогда не вызывается, надо поразбираться
-      expect(mockOnFocusOutside).toHaveBeenCalled();
-    });
+    expect(mockOnFocusOutside).toHaveBeenCalled();
   });
 
   it('add event listeners on mount', () => {

--- a/packages/react-ui/internal/RenderLayer/__tests__/RenderLayer-test.tsx
+++ b/packages/react-ui/internal/RenderLayer/__tests__/RenderLayer-test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RenderLayer } from '../RenderLayer';
+
+describe('<RenderLayer />', () => {
+  const mockOnClickOutside = jest.fn();
+  const mockOnFocusOutside = jest.fn();
+  const mockGetAnchorElement = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('active enabled by default', () => {
+    const { container } = render(
+      <RenderLayer>
+        <div>Тестовый контент</div>
+      </RenderLayer>,
+    );
+
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('call onClickOutside on click outside', async () => {
+    render(
+      <RenderLayer onClickOutside={mockOnClickOutside}>
+        <button>Кнопка внутри</button>
+      </RenderLayer>,
+    );
+
+    await userEvent.click(screen.getByText('Кнопка внутри'));
+    expect(mockOnClickOutside).not.toHaveBeenCalled();
+
+    await userEvent.click(document.body);
+    expect(mockOnClickOutside).toHaveBeenCalled();
+  });
+
+  it.skip('call onFocusOutside on lost focus', async () => {
+    render(
+      <RenderLayer onFocusOutside={mockOnFocusOutside}>
+        <input type="text" />
+      </RenderLayer>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.focus(input);
+    fireEvent.click(document.body);
+
+    await waitFor(() => {
+      // mockOnFocusOutside никогда не вызывается, надо поразбираться
+      expect(mockOnFocusOutside).toHaveBeenCalled();
+    });
+  });
+
+  it('add event listeners on mount', () => {
+    const addEventListenerSpy = jest.spyOn(global, 'addEventListener');
+
+    render(
+      <RenderLayer active onClickOutside={mockOnClickOutside} onFocusOutside={mockOnFocusOutside}>
+        <div />
+      </RenderLayer>,
+    );
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+  });
+
+  it('disable event listeners on unmount', () => {
+    const removeEventListenerSpy = jest.spyOn(global, 'removeEventListener');
+    const { unmount } = render(
+      <RenderLayer active onClickOutside={mockOnClickOutside} onFocusOutside={mockOnFocusOutside}>
+        <div />
+      </RenderLayer>,
+    );
+
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+  });
+
+  it('call getAnchorElement', () => {
+    mockGetAnchorElement.mockReturnValue(document.createElement('div'));
+
+    render(
+      <RenderLayer getAnchorElement={mockGetAnchorElement} onClickOutside={mockOnClickOutside}>
+        <div />
+      </RenderLayer>,
+    );
+
+    expect(mockGetAnchorElement).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
В PasswordInput используется RenderLayer, который всегда active=true, это приводит к тому что события слушаются даже если компонент не в фокусе, условно даже если в другом компоненте на форме мы теряем фокус то тригернется и PasswordInput.

Замечено в ветке про shadow dom, там это поведение ломающее.
<!-- Подробно опиши решаемую проблему. -->


## Решение
Починить использование active в RenderLayer, на фокус ставить его, на потерю снимать подписки.
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

Задача - https://yt.skbkontur.ru/issue/IF-2172
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
