### PR TITLE
fix(Popup): fix error 'Anchor element is not defined' on render

### DIFF
--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -14,7 +14,7 @@ import { Toggle } from '../../Toggle';
 import { Button } from '../../Button';
 import { Gapped } from '../../Gapped';
 import { MenuHeader } from '../../MenuHeader';
-import { mergeRefs } from '../../../lib/utils';
+import { mergeRefs } from '../../../lib/mergeRefs';
 import { Tooltip } from '../../Tooltip';
 import { rootNode, TSetRootNode } from '../../../lib/rootNode';
 
@@ -405,7 +405,7 @@ class SimpleCombobox extends React.Component<SimpleComboboxProps & ComboBoxProps
     return (
       <ComboBox
         {...this.props}
-        ref={mergeRefs([this.setRootNode, this.comboBoxRef])}
+        ref={mergeRefs(this.setRootNode, this.comboBoxRef)}
         value={this.state.value}
         getItems={this.getItems}
         onValueChange={(value) => this.setState({ value })}

--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -16,7 +16,7 @@ import { Gapped } from '../../Gapped';
 import { MenuHeader } from '../../MenuHeader';
 import { mergeRefs } from '../../../lib/mergeRefs';
 import { Tooltip } from '../../Tooltip';
-import { rootNode, TSetRootNode } from '../../../lib/rootNode';
+import { rootNode } from '../../../lib/rootNode';
 
 const { getCities } = require('../__mocks__/getCities.ts');
 
@@ -398,7 +398,7 @@ class SimpleCombobox extends React.Component<SimpleComboboxProps & ComboBoxProps
   public state = {
     value: this.props.noInitialValue ? null : { value: 1, label: 'First' },
   };
-  private setRootNode!: TSetRootNode;
+  private setRootNode!: (instance: ComboBox) => void;
   private comboBoxRef: React.RefObject<ComboBox> = React.createRef<ComboBox>();
 
   public render() {

--- a/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__stories__/Combobox.stories.tsx
@@ -16,7 +16,7 @@ import { Gapped } from '../../Gapped';
 import { MenuHeader } from '../../MenuHeader';
 import { mergeRefs } from '../../../lib/mergeRefs';
 import { Tooltip } from '../../Tooltip';
-import { rootNode } from '../../../lib/rootNode';
+import { rootNode, TSetRootNode } from '../../../lib/rootNode';
 
 const { getCities } = require('../__mocks__/getCities.ts');
 
@@ -398,8 +398,8 @@ class SimpleCombobox extends React.Component<SimpleComboboxProps & ComboBoxProps
   public state = {
     value: this.props.noInitialValue ? null : { value: 1, label: 'First' },
   };
-  private setRootNode!: (instance: ComboBox) => void;
-  private comboBoxRef: React.RefObject<ComboBox> = React.createRef<ComboBox>();
+  private setRootNode!: TSetRootNode;
+  private comboBoxRef: React.RefObject<ComboBox | null> = React.createRef<ComboBox>();
 
   public render() {
     return (

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -599,7 +599,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     return isFunction(this.props.children) ? this.props.children() : this.props.children;
   }
 
-  private refPopupContentElement = (element: Nullable<Element>) => {
+  private refPopupContentElement = (element: HTMLDivElement) => {
     this.lastPopupContentElement = element;
   };
 

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -10,15 +10,7 @@ import * as LayoutEvents from '../../lib/LayoutEvents';
 import { Priority, ZIndex } from '../ZIndex';
 import { RenderContainer } from '../RenderContainer';
 import { FocusEventType, MouseEventType } from '../../typings/event-types';
-import {
-  getRandomID,
-  isFunction,
-  isNonNullable,
-  isNullable,
-  isRefableElement,
-  mergeRefs,
-  mergeRefsMemo,
-} from '../../lib/utils';
+import { getRandomID, isFunction, isNonNullable, isNullable, isRefableElement } from '../../lib/utils';
 import { isIE11, isEdge } from '../../lib/client';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
 import { Theme } from '../../lib/theming/Theme';
@@ -37,6 +29,7 @@ import {
   ReactUIFeatureFlags,
   ReactUIFeatureFlagsContext,
 } from '../../lib/featureFlagsContext';
+import { mergeRefs } from '../../lib/mergeRefs';
 
 import { PopupPin } from './PopupPin';
 import { Offset, PopupHelper, PositionObject, Rect } from './PopupHelper';
@@ -279,7 +272,6 @@ export class Popup extends React.Component<PopupProps, PopupState> {
   private refForTransition = React.createRef<HTMLDivElement>();
   private hasAnchorElementListeners = false;
   private rootId = PopupIds.root + getRandomID();
-  private useMemoRefs = mergeRefsMemo();
 
   public anchorElement: Nullable<Element> = null;
   private absoluteParent: Nullable<HTMLDivElement> = null;
@@ -388,7 +380,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
     const anchorWithRef =
       anchor && React.isValidElement(anchor) && isRefableElement(anchor)
         ? React.cloneElement(anchor, {
-            ref: this.useMemoRefs(
+            ref: mergeRefs(
               (anchor as React.RefAttributes<this>)?.ref as React.RefCallback<this>,
               this.updateAnchorElement,
             ),
@@ -528,7 +520,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
       <div
         className={styles.content(this.theme)}
         data-tid={PopupDataTids.content}
-        ref={mergeRefs([this.refForTransition, this.refPopupContentElement])}
+        ref={mergeRefs(this.refForTransition, this.refPopupContentElement)}
       >
         <div
           className={styles.contentInner(this.theme)}

--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -381,7 +381,7 @@ export class Popup extends React.Component<PopupProps, PopupState> {
       anchor && React.isValidElement(anchor) && isRefableElement(anchor)
         ? React.cloneElement(anchor, {
             ref: mergeRefs(
-              (anchor as React.RefAttributes<this>)?.ref as React.RefCallback<this>,
+              (anchor as React.RefAttributes<typeof anchor>)?.ref as React.RefCallback<any>,
               this.updateAnchorElement,
             ),
           } as { ref: (instance: Nullable<React.ReactInstance>) => void })

--- a/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
+++ b/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
@@ -41,8 +41,7 @@ describe('mergeRefs', () => {
     }
     const funcRef = jest.fn();
     const Comp = ({ refFn, triggerRerender }: CompProps) => {
-      console.log(triggerRerender);
-      return <div ref={mergeRefs(refFn)} />;
+      return <div ref={mergeRefs(refFn)} style={{width: +triggerRerender }} />;
     };
 
     const { rerender } = render(<Comp refFn={funcRef} triggerRerender />);
@@ -50,5 +49,27 @@ describe('mergeRefs', () => {
 
     rerender(<Comp refFn={funcRef} triggerRerender={false} />);
     expect(funcRef).toHaveBeenCalledTimes(1);
+  });
+
+  it('change ref and call new', () => {
+    interface CompProps {
+      refFn: (element: HTMLDivElement) => void;
+    }
+    const funcRef1 = jest.fn();
+    const funcRef2 = jest.fn();
+    const Comp = ({ refFn }: CompProps) => {
+      return <div ref={mergeRefs(refFn)} />;
+    };
+
+    const { rerender } = render(<Comp refFn={funcRef1} />);
+
+    rerender(<Comp refFn={funcRef2} />);
+
+    expect(funcRef1.mock.calls).toHaveLength(2);
+    expect(funcRef1.mock.calls[0][0]).toBeTruthy(); //attach
+    expect(funcRef1.mock.calls[1][0]).toBeNull(); //detach
+
+    expect(funcRef2.mock.calls).toHaveLength(1); //attach new
+    expect(funcRef2.mock.calls[0][0]).toBeTruthy();
   });
 });

--- a/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
+++ b/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
@@ -1,7 +1,7 @@
 import React, { createRef, forwardRef, useImperativeHandle } from 'react';
 import { render } from '@testing-library/react';
 
-import { mergeRefs } from '../utils';
+import { mergeRefs } from '../mergeRefs';
 
 describe('mergeRefs', () => {
   it('correctly merges refs', () => {
@@ -15,7 +15,7 @@ describe('mergeRefs', () => {
     const objRef = createRef();
     const Example = ({ visible }: { visible: boolean }) => {
       if (visible) {
-        return <ComponentWithImperativeMethods ref={mergeRefs([funcRef, objRef])} />;
+        return <ComponentWithImperativeMethods ref={mergeRefs(funcRef, objRef)} />;
       }
 
       return null;
@@ -32,5 +32,23 @@ describe('mergeRefs', () => {
     expect(funcRef).toHaveBeenCalledTimes(2);
     expect(funcRef).toHaveBeenCalledWith(null);
     expect(objRef.current).toBeNull();
+  });
+
+  it('save old refs to cache', () => {
+    interface CompProps {
+      refFn: (element: HTMLDivElement) => void;
+      triggerRerender: boolean;
+    }
+    const funcRef = jest.fn();
+    const Comp = ({ refFn, triggerRerender }: CompProps) => {
+      console.log(triggerRerender);
+      return <div ref={mergeRefs(refFn)} />;
+    };
+
+    const { rerender } = render(<Comp refFn={funcRef} triggerRerender />);
+    expect(funcRef).toHaveBeenCalledTimes(1);
+
+    rerender(<Comp refFn={funcRef} triggerRerender={false} />);
+    expect(funcRef).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
+++ b/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
@@ -41,7 +41,7 @@ describe('mergeRefs', () => {
     }
     const funcRef = jest.fn();
     const Comp = ({ refFn, triggerRerender }: CompProps) => {
-      return <div ref={mergeRefs(refFn)} style={{width: +triggerRerender }} />;
+      return <div ref={mergeRefs(refFn)} style={{ width: +triggerRerender }} />;
     };
 
     const { rerender } = render(<Comp refFn={funcRef} triggerRerender />);
@@ -71,5 +71,58 @@ describe('mergeRefs', () => {
 
     expect(funcRef2.mock.calls).toHaveLength(1); //attach new
     expect(funcRef2.mock.calls[0][0]).toBeTruthy();
+  });
+
+  describe('return callbacks comparation', () => {
+    const funcRef1 = jest.fn();
+    const funcRef2 = jest.fn();
+    const funcRef3 = jest.fn();
+    it('set same refs return same callbacks', () => {
+      const firstCall = mergeRefs(funcRef1, funcRef2, funcRef3);
+      const secondCall = mergeRefs(funcRef1, funcRef2, funcRef3);
+      expect(firstCall === secondCall).toBeTruthy();
+
+      const thirdCall = mergeRefs(funcRef1, funcRef2, funcRef3);
+      expect(secondCall === thirdCall).toBeTruthy();
+      expect(firstCall === thirdCall).toBeTruthy();
+    });
+
+    it('change order return different callbacks', () => {
+      const firstCall = mergeRefs(funcRef1, funcRef2, funcRef3);
+      const secondCall = mergeRefs(funcRef2, funcRef3, funcRef2);
+      expect(firstCall !== secondCall).toBeTruthy();
+
+      const thirdCall = mergeRefs(funcRef1, funcRef2, funcRef3);
+      expect(secondCall !== thirdCall).toBeTruthy();
+      expect(firstCall === thirdCall).toBeTruthy();
+    });
+
+    it('change params count return different callbacks', () => {
+      const firstCall = mergeRefs(funcRef1, funcRef2, funcRef3);
+      const secondCall = mergeRefs(funcRef2, funcRef3);
+      expect(firstCall !== secondCall).toBeTruthy();
+
+      const thirdCall = mergeRefs(funcRef1);
+      expect(secondCall !== thirdCall).toBeTruthy();
+      expect(firstCall !== thirdCall).toBeTruthy();
+    });
+
+    it('change params return different callbacks', () => {
+      const firstCall = mergeRefs(funcRef1, funcRef2);
+      const secondCall = mergeRefs(funcRef1, funcRef3);
+      expect(firstCall !== secondCall).toBeTruthy();
+
+      const thirdCall = mergeRefs(funcRef1, funcRef3);
+      expect(secondCall === thirdCall).toBeTruthy();
+    });
+
+    it('params can be null', () => {
+      const firstCall = mergeRefs(funcRef1, null, funcRef2);
+      const secondCall = mergeRefs(funcRef1, null, funcRef2);
+      expect(firstCall === secondCall).toBeTruthy();
+
+      const thirdCall = mergeRefs(funcRef1, funcRef2);
+      expect(secondCall !== thirdCall).toBeTruthy();
+    });
   });
 });

--- a/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
+++ b/packages/react-ui/lib/__tests__/mergeRefs-test.tsx
@@ -37,17 +37,16 @@ describe('mergeRefs', () => {
   it('save old refs to cache', () => {
     interface CompProps {
       refFn: (element: HTMLDivElement) => void;
-      triggerRerender: boolean;
     }
     const funcRef = jest.fn();
-    const Comp = ({ refFn, triggerRerender }: CompProps) => {
-      return <div ref={mergeRefs(refFn)} style={{ width: +triggerRerender }} />;
+    const Comp = ({ refFn }: CompProps) => {
+      return <div ref={mergeRefs(refFn)} />;
     };
 
-    const { rerender } = render(<Comp refFn={funcRef} triggerRerender />);
+    const { rerender } = render(<Comp refFn={funcRef} />);
     expect(funcRef).toHaveBeenCalledTimes(1);
 
-    rerender(<Comp refFn={funcRef} triggerRerender={false} />);
+    rerender(<Comp refFn={funcRef} />);
     expect(funcRef).toHaveBeenCalledTimes(1);
   });
 
@@ -116,13 +115,13 @@ describe('mergeRefs', () => {
       expect(secondCall === thirdCall).toBeTruthy();
     });
 
-    it('params can be null', () => {
+    it('params can be null/undefined and will be ignored', () => {
       const firstCall = mergeRefs(funcRef1, null, funcRef2);
-      const secondCall = mergeRefs(funcRef1, null, funcRef2);
+      const secondCall = mergeRefs(funcRef1, funcRef2, undefined);
       expect(firstCall === secondCall).toBeTruthy();
 
       const thirdCall = mergeRefs(funcRef1, funcRef2);
-      expect(secondCall !== thirdCall).toBeTruthy();
+      expect(secondCall === thirdCall).toBeTruthy();
     });
   });
 });

--- a/packages/react-ui/lib/mergeRefs.ts
+++ b/packages/react-ui/lib/mergeRefs.ts
@@ -1,0 +1,62 @@
+import type React from 'react';
+
+import { Nullable } from '../typings/utility-types';
+
+import { isNonNullable } from './utils';
+
+type refVariants<T> = React.RefObject<T> | React.RefCallback<T> | React.LegacyRef<T>;
+type refCallback<T> = (this: { refs: Array<refVariants<T>> }, value: T | React.LegacyRef<Element>) => void;
+
+interface IRefCallbackCache<T> {
+  refs: Array<refVariants<T>>;
+  callback: refCallback<T>;
+}
+
+function applyRef<T>(this: { refs: Array<refVariants<T>> }, value: T) {
+  this.refs.forEach((ref) => {
+    if (typeof ref === 'function') {
+      return ref(value);
+    } else if (isNonNullable(ref)) {
+      return ((ref as React.MutableRefObject<T>).current = value);
+    }
+  });
+}
+
+const cache: Array<IRefCallbackCache<any>> = [];
+
+/**
+ * Merges two or more refs into one with cached refs
+ *
+ * @returns function that passed refs: (...refs) =>
+ *
+ * @example
+ * const SomeComponent = forwardRef((props, ref) => {
+ *  const localRef = useRef();
+ *  const mergeRefs = useRef(mergeRefsMemo());
+ *
+ *  return <div ref={mergeRefs.current(localRef, ref)} />;
+ * });
+ */
+export function mergeRefs<T>(...refs: Array<refVariants<T>>) {
+  const callback = getCallbackInCache(...refs);
+
+  if (callback) {
+    return callback;
+  }
+
+  const cachedApplyRef = applyRef.bind({ refs });
+  cache.push({ refs, callback: cachedApplyRef });
+  return cachedApplyRef;
+}
+
+function getCallbackInCache<T>(...refs: Array<refVariants<T>>): Nullable<refCallback<T>> {
+  for (const { refs: cachedRefs, callback } of cache) {
+    const isCachedRefs = refs.every((newRef) => cachedRefs.includes(newRef));
+
+    if (isCachedRefs) {
+      return callback;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/react-ui/lib/mergeRefs.ts
+++ b/packages/react-ui/lib/mergeRefs.ts
@@ -14,15 +14,18 @@ type CacheValue<T> = RefCallback<T> | WeakMap<CacheKey<T>, CacheValue<T>>;
 const cache = new WeakMap<CacheKey<any>, CacheValue<any>>();
 
 /**
- * Merges two or more refs into one with cached ref
+ * Позволяет объединить несколько параметров ref в один вызов, в котором во все переданные параметры просетится ref.
+ *
+ * Кеширует результат возвращаемой функции, так что при одинаковых входных параметрах React-у будет возвращена одинаковая функция.
+ * Это позволит не вызывать лишние commitAttachRef и commitDetachRef и не ловить сайдэффекты связанные со значением ref в моменте
+ *
+ * Не прокидывай в параметрах стрелочные функции, так результат не будет закеширован.
  *
  * @returns function that passed refs: (...refs) =>
  *
  * @example
  * const SomeComponent = forwardRef((props, ref) => {
  *  const localRef = useRef();
- *  const mergeRefs = useRef(mergeRefsMemo());
- *
  *  return <div ref={mergeRefs(localRef, ref)} />;
  * });
  */

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -156,31 +156,6 @@ export const isReactUIComponent = <P = any>(name: string) => {
 };
 
 /**
- * Merges two or more refs into one.
- *
- * @param refs Array of refs.
- * @returns A single ref composing all the refs passed.
- *
- * @example
- * const SomeComponent = forwardRef((props, ref) => {
- *  const localRef = useRef();
- *
- *  return <div ref={mergeRefs([localRef, ref])} />;
- * });
- */
-export function mergeRefs<T = any>(refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>): React.RefCallback<T> {
-  return (value) => {
-    refs.forEach((ref) => {
-      if (typeof ref === 'function') {
-        return ref(value);
-      } else if (isNonNullable(ref)) {
-        return ((ref as React.MutableRefObject<T | null>).current = value);
-      }
-    });
-  };
-}
-
-/**
  * Extracts all data attributes from props and returns them as well as props.
  *
  * @param props Props object to extract data attributes from.

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -155,6 +155,19 @@ export const isReactUIComponent = <P = any>(name: string) => {
   };
 };
 
+/** @deprecated Переехал в `lib/mergeRefs.ts`. Со следующей мажорной версии от сюда будет удален*/
+export function mergeRefs<T = any>(refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>): React.RefCallback<T> {
+  return (value) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        return ref(value);
+      } else if (isNonNullable(ref)) {
+        return ((ref as React.MutableRefObject<T | null>).current = value);
+      }
+    });
+  };
+}
+
 /**
  * Extracts all data attributes from props and returns them as well as props.
  *

--- a/packages/react-ui/lib/utils.ts
+++ b/packages/react-ui/lib/utils.ts
@@ -156,44 +156,6 @@ export const isReactUIComponent = <P = any>(name: string) => {
 };
 
 /**
- * Merges two or more refs into one with cached refs
- *
- * @returns function that passed refs: (...refs) =>
- *
- * @example
- * const SomeComponent = forwardRef((props, ref) => {
- *  const localRef = useRef();
- *  const mergeRefs = useRef(mergeRefsMemo());
- *
- *  return <div ref={mergeRefs.current(localRef, ref)} />;
- * });
- */
-export function mergeRefsMemo<T>() {
-  type refVariants = React.RefObject<T> | React.RefCallback<T>;
-  let cacheRefs: refVariants[] = [];
-  let cachedApplyRef = applyRef;
-  function applyRef(this: { refs: refVariants[] }, value: T) {
-    this.refs.forEach((ref) => {
-      if (typeof ref === 'function') {
-        return ref(value);
-      } else if (isNonNullable(ref)) {
-        return ((ref as React.MutableRefObject<T>).current = value);
-      }
-    });
-  }
-
-  return (...refs: refVariants[]) => {
-    const isNewRefs = refs.some((newRef, index) => newRef !== cacheRefs[index]);
-    if (isNewRefs) {
-      cachedApplyRef = applyRef.bind({ refs });
-      cacheRefs = refs;
-      return cachedApplyRef;
-    }
-    return cachedApplyRef;
-  };
-}
-
-/**
  * Merges two or more refs into one.
  *
  * @param refs Array of refs.


### PR DESCRIPTION
## Проблема

При рендере tooltip-a на странице, были случаи появления ошибки 'Anchor element is not defined or not instance of Element'. Частично эту ошибку заглушили в #3356, но не до конца. 

## Решение

Изменена функция передачи ref ссылки в якорь, относительно которого рендерится tooltip со стрелочной, на обычную. Это позволило не вызывать лишний раз commitDetachRef в компонентах жизненного цикла, которые приводили к ошибке.

## Ссылки

[IF-1145](https://yt.skbkontur.ru/issue/IF-1145) Popup: разобраться, откуда появляется варнинг  'Anchor element is not defined or not instance of Element'

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
