### PR TITLE
fix(Popup,Tooltip,Dropdown): improve position props type (#3617)

### DIFF
--- a/packages/react-ui/internal/Popup/Popup.tsx
+++ b/packages/react-ui/internal/Popup/Popup.tsx
@@ -38,7 +38,7 @@ import { styles } from './Popup.styles';
 const POPUP_BORDER_DEFAULT_COLOR = 'transparent';
 const TRANSITION_TIMEOUT = { enter: 0, exit: 200 };
 
-export const PopupNonPinnablePositions = ['middle center', 'middle left', 'middle right'];
+export const PopupNonPinnablePositions = ['middle center', 'middle left', 'middle right'] as const;
 
 export const PopupPinnablePositions = [
   'top center',
@@ -53,7 +53,7 @@ export const PopupPinnablePositions = [
   'right middle',
   'right top',
   'right bottom',
-];
+] as const;
 
 export const PopupPositions = [...PopupPinnablePositions, ...PopupNonPinnablePositions] as const;
 


### PR DESCRIPTION
Пересоздано из #3617 для прогона тестов.

## Проблема

У компонентов `Popup`, `Tooltip`, `Dropdown` и некоторых других (все, кто используют тип позиционирования от `Popup`) отсутствовала корректная типизация пропса, отвечающего за позиционирование.

## Ссылки

[Typescript Playground](https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAYwgOwM7wAoTAVzAORQwEtlkBDAIwBtgtViZiVU4BeOAbQHIBbYgCYDaiYMhjAo3ADRw+g4cDi0AZjBlz+QkVGIBzABbqAunHKskaGAG4AULdCRYiFpmx4SZKrXqNmadi5bODkYbFFxSRlg0PDVdWkY7jCwOF1DBKTKCBgw3giJKUSQ7mzciHz46JKyvLT9I2q5eLgtRSbuFpSOltqKjvSjVoVaAYb4buK5Qfg+3mjTcxcrazh7R2h4S3Q4LFwwXyYWQM4AOnO9j1IKGjoIBiO0WXPTy4Iia+87h-9URYtXHYHOBNnAYABPMBKN6HX4AFUhSg4AAoIVCICpdu4Dvc-CwAJScZA4XiUSTGOwbZxo6HYzw3Hy4x6oBFQwKoxEYrH7elfWEEokkslQClAA)

**с изменениями из реквеста**:

<img width="920" alt="Screenshot 2025-03-14 at 12 58 23" src="https://github.com/user-attachments/assets/a60b9d2e-5b56-4a2c-b6eb-be984a71b4df" />

**без изменений**:

<img width="918" alt="Screenshot 2025-03-14 at 12 58 37" src="https://github.com/user-attachments/assets/fb683687-fc44-47f7-ba2e-5e1a3dcff165" />
