### PR TITLE
chore(listenFocusOutside): replace Error with warning

### DIFF
--- a/packages/react-ui/lib/listenFocusOutside.ts
+++ b/packages/react-ui/lib/listenFocusOutside.ts
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { globalObject } from '@skbkontur/global-object';
+import warning from 'warning';
 
 import { PORTAL_INLET_ATTR, PORTAL_OUTLET_ATTR } from '../internal/RenderContainer';
 
@@ -87,7 +88,8 @@ export function findRenderContainer(node: Element, rootNode: Element, container?
     const nextNode = globalObject.document?.querySelector(`[${PORTAL_INLET_ATTR}~="${newContainerId}"]`);
 
     if (!nextNode) {
-      throw Error(`Origin node for render container was not found`);
+      warning(true, `Origin node for render container was not found`);
+      return null;
     }
 
     return findRenderContainer(nextNode, rootNode, nextNode);


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Ошибка бросается в не критическом месте. Жалоб от пользователей нет, но ошибки сыпятся.
Это код для поиска фокуса вне портала, и ненахождение родителя контейнера не должно бросать ошибку.


## Решение

Заменил проброс ошибки на варнинг.


## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
