### PR TITLE
docs(): simplify external Storybooks with a single item

### DIFF
--- a/packages/react-ui-validations/.storybook/preview-head.html
+++ b/packages/react-ui-validations/.storybook/preview-head.html
@@ -237,6 +237,48 @@
     line-height: 24px;
   }
 
+  /* Simplify external storybooks with only 1 story */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div[data-selected='true']:only-child) {
+    position: relative;
+    z-index: 1;
+    color: white;
+    pointer-events: none;
+  }
+
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child),
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) + div > div {
+    padding: 0;
+    border: 0;
+    margin: 8px 0;
+  }
+
+  #storybook-explorer-tree [aria-expanded] + div > div > div:only-child {
+    margin-top: -32px;
+    font-size: 0;
+  }
+
+  #storybook-explorer-tree [aria-expanded] + div > div > div:not([data-selected='true']):only-child:hover {
+    background: #029cfd;
+    opacity: 0.1;
+  }
+
+  #storybook-explorer-tree [aria-expanded] + div > div > div:only-child * {
+    width: 0;
+    opacity: 0;
+  }
+
+  #storybook-explorer-tree
+    [aria-expanded]:has(+ div > div > div:only-child)
+    [data-action='collapse-ref']
+    span:first-child {
+    opacity: 0;
+  }
+
+  /* Hide external storybook link icon */
+  #storybook-explorer-tree [aria-expanded] [aria-label='toggle indicator'] {
+    display: none;
+  }
+
   @media screen and (max-width: 1100px) {
     div:has(> div > div.toc-wrapper) {
       display: none;

--- a/packages/react-ui-validations/.storybook/preview-head.html
+++ b/packages/react-ui-validations/.storybook/preview-head.html
@@ -237,14 +237,7 @@
     line-height: 24px;
   }
 
-  /* Simplify external storybooks with only 1 story */
-  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div[data-selected='true']:only-child) {
-    position: relative;
-    z-index: 1;
-    color: white;
-    pointer-events: none;
-  }
-
+  /* Exteral storybooks with 1 story. Move 1st link to title */
   #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child),
   #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) + div > div {
     padding: 0;
@@ -267,6 +260,13 @@
     opacity: 0;
   }
 
+  /* Exteral storybooks with 1 story. Disable collapse button */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) {
+    position: relative;
+    z-index: 1;
+    pointer-events: none;
+  }
+
   #storybook-explorer-tree
     [aria-expanded]:has(+ div > div > div:only-child)
     [data-action='collapse-ref']
@@ -274,9 +274,22 @@
     opacity: 0;
   }
 
-  /* Hide external storybook link icon */
-  #storybook-explorer-tree [aria-expanded] [aria-label='toggle indicator'] {
-    display: none;
+  /* Exteral storybooks with 1 story. Disable tab keys for collapse button */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) [data-action='collapse-ref'] {
+    visibility: hidden;
+  }
+
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) [data-action='collapse-ref'] {
+    visibility: visible;
+  }
+
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) aside {
+    pointer-events: all;
+  }
+
+  /* Exteral storybooks with 1 story. Invert text */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div[data-selected='true']:only-child) * {
+    color: white;
   }
 
   @media screen and (max-width: 1100px) {

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -248,14 +248,7 @@
     line-height: 24px;
   }
 
-  /* Simplify external storybooks with only 1 story */
-  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div[data-selected='true']:only-child) {
-    position: relative;
-    z-index: 1;
-    color: white;
-    pointer-events: none;
-  }
-
+  /* Exteral storybooks with 1 story. Move 1st link to title */
   #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child),
   #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) + div > div {
     padding: 0;
@@ -278,6 +271,13 @@
     opacity: 0;
   }
 
+  /* Exteral storybooks with 1 story. Disable collapse button */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) {
+    position: relative;
+    z-index: 1;
+    pointer-events: none;
+  }
+
   #storybook-explorer-tree
     [aria-expanded]:has(+ div > div > div:only-child)
     [data-action='collapse-ref']
@@ -285,9 +285,22 @@
     opacity: 0;
   }
 
-  /* Hide external storybook link icon */
-  #storybook-explorer-tree [aria-expanded] [aria-label='toggle indicator'] {
-    display: none;
+  /* Exteral storybooks with 1 story. Disable tab keys for collapse button */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) [data-action='collapse-ref'] {
+    visibility: hidden;
+  }
+
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) [data-action='collapse-ref'] {
+    visibility: visible;
+  }
+
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) aside {
+    pointer-events: all;
+  }
+
+  /* Exteral storybooks with 1 story. Invert text */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div[data-selected='true']:only-child) * {
+    color: white;
   }
 
   @media screen and (max-width: 1100px) {

--- a/packages/react-ui/.storybook/preview-head.html
+++ b/packages/react-ui/.storybook/preview-head.html
@@ -248,6 +248,48 @@
     line-height: 24px;
   }
 
+  /* Simplify external storybooks with only 1 story */
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div[data-selected='true']:only-child) {
+    position: relative;
+    z-index: 1;
+    color: white;
+    pointer-events: none;
+  }
+
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child),
+  #storybook-explorer-tree [aria-expanded]:has(+ div > div > div:only-child) + div > div {
+    padding: 0;
+    border: 0;
+    margin: 8px 0;
+  }
+
+  #storybook-explorer-tree [aria-expanded] + div > div > div:only-child {
+    margin-top: -32px;
+    font-size: 0;
+  }
+
+  #storybook-explorer-tree [aria-expanded] + div > div > div:not([data-selected='true']):only-child:hover {
+    background: #029cfd;
+    opacity: 0.1;
+  }
+
+  #storybook-explorer-tree [aria-expanded] + div > div > div:only-child * {
+    width: 0;
+    opacity: 0;
+  }
+
+  #storybook-explorer-tree
+    [aria-expanded]:has(+ div > div > div:only-child)
+    [data-action='collapse-ref']
+    span:first-child {
+    opacity: 0;
+  }
+
+  /* Hide external storybook link icon */
+  #storybook-explorer-tree [aria-expanded] [aria-label='toggle indicator'] {
+    display: none;
+  }
+
   @media screen and (max-width: 1100px) {
     div:has(> div > div.toc-wrapper) {
       display: none;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

<!-- Подробно опиши решаемую проблему. -->

- Внешние Storybook с 1-м пунктом занимали слишком много места
- ~~Не работала ссылка на внешний сторибук~~

| Было | Стало |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c9466803-3752-46e8-9b45-cf14ab89a357) | ![image](https://github.com/user-attachments/assets/a03c6a00-fdf2-40ba-b6eb-bfdd58214333) |


## Решение

- Если всего 1 пункт, то он открывается сразу и не занимает много места — написал CSS-селектор, который "подтягивает" единственный пункт меню наверх
- ~~Удалил ссылки на внешние Storybook (не работали)~~
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
