### PR TITLE
feat(DateInput,DatePicker): add screenreader support to custom input

### DIFF
--- a/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
+++ b/packages/react-ui/components/ComboBox/__tests__/ComboBox-test.tsx
@@ -291,7 +291,7 @@ describe('ComboBox', () => {
       clickOutside();
       await delay(0);
 
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(InputDataTids.root)).not.toBeInTheDocument();
       expect(onBlur).toHaveBeenCalledTimes(1);
     });
 
@@ -1299,7 +1299,7 @@ describe('ComboBox', () => {
           <p id="elementId">Description</p>
         </div>,
       );
-      const comboBox = screen.getByTestId(InputLikeTextDataTids.nativeInput);
+      const comboBox = screen.getByRole('textbox');
       expect(comboBox).toHaveAttribute('aria-describedby', 'elementId');
       expect(comboBox).toHaveAccessibleDescription('Description');
     });
@@ -1351,7 +1351,7 @@ describe('ComboBox', () => {
     expect(screen.getByRole('textbox')).toHaveFocus();
     comboboxRef.current?.blur();
     await delay(0);
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(InputDataTids.root)).not.toBeInTheDocument();
     expect(screen.getByTestId(InputLikeTextDataTids.root)).not.toHaveFocus();
   });
 

--- a/packages/react-ui/components/DateInput/DateInput.tsx
+++ b/packages/react-ui/components/DateInput/DateInput.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { AriaAttributes, HTMLAttributes } from 'react';
 import ReactDOM from 'react-dom';
 import { globalObject } from '@skbkontur/global-object';
 
@@ -35,7 +35,10 @@ export const DateInputDataTids = {
   icon: 'DateInput__icon',
 } as const;
 
