### PR TITLE
fix(PasswordInput): width in percent

### DIFF
--- a/packages/react-ui/.creevey/images/PasswordInput/Width/chrome2022.png
+++ b/packages/react-ui/.creevey/images/PasswordInput/Width/chrome2022.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64c37a9ad4c92a1e1b4904f00b1fc87b05f2c67b455fe0d51cc4ac5a33cabb32
+size 1511

--- a/packages/react-ui/components/PasswordInput/PasswordInput.styles.ts
+++ b/packages/react-ui/components/PasswordInput/PasswordInput.styles.ts
@@ -7,6 +7,7 @@ export const styles = memoizeStyle({
       position: relative;
       display: inline-block;
       line-height: normal;
+      width: 100%;
 
       input::-ms-clear,
       input::-ms-reveal {

--- a/packages/react-ui/components/PasswordInput/__creevey__/PasswordInput.creevey.mts
+++ b/packages/react-ui/components/PasswordInput/__creevey__/PasswordInput.creevey.mts
@@ -35,4 +35,12 @@ kind('PasswordInput', () => {
       await context.matchImage(await context.takeScreenshot(), 'With visible password');
     });
   });
+
+  story('Width', ({ setStoryParameters }) => {
+    setStoryParameters({
+      skip: {
+        'no themes': { in: /^(?!\b(chrome2022)\b)/ },
+      },
+    });
+  });
 });

--- a/packages/react-ui/components/PasswordInput/__stories__/PasswordInput.stories.tsx
+++ b/packages/react-ui/components/PasswordInput/__stories__/PasswordInput.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Story } from '../../../typings/stories';
 import { PasswordInput } from '../PasswordInput';
 import { Nullable } from '../../../typings/utility-types';
+import { Gapped } from '../../Gapped';
 
 interface ComponentProps {
   capsLockEnabled?: boolean;
@@ -54,3 +55,14 @@ export default {
 export const Plain: Story = () => <Component />;
 export const CapsLockLabel = () => <Component capsLockEnabled />;
 CapsLockLabel.storyName = 'CapsLock label';
+
+export const Width = () => {
+  return (
+    <div style={{ width: '505px' }}>
+      <Gapped vertical gap={5} style={{ width: '250px' }}>
+        <PasswordInput width={'100%'} onValueChange={() => {}} />
+        <PasswordInput width={'200%'} onValueChange={() => {}} />
+      </Gapped>
+    </div>
+  );
+};


### PR DESCRIPTION
## Проблема

В PasswordInput неправильно устанавливается ширина в процентах. 
Пример -- width=200% в PasswordInput и Input. Input -- для сравнения, как должно быть.
![image](https://github.com/user-attachments/assets/d970f04e-09a4-46e8-84d9-2a9a5f669a44)

## Решение

Добавила в стилях width=100% на рутовый div.

## Ссылки

[IF-2181](https://yt.skbkontur.ru/issue/IF-2181)

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ✅ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
