### PR TITLE
docs(Input,Combobox,Autocomplete): update examples & props desc

### DIFF
--- a/packages/react-ui/components/Autocomplete/__docs__/Autocomplete.docs.stories.tsx
+++ b/packages/react-ui/components/Autocomplete/__docs__/Autocomplete.docs.stories.tsx
@@ -112,23 +112,27 @@ export const Example9: Story = () => {
 };
 Example9.storyName = 'Режима прозрачной рамки';
 
-/** При значении "auto" крестик отображается при наведении или при фокусировке на непустом поле. <br/>
- * При значении "always" крестик отображается всегда, если поле непустое. <br/>
- * При значении "never" крестик никогда не отображается.<br/><br/>
- * При одновременной передаче showClearIcon и rightIcon, крестик имеет больший приоритет. */
+/**
+ * - `always` — всегда показывать иконку очистки значения в заполненном поле
+ * - `auto` — показывать иконку в заполненном поле при hover/focus
+ * - `never` — не показывать (по умолчанию)
+ *
+ * При одновременной настройке `showClearIcon` и `rightIcon` показывается иконка очистки.
+ */
 export const Example10: Story = () => {
   const items = [
-    'Отображаю крестик всегда',
-    'Отображаю крестик по фокусу или наведению',
-    'Никогда не отображаю крестик',
-    'showClearIcon=auto одновременно с rightIcon',
+    'showClearIcon="auto"',
+    'showClearIcon="always"',
+    'showClearIcon="never"',
+    'showClearIcon="auto" + rightIcon',
   ];
+
   const [valueAlways, setValueAlways] = React.useState(items[0]);
   const [valueAuto, setValueAuto] = React.useState(items[1]);
   const [valueNever, setValueNever] = React.useState(items[2]);
   const [valueWithIcon, setValueWithIcon] = React.useState(items[3]);
   return (
-    <Gapped gap={10} vertical>
+    <Gapped vertical>
       <Autocomplete
         showClearIcon="always"
         source={items}
@@ -156,4 +160,4 @@ export const Example10: Story = () => {
     </Gapped>
   );
 };
-Example10.storyName = 'Крестик для очистки';
+Example10.storyName = 'Иконка очистки поля';

--- a/packages/react-ui/components/ComboBox/ComboBox.tsx
+++ b/packages/react-ui/components/ComboBox/ComboBox.tsx
@@ -13,11 +13,11 @@ export interface ComboBoxProps<T>
   extends Pick<AriaAttributes, 'aria-describedby' | 'aria-label'>,
     Pick<HTMLAttributes<HTMLElement>, 'id'>,
     CommonProps {
-  /** Устанавливает иконку крестика, при нажатии на который комбобокс очищается.<br/>
-   * При значении "auto" крестик отображается при наведении или при фокусировке на непустом поле.<br/>
-   * При значении "always" крестик отображается всегда, если поле непустое.<br/>
-   * При значении "never" крестик никогда не отображается.<br/>
-   * При одновременной передаче showClearIcon и rightIcon, крестик имеет больший приоритет.
+  /** Показывать иконку очистки значения в непустом поле:
+   * - `always` — всегда показывать иконку
+   * - `auto` — показывать иконку при hover/focus
+   * - `never` — не показывать иконку
+   * При одновременной настройке `showClearIcon` и `rightIcon` показывается иконка очистки.
    * @default never */
   showClearIcon?: ShowClearIcon;
 

--- a/packages/react-ui/components/ComboBox/__docs__/ComboBox.docs.stories.tsx
+++ b/packages/react-ui/components/ComboBox/__docs__/ComboBox.docs.stories.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { getCities } from '@skbkontur/react-ui/components/ComboBox/__mocks__/getCities';
 import { MenuFooter } from '@skbkontur/react-ui/components/MenuFooter';
 import { CheckAIcon } from '@skbkontur/icons/icons/CheckAIcon';
-import { ComboBox, Tooltip, Group, Button, Gapped, MenuSeparator, MenuItem } from '@skbkontur/react-ui';
-import { UiFilterFunnelIcon16Regular } from '@skbkontur/icons/icons/UiFilterFunnelIcon/UiFilterFunnelIcon16Regular';
+import { ComboBox, Tooltip, Group, Button, Gapped, MenuSeparator, MenuItem, ShowClearIcon } from '@skbkontur/react-ui';
 
 import { Meta, Story } from '../../../typings/stories';
 
@@ -494,7 +493,58 @@ export const Example7: Story = () => {
     </div>
   );
 };
-Example7.storyName = 'Сброс контрола';
+Example7.storyName = 'Сброс значения';
+
+/**
+ * - `always` — всегда показывать иконку очистки значения в заполненном поле
+ * - `auto` — показывать иконку в заполненном поле при hover/focus
+ * - `never` — не показывать (по умолчанию)
+ *
+ * При одновременной настройке `showClearIcon` и `rightIcon` показывается иконка очистки.
+ */
+export const Example8: Story = () => {
+  const items = [
+    { value: 'always', label: 'showClearIcon="always"' },
+    { value: 'auto', label: 'showClearIcon="auto"' },
+    { value: 'never', label: 'showClearIcon="never"' },
+    { value: 'icon', label: 'showClearIcon="auto" + rightIcon' },
+  ];
+  const [valueAlways, setValueAlways] = React.useState(items[0]);
+  const [valueAuto, setValueAuto] = React.useState(items[1]);
+  const [valueNever, setValueNever] = React.useState(items[2]);
+  const [valueWithIcon, setValueWithIcon] = React.useState(items[3]);
+
+  const getItems = (q: string) => Promise.resolve(items.filter((x) => x.label.toLowerCase().includes(q.toLowerCase())));
+
+  return (
+    <Gapped vertical>
+      <ComboBox
+        showClearIcon="always"
+        value={valueAlways}
+        onValueChange={setValueAlways}
+        getItems={getItems}
+        width="375px"
+      />
+      <ComboBox showClearIcon="auto" getItems={getItems} value={valueAuto} onValueChange={setValueAuto} width="375px" />
+      <ComboBox
+        showClearIcon="never"
+        value={valueNever}
+        onValueChange={setValueNever}
+        getItems={getItems}
+        width="375px"
+      />
+      <ComboBox
+        showClearIcon="auto"
+        rightIcon
+        value={valueWithIcon}
+        onValueChange={setValueWithIcon}
+        getItems={getItems}
+        width="375px"
+      />
+    </Gapped>
+  );
+};
+Example8.storyName = 'Иконка очистки поля';
 
 export const Example9: Story = () => {
   const getItems = (q) => {
@@ -538,67 +588,3 @@ export const Example9: Story = () => {
   );
 };
 Example9.storyName = 'Размер';
-
-/** При значении "auto" крестик отображается при наведении или при фокусировке на непустом поле.<br/>
- * При значении "always" крестик отображается всегда, если поле непустое.<br/>
- * При значении "never" крестик никогда не отображается.<br/><br/>
- * При одновременной передаче showClearIcon и rightIcon, крестик имеет больший приоритет.
- * */
-export const Example10: Story = () => {
-  const items = [
-    {
-      value: 1,
-      label: 'Отображаю крестик всегда',
-    },
-    {
-      value: 2,
-      label: 'Отображаю крестик по фокусу',
-    },
-    {
-      value: 3,
-      label: 'Никогда не отображаю крестик',
-    },
-    {
-      value: 4,
-      label: 'showClearIcon=auto одновременно с rightIcon',
-    },
-  ];
-  const [valueAlways, setValueAlways] = React.useState(items[0]);
-  const [valueAuto, setValueAuto] = React.useState(items[1]);
-  const [valueNever, setValueNever] = React.useState(items[2]);
-  const [valueWithIcon, setValueWithIcon] = React.useState(items[3]);
-  const getItems = (q: string) => {
-    return Promise.resolve(
-      items.filter((x) => x.label.toLowerCase().includes(q.toLowerCase()) || x.value.toString(10) === q),
-    );
-  };
-  return (
-    <Gapped gap={10} vertical>
-      <ComboBox
-        showClearIcon="always"
-        getItems={getItems}
-        value={valueAlways}
-        onValueChange={setValueAlways}
-        width="350px"
-      />
-      <ComboBox showClearIcon="auto" getItems={getItems} value={valueAuto} onValueChange={setValueAuto} width="350px" />
-      <ComboBox
-        showClearIcon="never"
-        getItems={getItems}
-        value={valueNever}
-        onValueChange={setValueNever}
-        width="350px"
-      />
-      <br />
-      <ComboBox
-        showClearIcon="auto"
-        getItems={getItems}
-        value={valueWithIcon}
-        onValueChange={setValueWithIcon}
-        width="350px"
-        rightIcon={<UiFilterFunnelIcon16Regular />}
-      />
-    </Gapped>
-  );
-};
-Example10.storyName = 'Крестик для очистки';

--- a/packages/react-ui/components/Input/Input.tsx
+++ b/packages/react-ui/components/Input/Input.tsx
@@ -28,7 +28,7 @@ import { PolyfillPlaceholder } from './InputLayout/PolyfillPlaceholder';
 export const inputTypes = ['password', 'text', 'number', 'tel', 'search', 'time', 'date', 'url', 'email'] as const;
 
 export type InputAlign = 'left' | 'center' | 'right';
-export type ShowClearIcon = 'always' | 'auto' | 'never';
+export type ShowClearIcon = 'auto' | 'always' | 'never';
 export type InputType = (typeof inputTypes)[number];
 export type InputIconType = React.ReactNode | (() => React.ReactNode);
 
@@ -78,11 +78,11 @@ export interface InputProps
     Override<
       React.InputHTMLAttributes<HTMLInputElement>,
       {
-        /** Устанавливает иконку крестика, при нажатии на который инпут очищается.<br/>
-         * При значении "auto" крестик отображается при наведении или при фокусировке на непустом поле.<br/>
-         * При значении "always" крестик отображается всегда, если поле непустое.<br/>
-         * При значении "never" крестик никогда не отображается.<br/>
-         * При одновременной передаче showClearIcon и rightIcon, крестик имеет больший приоритет.
+        /** Показывать иконку очистки значения в непустом поле:
+         * - `always` — всегда показывать иконку
+         * - `auto` — показывать иконку при hover/focus
+         * - `never` — не показывать иконку
+         * При одновременной настройке `showClearIcon` и `rightIcon` показывается иконка очистки.
          * @default never */
         showClearIcon?: ShowClearIcon;
 

--- a/packages/react-ui/components/Input/__docs__/Input.docs.stories.tsx
+++ b/packages/react-ui/components/Input/__docs__/Input.docs.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { SearchLoupeIcon } from '@skbkontur/icons/icons/SearchLoupeIcon';
-import { UiFilterFunnelIcon16Regular } from '@skbkontur/icons/icons/UiFilterFunnelIcon/UiFilterFunnelIcon16Regular';
 import { Input, Button, Group, Gapped } from '@skbkontur/react-ui';
 
 import { Meta, Story } from '../../../typings/stories';
@@ -86,15 +85,18 @@ export const Example5: Story = () => {
 };
 Example5.storyName = 'type';
 
-/** При значении "auto" крестик отображается при наведении или при фокусировке на непустом поле.<br/>
- * При значении "always" крестик отображается всегда, если поле непустое.<br/>
- * При значении "never" крестик никогда не отображается.<br/><br/>
- * При одновременной передаче showClearIcon и rightIcon, крестик имеет больший приоритет. */
+/**
+ * - `always` — всегда показывать иконку очистки значения в заполненном поле
+ * - `auto` — показывать иконку в заполненном поле при hover/focus
+ * - `never` — не показывать (по умолчанию)
+ *
+ * При одновременной настройке `showClearIcon` и `rightIcon` показывается иконка очистки.
+ */
 export const Example6: Story = () => {
-  const [valueAlways, setValueAlways] = React.useState('Отображаю крестик всегда');
-  const [valueAuto, setValueAuto] = React.useState('Отображаю крестик по ховеру или фокусу');
-  const [valueNever, setValueNever] = React.useState('Никогда не отображаю крестик');
-  const [valueWithIcon, setValueWithIcon] = React.useState('showClearIcon=auto одновременно с rightIcon');
+  const [valueAlways, setValueAlways] = React.useState('showClearIcon="always"');
+  const [valueAuto, setValueAuto] = React.useState('showClearIcon="auto"');
+  const [valueNever, setValueNever] = React.useState('showClearIcon="never"');
+  const [valueWithIcon, setValueWithIcon] = React.useState('showClearIcon="auto" + rightIcon');
   return (
     <Gapped gap={10} vertical>
       <Input showClearIcon="always" value={valueAlways} onValueChange={setValueAlways} width="350px" />
@@ -106,9 +108,9 @@ export const Example6: Story = () => {
         value={valueWithIcon}
         onValueChange={setValueWithIcon}
         width="350px"
-        rightIcon={<UiFilterFunnelIcon16Regular />}
+        rightIcon={<SearchLoupeIcon />}
       />
     </Gapped>
   );
 };
-Example6.storyName = 'Крестик для очистки';
+Example6.storyName = 'Иконка очистки поля';


### PR DESCRIPTION
| Было | Стало |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/49f46666-da50-48a7-a14e-7308c7d60654" width="300"> | <img src="https://github.com/user-attachments/assets/4f521bfc-0cbd-4a1e-b228-b734c2d15d32" width="300"> | 

Прибрался в описаниях в props и в примерах:
- Input
- Combobox
- Autocomplete

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