-export interface DateInputProps extends CommonProps, Pick<HTMLAttributes<HTMLElement>, 'id'> {
+export interface DateInputProps
+  extends CommonProps,
+    Pick<AriaAttributes, 'aria-describedby' | 'aria-label' | 'aria-labelledby'>,
+    Pick<HTMLAttributes<HTMLElement>, 'id'> {
   /** Устанавливает фокус на контроле после окончания загрузки страницы. */
   autoFocus?: boolean;
 
@@ -235,6 +238,9 @@ export class DateInput extends React.Component<DateInputProps, DateInputState> {
             value={this.iDateMediator.getInternalString()}
             inputMode={'numeric'}
             takeContentWidth
+            aria-describedby={this.props['aria-describedby']}
+            aria-label={this.props['aria-label']}
+            aria-labelledby={this.props['aria-labelledby']}
           >
             <span className={cx(styles.value(), { [styles.valueVisible()]: showValue })}>
               <DateFragmentsView

--- a/packages/react-ui/components/DateInput/__tests__/DateInput-test.tsx
+++ b/packages/react-ui/components/DateInput/__tests__/DateInput-test.tsx
@@ -372,3 +372,36 @@ describe('DateInput as InputlikeText', () => {
     expect(getSelection()?.toString()).toBe('');
   });
 });
+
+describe('a11y', () => {
+  it('passes correct value to `aria-describedby` attribute', () => {
+    const id = 'elementId';
+    const description = 'The caption that describes DateInput';
+    renderRTL(
+      <>
+        <DateInput aria-describedby={id} />
+        <p id={id}>{description}</p>
+      </>,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', id);
+    expect(input).toHaveAccessibleDescription(description);
+  });
+
+  it('passes correct value to `aria-label` attribute', async () => {
+    const label = 'Label for DateInput';
+    renderRTL(<DateInput aria-label={label} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-label', label);
+  });
+
+  it('passes correct value to `aria-labelledby` attribute', async () => {
+    const id = 'elementId';
+    renderRTL(<DateInput aria-labelledby={id} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-labelledby', id);
+  });
+});

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -178,6 +178,8 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
       onMouseDragEnd,
       takeContentWidth,
       'aria-describedby': ariaDescribedby,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledby,
       ...rest
     } = props;
 
@@ -223,6 +225,8 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
           role="textbox"
           aria-disabled={disabled}
           aria-describedby={ariaDescribedby}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
         >
           <InputLayoutContext.Provider value={context}>
             <input type="hidden" data-tid={InputLikeTextDataTids.nativeInput} value={value} disabled={disabled} />

--- a/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
+++ b/packages/react-ui/internal/InputLikeText/InputLikeText.tsx
@@ -214,21 +214,18 @@ export class InputLikeText extends React.Component<InputLikeTextProps, InputLike
           {...rest}
           className={className}
           style={{ width, textAlign: align }}
-          tabIndex={disabled ? undefined : 0}
+          tabIndex={disabled ? -1 : 0}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           ref={this.innerRef}
           onKeyDown={this.handleKeyDown}
           onMouseDown={this.handleMouseDown}
+          role="textbox"
+          aria-disabled={disabled}
+          aria-describedby={ariaDescribedby}
         >
           <InputLayoutContext.Provider value={context}>
-            <input
-              data-tid={InputLikeTextDataTids.nativeInput}
-              type="hidden"
-              value={value}
-              disabled={disabled}
-              aria-describedby={ariaDescribedby}
-            />
+            <input type="hidden" data-tid={InputLikeTextDataTids.nativeInput} value={value} disabled={disabled} />
             {leftSide}
             <span className={wrapperClass}>
               <span

--- a/packages/react-ui/internal/InputLikeText/__tests__/InputLikeText-test.tsx
+++ b/packages/react-ui/internal/InputLikeText/__tests__/InputLikeText-test.tsx
@@ -21,6 +21,7 @@ describe('InputLikeText', () => {
   it('should pass disabled to native input', () => {
     render(<InputLikeText disabled />);
 
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-disabled', 'true');
     expect(screen.getByTestId(InputLikeTextDataTids.nativeInput)).toBeDisabled();
   });
 });


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

1. Скринридер **не читает** значения`<DateInput>`
2. Нет поддержки **aria-атрибутов** в кастомном input — нет возможности добавлять инструкции для пользователей со скринридером. Например, они нужны для подписей в DateRangePicker.

Проблемы связаны с тем, что кастомный ипнут состоит из `<span tabindex="0" onKeyDown>` + `<input type="hidden">`.


## Решение

Изменения затрагивают компонент `<DateInput>` и тесты `<Combobox>`, которые  используют `<InputLikeText>`.

### 1. Доступность \<DateInput\> и \<InputLikeText\>
  - [x] Добавил к `span` атрибут `role="textbox"`
  - [x] Добавил поддержку ARIA-атрибутов
    - [x] aria-label
    - [x] aria-labelledby
    - [x] aria-describedby (ранее был на input type="hidden" и не работал)
    - [x] aria-disabled (ранее disabled был только на input type="hidden")

<img src="https://github.com/user-attachments/assets/78017069-10ae-43ad-802e-55cebfd36dda" width="334">

### 2. Починка тестов \<ComboBox\>

`<ComboBox>` использует `<InputLikeText>` только для внешнего вида и получения фокуса.

После получения фокуса поле `<InputLikeText>` заменяется на обычный `<Input>` — проверки на это появились в тестах на focus/blur в PR #3133.

Ранее через `queryByRole('textbox').not.toBeInTheDocument()` мы проверяли отсутствие `<Input>`, но теперь  `<InputLikeText>` тоже имеет **правильную роль** `textbox`.

- [x] Исправил конфликты через указание более точных data-tid:
`getByRole('textbox')` → `queryByTestId(InputDataTids.root)`


## Ссылки

- [Аудит доступности DatePicker](https://wiki.skbkontur.ru/display/A11y/DateRangePicker)
- [Обсуждение в Mattermost #accessibility_support](https://chat.skbkontur.ru/kontur/pl/3w9995wj5i8a5cu5ms5w4jctna)
- [IF-2175](https://yt.skbkontur.ru/issue/IF-2175/DateInput-ne-vosproizvoditsya-v-skrinridere)


## Демо

### Исправленный ввод в скринридере
| **Было**  | **Стало**  |
| --- | --- |
| — Нельзя было прокинуть название поля, скринридер говорил `__.__.____`<br />— Не работал ввод вместе со скринридером — в NVDA цифры на клавиатуре "1", "2" тригерят навигацию к заголовкам 1 и 2 уровня <br /> <br /> <img src="https://github.com/user-attachments/assets/2415494b-c17e-4b7b-a55b-2c0b81d8f626" width="300"> | — Произносится лейбл (например, "дата") и произносится `edit` <br /> — Работает ввод и произносятся цифры <br /> — Значения не читаются целиком из-за маски (стало лучше, но не идеально — обходится через aria-атрибуты) <br /><br /><br /><br /> <img src="https://github.com/user-attachments/assets/413c7be7-628a-4afd-b39a-147dd31805a0" width="300"> |



## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

4. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

5. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
