### PR TITLE
fix(MaskedInput): fix change theme

### DIFF
--- a/packages/react-ui/.creevey/images/MaskedInput/Change Theme/chrome2022.png
+++ b/packages/react-ui/.creevey/images/MaskedInput/Change Theme/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5fb8d5656e71489b542c231de368afe190f804c2ced0129d3070b491a235707
+size 1144

--- a/packages/react-ui/components/MaskedInput/ColorableInputElement/ColorableInputElement.tsx
+++ b/packages/react-ui/components/MaskedInput/ColorableInputElement/ColorableInputElement.tsx
@@ -47,13 +47,15 @@ export const ColorableInputElement = forwardRefAndName(
       updateActive();
     }, [active, showOnFocus, props.value, props.defaultValue, props.disabled, focused.current, theme]);
 
-    const debouncedPaintText = useCallback(debounce(paintText), [
+    const paintTextCallback = useCallback(paintText, [
       showOnFocus,
       props.disabled,
       theme.inputTextColor,
       theme.inputPlaceholderColor,
       theme.inputTextColorDisabled,
     ]);
+
+    const debouncedPaintText = useCallback(debounce(paintTextCallback), [paintTextCallback]);
 
     useEffect(() => {
       if (inputRef.current) {

--- a/packages/react-ui/components/MaskedInput/ColorableInputElement/ColorableInputElement.tsx
+++ b/packages/react-ui/components/MaskedInput/ColorableInputElement/ColorableInputElement.tsx
@@ -27,7 +27,6 @@ export const ColorableInputElement = forwardRefAndName(
     const focused = useRef(false);
     const inputStyle = React.useRef<CSSStyleDeclaration>();
     const theme = useContext(ThemeContext);
-    const debouncedPaintText = useCallback(debounce(paintText), []);
     const [active, setActive] = useState(true);
 
     const { children, onInput, onFocus, onBlur, showOnFocus, ...inputProps } = props;
@@ -44,9 +43,17 @@ export const ColorableInputElement = forwardRefAndName(
     useEffect(updateActive, []);
 
     useEffect(() => {
-      activation(props);
+      activation();
       updateActive();
-    }, [active, showOnFocus, props.value, props.defaultValue, props.disabled, focused.current]);
+    }, [active, showOnFocus, props.value, props.defaultValue, props.disabled, focused.current, theme]);
+
+    const debouncedPaintText = useCallback(debounce(paintText), [
+      showOnFocus,
+      props.disabled,
+      theme.inputTextColor,
+      theme.inputPlaceholderColor,
+      theme.inputTextColorDisabled,
+    ]);
 
     useEffect(() => {
       if (inputRef.current) {
@@ -72,7 +79,7 @@ export const ColorableInputElement = forwardRefAndName(
       const isActive = !inputRef.current?.parentElement?.querySelector(':placeholder-shown');
       setActive(isActive);
 
-      activation(props);
+      activation();
 
       onInput?.(e);
     }
@@ -99,9 +106,9 @@ export const ColorableInputElement = forwardRefAndName(
       });
     }
 
-    function activation(props: ColorableInputElementProps) {
+    function activation() {
       if (active) {
-        debouncedPaintText(props);
+        debouncedPaintText();
       } else {
         debouncedPaintText.cancel();
         inputRef.current && (inputRef.current.style.backgroundImage = '');
@@ -109,7 +116,7 @@ export const ColorableInputElement = forwardRefAndName(
       }
     }
 
-    function paintText(_props: Partial<ColorableInputElementProps> = props) {
+    function paintText() {
       if (!spanRef.current || !inputRef.current || !inputStyle.current || !isBrowser(globalObject)) {
         return;
       }
@@ -143,11 +150,11 @@ export const ColorableInputElement = forwardRefAndName(
 
       let typedValueColor = theme.inputTextColor;
       let maskColor = theme.inputPlaceholderColor;
-      if (_props.disabled) {
+      if (props.disabled) {
         typedValueColor = theme.inputTextColorDisabled;
         maskColor = theme.inputTextColorDisabled;
       }
-      if (_props.showOnFocus) {
+      if (props.showOnFocus) {
         maskColor = focused.current ? maskColor : 'transparent';
       }
 

--- a/packages/react-ui/components/MaskedInput/ColorableInputElement/ColorableInputElement.tsx
+++ b/packages/react-ui/components/MaskedInput/ColorableInputElement/ColorableInputElement.tsx
@@ -114,7 +114,7 @@ export const ColorableInputElement = forwardRefAndName(
     useEffect(() => {
       activation();
       updateActive();
-    }, [active, props.showOnFocus, props.value, props.defaultValue, props.disabled, theme, activation]);
+    }, [props.value, props.defaultValue, theme, activation]);
 
     useEffect(() => {
       if (inputRef.current) {

--- a/packages/react-ui/components/MaskedInput/__stories__/MaskedInput.stories.tsx
+++ b/packages/react-ui/components/MaskedInput/__stories__/MaskedInput.stories.tsx
@@ -1,12 +1,15 @@
 // TODO: Rewrite stories and enable rule (in process of functional refactoring).
 /* eslint-disable react/no-unstable-nested-components */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { ComponentTable } from '../../../internal/ComponentTable';
 import { SearchLoupeIcon16Regular } from '../../../internal/icons2022/SearchLoupeIcon/SearchLoupeIcon16Regular';
 import { Meta, Story } from '../../../typings/stories';
 import { MaskedInput, MaskedInputProps } from '../MaskedInput';
 import { Input, InputProps } from '../../Input';
+import { ThemeContext } from '../../../lib/theming/ThemeContext';
+import { LIGHT_THEME } from '../../../lib/theming/themes/LightTheme';
+import { DARK_THEME } from '../../../lib/theming/themes/DarkTheme';
 
 export default {
   title: 'MaskedInput',
@@ -442,4 +445,23 @@ export const RewriteInMiddle: Story = () => {
   const [value, setValue] = React.useState('12');
 
   return <MaskedInput {...DEFAULT_PROPS} mask="9999" alwaysShowMask value={value} onValueChange={setValue} />;
+};
+
+export const ChangeTheme: Story = () => {
+  const [theme, setTheme] = React.useState(DARK_THEME);
+
+  useEffect(() => {
+    setTheme(LIGHT_THEME);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <MaskedInput {...DEFAULT_PROPS} alwaysShowMask value="123" />
+    </ThemeContext.Provider>
+  );
+};
+ChangeTheme.parameters = {
+  creevey: {
+    skip: { 'enough basic theme': { in: /^(?!\b(chrome2022)\b)/ } },
+  },
 };


### PR DESCRIPTION
## Проблема

При смене темы компонент не перекрашивает текст.
Причина в методе `paintText()` в компоненте `ColorableInputElement`. Этот метод обёрнут в `useCallback`, а значит необходимо указать зависимости, чтобы он обновлялся.

## Решение

- Добавил зависимости в `useCallback`
- Добавил тест на смену темы

---

Изначально хотел использовать в тесте темы мажорных версий — `LIGHT_THEME_2022_0` и `DARK_THEME_2022_0`.
Идея была в том, что этот тест именно смены темы, поэтому нет смысла обновлять скриншот если обновиться тема.

Но потом подумал, что тогда при обновлении мажора придётся обновлять сам тест-кейс. Каждый раз..
И решил проще и лучше уж обновлять скриншот вместе с другими скриншотами, чем обновлять уникальный тест-кейс в каждом мажоре.

## Ссылки

`IF-2193`

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
