### PR TITLE
fix(MenuItem): correctly pass state to functional children

### DIFF
--- a/packages/react-ui/components/MenuItem/MenuItem.tsx
+++ b/packages/react-ui/components/MenuItem/MenuItem.tsx
@@ -318,7 +318,7 @@ export class MenuItem extends React.Component<MenuItemProps> {
 
     let content = children;
     if (isFunction(children)) {
-      content = children(state);
+      content = children(this.activeState);
     }
 
     const Component = this.getComponent();

--- a/packages/react-ui/components/MenuItem/__tests__/MenuItem-test.tsx
+++ b/packages/react-ui/components/MenuItem/__tests__/MenuItem-test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
-import { MenuItem, MenuItemDataTids } from '../MenuItem';
+import { Menu } from '../../../internal/Menu';
+import { MenuItem, MenuItemDataTids, MenuItemState } from '../MenuItem';
 
 describe('MenuItem', () => {
   it('renders multiple children', () => {
@@ -89,6 +90,17 @@ describe('MenuItem', () => {
     render(<MenuItem data-tid={customDataTid} />);
 
     expect(screen.getByTestId(customDataTid)).toBeInTheDocument();
+  });
+
+  it('should pass state to functional children when highlighted by Menu', () => {
+    const renderChild = jest.fn((state: MenuItemState) => <div>{`${state}`}</div>);
+    render(
+      <Menu initialSelectedItemIndex={0}>
+        <MenuItem>{renderChild}</MenuItem>
+      </Menu>,
+    );
+
+    expect(renderChild).toHaveBeenCalledWith('hover');
   });
 
   describe('a11y', () => {

--- a/packages/react-ui/internal/Menu/Menu.tsx
+++ b/packages/react-ui/internal/Menu/Menu.tsx
@@ -57,7 +57,7 @@ export interface MenuProps extends CommonProps, Pick<HTMLAttributes<HTMLDivEleme
 }
 
 export interface MenuState {
-  highlightedIndex: number;
+  highlightedIndex: number; // TODO unused variable, remove in next major release
   maxHeight: number | string;
   scrollState: ScrollContainerScrollState;
   enableIconPadding: boolean;


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
В версии 5.х в `Menu` по умолчанию работает подсветка пунктов меню, реализованная через контекст, и компонент явно не передаёт состояние подсветки в свои дочерние компоненты. А в `MenuItem` осталась старая логика получения состояния подсветки через проп `state`.
<!-- Подробно опиши решаемую проблему. -->

## Решение
Передавать в контент функцию состояние `hover` через `this.activeState`, т.к. в старой системе  `Menu` передавало только его. Состояние же `selected` обычно передаётся явно компонентами более высокого уровня, использующими `Menu`, например `Select`.
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки

<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->
fix [IF-2222](https://yt.skbkontur.ru/issue/IF-2222)
## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ✅ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ⬜ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
