### PR TITLE
fix(MiniModal): prop 'gap' works in old browsers

### DIFF
--- a/packages/react-ui/components/MiniModal/MiniModal.styles.ts
+++ b/packages/react-ui/components/MiniModal/MiniModal.styles.ts
@@ -27,12 +27,11 @@ export const styles = memoizeStyle({
     `;
   },
 
-  actions(t: Theme) {
+  actions() {
     return css`
       display: flex;
       justify-content: stretch;
       text-align: center;
-      gap: ${t.miniModalActionGap};
 
       .${buttonGlobalClasses.root} {
         width: 100%;
@@ -52,20 +51,9 @@ export const styles = memoizeStyle({
     `;
   },
 
-  actionsRow() {
+  actionsRow(t: Theme) {
     return css`
       flex-direction: row;
-    `;
-  },
-
-  actionsColumn() {
-    return css`
-      flex-direction: column;
-    `;
-  },
-
-  actionsRowIE11Fallback(t: Theme) {
-    return css`
       > *:nth-of-type(1) {
         margin-right: calc(${t.miniModalActionGap} / 2);
       }
@@ -75,8 +63,9 @@ export const styles = memoizeStyle({
     `;
   },
 
-  actionsColumnIE11Fallback(t: Theme) {
+  actionsColumn(t: Theme) {
     return css`
+      flex-direction: column;
       > *:nth-of-type(2) {
         margin-top: ${t.miniModalActionGap};
       }

--- a/packages/react-ui/components/MiniModal/MiniModal.styles.ts
+++ b/packages/react-ui/components/MiniModal/MiniModal.styles.ts
@@ -41,12 +41,6 @@ export const styles = memoizeStyle({
 
   actionsIndent(t: Theme) {
     return css`
-      height: ${t.miniModalCancelIndent};
-    `;
-  },
-
-  actionsIndentIE11Fallback(t: Theme) {
-    return css`
       padding: ${t.miniModalCancelIndent} 0;
     `;
   },

--- a/packages/react-ui/components/MiniModal/MiniModalFooter.tsx
+++ b/packages/react-ui/components/MiniModal/MiniModalFooter.tsx
@@ -3,7 +3,6 @@ import React, { useContext } from 'react';
 import { Modal, ModalFooterProps } from '../Modal';
 import { forwardRefAndName } from '../../lib/forwardRefAndName';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
-import { isIE11 } from '../../lib/client';
 import { cx } from '../../lib/theming/Emotion';
 
 import { styles } from './MiniModal.styles';
@@ -33,24 +32,15 @@ export const MiniModalFooter = forwardRefAndName<HTMLDivElement, MiniModalFooter
     const childrenCount = React.Children.count(children);
     const _direction = childrenCount > 2 || childrenCount === 1 ? 'column' : direction;
 
-    // IE11 does not support CSS property `gap`
-    const IE11FallbackClasses =
-      isIE11 &&
-      cx(
-        _direction === 'row' && styles.actionsRowIE11Fallback(theme),
-        _direction === 'column' && styles.actionsColumnIE11Fallback(theme),
-      );
-
     return (
       <Modal.Footer {...rest}>
         <div
           ref={ref}
           data-tid={MiniModalDataTids.actions}
           className={cx(
-            styles.actions(theme),
-            _direction === 'row' && styles.actionsRow(),
-            _direction === 'column' && styles.actionsColumn(),
-            IE11FallbackClasses,
+            styles.actions(),
+            _direction === 'row' && styles.actionsRow(theme),
+            _direction === 'column' && styles.actionsColumn(theme),
           )}
         >
           {children}

--- a/packages/react-ui/components/MiniModal/MiniModalIndent.tsx
+++ b/packages/react-ui/components/MiniModal/MiniModalIndent.tsx
@@ -2,8 +2,6 @@ import React, { useContext } from 'react';
 
 import { forwardRefAndName } from '../../lib/forwardRefAndName';
 import { ThemeContext } from '../../lib/theming/ThemeContext';
-import { cx } from '../../lib/theming/Emotion';
-import { isIE11 } from '../../lib/client';
 
 import { styles } from './MiniModal.styles';
 import { MiniModalDataTids } from './MiniModal';
@@ -18,13 +16,6 @@ export const MiniModalIndent = forwardRefAndName<HTMLDivElement, React.InputHTML
   ({ children, ...rest }, ref) => {
     const theme = useContext(ThemeContext);
 
-    return (
-      <div
-        data-tid={MiniModalDataTids.indent}
-        ref={ref}
-        className={cx(!isIE11 ? styles.actionsIndent(theme) : styles.actionsIndentIE11Fallback(theme))}
-        {...rest}
-      />
-    );
+    return <div data-tid={MiniModalDataTids.indent} ref={ref} className={styles.actionsIndent(theme)} {...rest} />;
   },
 );


### PR DESCRIPTION
<!--

Привет! Спасибо за твой вклад в проект!

Пожалуйста, опиши свой PR по шаблону ниже. Это важно, потому что подробное описание ускоряет ревью и служит хорошей документацией к изменениям.

Подробную информацию для контрибьютеров можно найти в специальном [гайде](https://github.com/skbkontur/retail-ui/blob/master/contributing.md).

-->

## Проблема
не работает flex gap в старых браузерах
<!-- Подробно опиши решаемую проблему. -->

## Решение
убрать использование gap до лучших времен, оставить только margin
<!-- В деталях опиши предлагаемые изменения, мотивацию принятых решений и все неочевидные моменты. -->

## Ссылки
https://yt.skbkontur.ru/issue/IF-2192/MiniModal-ne-rabotaet-flex-gap-v-staryh-brauzerah
<!-- Укажи ссылки на связанные issue/тикеты/обсуждения. Используй ключевые слова fix, close или resolve перед номером issue для его автоматического закрытия после принятия PR. -->

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ✅ без использования `any` (см. PR `2856`)
  ⬜ нерелевантно

4. Прочее
  ✅ все тесты и линтеры на CI проходят
  ✅ в коде нет лишних изменений
  ✅ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
