### PR TITLE
 ci(react-ui-testing): fix Selenium Grid 4 configuration issues

### DIFF
--- a/packages/react-ui-testing/TestPages/src/components/TestPages/InputTestPage.jsx
+++ b/packages/react-ui-testing/TestPages/src/components/TestPages/InputTestPage.jsx
@@ -42,7 +42,7 @@ export default class InputTextPage extends React.Component {
               data-tid="ShowInputAppearsAfterTimeout"
               onClick={() =>
                 !this.state.showInput
-                  ? setTimeout(() => this.setState({ showInput: true }), 2000)
+                  ? setTimeout(() => this.setState({ showInput: true }), 1500)
                   : this.setState({ showInput: false })
               }
             >

--- a/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
+++ b/packages/react-ui-testing/Tests/TestEnvironment/Browser.cs
@@ -77,6 +77,7 @@ namespace SKBKontur.SeleniumTesting.Tests.TestEnvironment
                 options.AddAdditionalOption("name", TestContext.CurrentContext.Test.Name);
                 options.AddAdditionalOption("tunnel-identifier", this.tunnelIdentifier);
                 options.AddAdditionalOption("maxDuration", 10800);
+                options.AddAdditionalOption("se:teamname", "front_infra");
 
                 webDriver = new RemoteWebDriver(new Uri(wdHub),
                     options.ToCapabilities(),

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Kontur.ReactUI.SeleniumTesting.Tests</AssemblyName>
     <Authors>Kontur</Authors>
@@ -27,7 +27,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.30.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.29.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/packages/react-ui-testing/Tests/Tests.csproj
+++ b/packages/react-ui-testing/Tests/Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.30.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.3.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблемы

1. В прошлый раз #3624 пропустил логин для подключения.
  Почему-то подумал, что мы подключаемся к общему Гриду и теперь не надо указывать команду.
2. В последней версии драйвера (4.30.0) нет некоторых исключений, которые используется в тестах, в самом реакт-тестинг и в тестах валидаций.
3. Иногда падает тест `TestCheckValueIntoControlThatAppearsAfterTimeout`.
  После двух кликов Инпут не успевает появиться раньше проверки его значения.


## Решения

1. Добавил нашу команду для подключения к Гриду
2. Вернул старую версию драйвера.
  Коды исключений надо либо заменить, либо отрефакторить логику. Подумал, что это может слишком затянуться и решил просто откатить драйвер.
3. Уменьшил таймаут появления Инпута с `2000мс` до `1500мс`.
  Проверка значение происходит тоже через `2000мс` после клика. И т.к таймер в тесте запускается раньше таймера на странице, то даже странно что этот тест вообще проходил.

---


## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

5. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

6. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

7. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
