### PR TITLE
docs(): disable Storybook hotkey '1' conflicted with DateInput

### DIFF
--- a/packages/react-ui-validations/.storybook/manager-head.html
+++ b/packages/react-ui-validations/.storybook/manager-head.html
@@ -29,4 +29,14 @@
   #storybook-explorer-searchfield {
     border-radius: 2px;
   }
+
+  /* Disable Storybook's sidebar hotkey '1' that conflicts with DateInput typing */
+  /* TODO: remove hack after fix <DateInput> onKeyDown behaviour in IF-2158 */
+  #storybook-explorer-menu {
+    visibility: hidden !important;
+  }
+
+  #storybook-explorer-menu > * {
+    visibility: visible !important;
+  }
 </style>

--- a/packages/react-ui/.storybook/manager-head.html
+++ b/packages/react-ui/.storybook/manager-head.html
@@ -29,4 +29,14 @@
   #storybook-explorer-searchfield {
     border-radius: 2px;
   }
+
+  /* Disable Storybook's sidebar hotkey '1' that conflicts with DateInput typing */
+  /* TODO: remove hack after fix <DateInput> onKeyDown behaviour in IF-2158 */
+  #storybook-explorer-menu {
+    visibility: hidden !important;
+  }
+
+  #storybook-explorer-menu > * {
+    visibility: visible !important;
+  }
 </style>


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Хоткеи DateInput конфликтуют с включенным сайдбаром Storybook — контрол теряет фокус при вводе '1'.

Проблема мешает показывать демки для пользователей библиотеки в песочнице.

## Решение

Отключил хоткей для бокового меню Storybook через хак с CSS-свйоством visibility. Остальные [хоткеи](https://ui.gitlab-pages.kontur.host/storybook-documentation/?path=/settings/shortcuts) не стал выключать.

<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

- [IF-2185](https://yt.skbkontur.ru/issue/IF-2185)
- [IF-2158](https://yt.skbkontur.ru/issue/IF-2158) — повесил TODO, что проблема исправится вместе с этой задачей

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
