### PR TITLE
fix(Combobox): use ComboBoxMenuDataTids in Menu

### DIFF
--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -300,7 +300,7 @@ describe('ComboBox', () => {
       act(() => {
         fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape', code: 'Escape' });
       });
-      expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
 
       fireEvent.blur(screen.getByRole('textbox'));
       await delay(0);
@@ -409,12 +409,12 @@ describe('ComboBox', () => {
     await delay(0);
 
     expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
 
     await delay(1000);
 
     expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
   });
 
   it('does not highlight menu item on focus with empty input', async () => {
@@ -566,13 +566,13 @@ describe('ComboBox', () => {
     it('closes', () => {
       comboboxRef?.current?.open();
       comboboxRef?.current?.close();
-      expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
     });
 
     it('closes on clickOutside', () => {
       comboboxRef?.current?.open();
       clickOutside();
-      expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+      expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
     });
   });
 
@@ -674,7 +674,7 @@ describe('ComboBox', () => {
       it('opens menu if it is closed', async () => {
         comboboxRef.current?.close();
 
-        expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
 
         await userEvent.click(screen.getByRole('textbox'));
         await delay(0);
@@ -686,7 +686,7 @@ describe('ComboBox', () => {
       it('runs empty search if menu is closed', async () => {
         comboboxRef.current?.close();
         delay(0);
-        expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
 
         await userEvent.click(screen.getByRole('textbox'));
         expect(getItems).toHaveBeenCalledWith('');
@@ -709,7 +709,7 @@ describe('ComboBox', () => {
         comboboxRef.current?.close();
         await userEvent.click(screen.getByRole('textbox'));
 
-        expect(screen.queryByTestId(MenuDataTids.root)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(ComboBoxMenuDataTids.items)).not.toBeInTheDocument();
       });
 
       it("doesn't run search if menu is closed", async () => {

--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -318,8 +318,8 @@ describe('ComboBox', () => {
     await userEvent.click(screen.getByTestId(InputLikeTextDataTids.root));
     await promise;
 
-    expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
-    expect(screen.getByTestId(MenuDataTids.root)).toHaveTextContent(content);
+    expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
+    expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toHaveTextContent(content);
   });
 
   it('calls default onClick on custom element select', async () => {
@@ -403,7 +403,7 @@ describe('ComboBox', () => {
     await delay(300);
 
     expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
-    expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+    expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
 
     clickOutside();
     await delay(0);
@@ -560,7 +560,7 @@ describe('ComboBox', () => {
 
     it('opens', () => {
       comboboxRef?.current?.open();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.notFound)).toBeInTheDocument();
     });
 
     it('closes', () => {
@@ -679,7 +679,7 @@ describe('ComboBox', () => {
         await userEvent.click(screen.getByRole('textbox'));
         await delay(0);
 
-        expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+        expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
         expect(screen.getAllByTestId(ComboBoxMenuDataTids.item)).toHaveLength(testValues.length);
       });
 
@@ -739,7 +739,7 @@ describe('ComboBox', () => {
       expect(getItems).toHaveBeenCalledWith(query);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(query);
     });
 
@@ -760,7 +760,7 @@ describe('ComboBox', () => {
       await delay(DELAY_BEFORE_SHOW_LOADER);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(query);
     });
 
@@ -780,14 +780,14 @@ describe('ComboBox', () => {
       await delay(DELAY_BEFORE_SHOW_LOADER);
 
       expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
 
       await delay(LOADER_SHOW_TIME);
       await delay(0);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(query);
     });
 
@@ -803,7 +803,7 @@ describe('ComboBox', () => {
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
       expect(screen.getByTestId(MenuMessageDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.failed)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
     });
 
@@ -824,7 +824,7 @@ describe('ComboBox', () => {
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
       expect(screen.getByTestId(MenuMessageDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.failed)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
     });
 
@@ -845,14 +845,14 @@ describe('ComboBox', () => {
 
       expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
       expect(screen.getByTestId(MenuMessageDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
 
       await delay(LOADER_SHOW_TIME);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
       expect(screen.getByTestId(MenuMessageDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.failed)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
     });
 
@@ -872,7 +872,7 @@ describe('ComboBox', () => {
       expect(getItems).toHaveBeenCalledWith(query);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(secondQuery);
     });
 
@@ -896,7 +896,7 @@ describe('ComboBox', () => {
       expect(getItems).toHaveBeenCalledWith(query);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(secondQuery);
     });
 
@@ -917,7 +917,7 @@ describe('ComboBox', () => {
       await delay(DELAY_BEFORE_SHOW_LOADER - 100);
 
       expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
 
       await delay(LOADER_SHOW_TIME + 100);
@@ -926,7 +926,7 @@ describe('ComboBox', () => {
       expect(getItems).toHaveBeenCalledWith(query);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(secondQuery);
     });
 
@@ -948,7 +948,7 @@ describe('ComboBox', () => {
       await delay(300);
 
       expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
 
       await delay(LOADER_SHOW_TIME + 100);
@@ -957,7 +957,7 @@ describe('ComboBox', () => {
       expect(getItems).toHaveBeenCalledWith(query);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(secondQuery);
     });
 
@@ -980,13 +980,13 @@ describe('ComboBox', () => {
       await delay(DELAY_BEFORE_SHOW_LOADER - 300);
 
       expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
 
       await delay(200);
 
       expect(screen.getByTestId(SpinnerDataTids.root)).toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.loading)).toBeInTheDocument();
       expect(screen.queryByTestId(ComboBoxMenuDataTids.item)).not.toBeInTheDocument();
 
       await delay(LOADER_SHOW_TIME - 200);
@@ -995,7 +995,7 @@ describe('ComboBox', () => {
       expect(getItems).toHaveBeenCalledWith(query);
 
       expect(screen.queryByTestId(SpinnerDataTids.root)).not.toBeInTheDocument();
-      expect(screen.getByTestId(MenuDataTids.root)).toBeInTheDocument();
+      expect(screen.getByTestId(ComboBoxMenuDataTids.items)).toBeInTheDocument();
       expect(screen.getByTestId(ComboBoxMenuDataTids.item)).toHaveTextContent(secondQuery);
     });
 

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -17,12 +17,13 @@ import { getRootNode, rootNode, TSetRootNode } from '../../lib/rootNode';
 import { isIE11 } from '../../lib/client';
 import { createPropsGetter } from '../../lib/createPropsGetter';
 import { isInstanceOf } from '../../lib/isInstanceOf';
+import { CommonProps, CommonWrapper } from '../CommonWrapper';
 
 import { styles } from './Menu.styles';
 import { MenuNavigation } from './MenuNavigation';
 import { MenuContext } from './MenuContext';
 
-export interface MenuProps extends Pick<HTMLAttributes<HTMLDivElement>, 'id'> {
+export interface MenuProps extends CommonProps, Pick<HTMLAttributes<HTMLDivElement>, 'id'> {
   children: React.ReactNode;
   hasMargin?: boolean;
   /**
@@ -212,50 +213,51 @@ export class Menu extends React.PureComponent<MenuProps, MenuState> {
 
     const isMobile = this.isMobileLayout;
     return (
-      <div
-        data-tid={MenuDataTids.root}
-        className={cx(getAlignRightClass(this.props), {
-          [styles.root(this.theme)]: true,
-          [styles.hasMargin(this.theme)]: hasMargin,
-          [styles.mobileRoot(this.theme)]: isMobile,
-          [styles.shadow(this.theme)]: !isMobile,
-        })}
-        style={this.getStyle(this.props)}
-        id={this.props.id}
-        onKeyDown={this.handleKeyDown}
-        ref={this.setRootNode}
-        tabIndex={0}
-      >
-        {this.props.header && this.renderHeader()}
-        <ScrollContainer
-          ref={this.refScrollContainer}
-          maxHeight={maxHeight}
-          preventWindowScroll={preventWindowScroll}
-          onScrollStateChange={this.handleScrollStateChange}
-          disabled={this.props.disableScrollContainer}
-          offsetY={offsetY}
+      <CommonWrapper rootNodeRef={this.setRootNode} {...this.props}>
+        <div
+          data-tid={MenuDataTids.root}
+          className={cx(getAlignRightClass(this.props), {
+            [styles.root(this.theme)]: true,
+            [styles.hasMargin(this.theme)]: hasMargin,
+            [styles.mobileRoot(this.theme)]: isMobile,
+            [styles.shadow(this.theme)]: !isMobile,
+          })}
+          style={this.getStyle(this.props)}
+          id={this.props.id}
+          onKeyDown={this.handleKeyDown}
+          tabIndex={0}
         >
-          <div
-            className={cx({
-              [styles.scrollContainer(this.theme)]: true,
-              [styles.scrollContainerMobile(this.theme)]: isMobile,
-            })}
-            ref={this.contentRef}
+          {this.props.header && this.renderHeader()}
+          <ScrollContainer
+            ref={this.refScrollContainer}
+            maxHeight={maxHeight}
+            preventWindowScroll={preventWindowScroll}
+            onScrollStateChange={this.handleScrollStateChange}
+            disabled={this.props.disableScrollContainer}
+            offsetY={offsetY}
           >
-            <MenuContext.Provider
-              value={{
-                navigation: this.menuNavigation,
-                onItemClick: this.props.onItemClick,
-                enableIconPadding: this.state.enableIconPadding,
-                setEnableIconPadding: this.setEnableIconPadding,
-              }}
+            <div
+              className={cx({
+                [styles.scrollContainer(this.theme)]: true,
+                [styles.scrollContainerMobile(this.theme)]: isMobile,
+              })}
+              ref={this.contentRef}
             >
-              {this.props.children}
-            </MenuContext.Provider>
-          </div>
-        </ScrollContainer>
-        {this.props.footer && this.renderFooter()}
-      </div>
+              <MenuContext.Provider
+                value={{
+                  navigation: this.menuNavigation,
+                  onItemClick: this.props.onItemClick,
+                  enableIconPadding: this.state.enableIconPadding,
+                  setEnableIconPadding: this.setEnableIconPadding,
+                }}
+              >
+                {this.props.children}
+              </MenuContext.Provider>
+            </div>
+          </ScrollContainer>
+          {this.props.footer && this.renderFooter()}
+        </div>
+      </CommonWrapper>
     );
   }
 

--- a/packages/react-ui/internal/Menu/__tests__/Menu-test.tsx
+++ b/packages/react-ui/internal/Menu/__tests__/Menu-test.tsx
@@ -49,4 +49,15 @@ describe('Menu', () => {
 
     expect(onClick).toHaveBeenCalledTimes(0);
   });
+
+  it('should set correct data-tid', () => {
+    const customDataTid = 'custom-data-tid';
+    render(
+      <Menu data-tid={customDataTid}>
+        <MenuItem>MenuItem</MenuItem>
+      </Menu>,
+    );
+
+    expect(screen.getByTestId(customDataTid)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->
Внутри `ComBoxMenu` в `Menu` прокидывались разные дататиды, но в `Menu` они фактически никак не использовались. Из-за этого не работали тесты для комбобокса из `SeleniumTesting`.
## Решение

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

- Обернул `Menu` в `CommonWrapper`, добавил в тип `CommonProps`.
- Добавил тест.

## Ссылки
fix [IF-2170](https://yt.skbkontur.ru/issue/IF-2170)
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
