### PR TITLE
feat(react-ui-testing): add methods for text input

### DIFF
--- a/packages/react-ui-testing/Tests/InputTests/InputTest.cs
+++ b/packages/react-ui-testing/Tests/InputTests/InputTest.cs
@@ -69,6 +69,19 @@ namespace SKBKontur.SeleniumTesting.Tests.InputTests
         }
 
         [Test]
+        public void TestClearAndInputTextWithDelays()
+        {
+            page.SimpleInput.ClearAndInputTextWithDelays("hello");
+            page.SimpleInput.Value.Wait().EqualTo("hello");
+        }
+
+        [Test]
+        public void TestClearAndEnsureInputText()
+        {
+            page.SimpleInput.ClearAndEnsureInputText("hello");
+        }
+
+        [Test]
         public void TestClearInput()
         {
             page.SimpleInput.ClearAndInputText("hello");


### PR DESCRIPTION
## Проблема

Метод для вставки текста в инпут (ClearAndInputText) - вставляет текст слишком быстро. Это приводит к нестабильному падению тестов - иногда фронт не успевает обрабатывать ввод или обрабатывает их в неправильном порядке. 

## Решение

Предоставить альтернативные методы, которые позволят избежать нестабильных падений:
1. `ClearAndInputTextWithDelays`. Метод с задержкой после каждого введенного символа (эмуляция скорости ввода, близкой к пользователю). 
2. `ClearAndEnsureInputText`. Метод с ожиданием успешного ввода после каждого введенного символа. 

Первый вариант более привычный для пользователей тестовых библиотек. Второй мне кажется более надежным. Когда я его применил к одному из нестабильных тестов в проекте, который падал 13/30 раз - он прошел 100 раз подряд.

## Чек-лист перед запросом ревью

1. Добавлены тесты на все изменения
  - [x] unit-тесты для логики

2. Добавлена (обновлена) документация
  - [x] комментарии для неочевидных мест в коде

3. Изменения корректно типизированы
  - [x] нерелевантно

4. Прочее
  - [x] все тесты и линтеры на CI проходят
  - [x] в коде нет лишних изменений
  - [x] заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
