### PR TITLE
 ci(react-ui-testing): use grid-4 url from env

### DIFF
--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -1,10 +1,12 @@
 using System;
+using System.IO;
 using System.Drawing;
 using Kontur.Selone.Extensions;
 using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Remote;
+using DotNetEnv;
 
 namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
 {
@@ -65,7 +67,11 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
             {
                 if (webDriver != null) return webDriver;
 
-                var wdHub = Environment.GetEnvironmentVariable("GRID_URL");
+                string fullPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../.env");
+                Env.Load(fullPath);
+
+                var wdHub = Env.GetString("GRID_URL");
+                Console.WriteLine($"Current Working Directory: {wdHub}");
                 ChromeOptions options = new ChromeOptions();
 
                 options.AddAdditionalOption(CapabilityType.Platform, "windows");

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -71,7 +71,6 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
                 Env.Load(fullPath);
 
                 var wdHub = Env.GetString("GRID_URL");
-                Console.WriteLine($"Current Working Directory: {wdHub}");
                 ChromeOptions options = new ChromeOptions();
 
                 options.AddAdditionalOption(CapabilityType.Platform, "windows");

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -65,7 +65,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
             {
                 if (webDriver != null) return webDriver;
 
-                var wdHub = "https://frontinfra:frontinfra@grid.testkontur.ru/wd/hub";
+                var wdHub = Environment.GetEnvironmentVariable("GRID_URL");
                 ChromeOptions options = new ChromeOptions();
 
                 options.AddAdditionalOption(CapabilityType.Platform, "windows");

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Kontur.ReactUI.SeleniumTesting.Tests</AssemblyName>
     <Authors>Kontur</Authors>
@@ -11,11 +11,11 @@
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
@@ -27,6 +27,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.29.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема

Осталось одно место использующее старый грид3

https://github.com/skbkontur/retail-ui/blob/40156951239bc7ae63033c09d03ad647c9e3df1f/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs#L68

## Решение

Добавил использование переменной окружения.

Для локальной работы подключается файл `.env`, но я не смог нормально проверить, т.к. локально проект у меня перестал тесты запускать. Почему-то не может достучаться до тестовых страниц, хотя они запущенны, и сам проект под админом открыт.
Думаю, пока можно оставить как есть.

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
