### PR TITLE
ci: add react 16, 17, 18, strcit true for diff version test config

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -97,23 +97,29 @@ project {
 object DiffVersionBuild: Project({
     name = "Diff version test"
 
-    val reactV = "18"
-    val tsV = "4"
-    val strictMode = "false"
+    val reactVersions = listOf("16", "17", "18")
+    val typescriptVersions = listOf("4")
+    val strictModeVariants = listOf("true")
 
-    buildType({
-      name = "Run All React$reactV TS$tsV strictMode$strictMode"
-      id("react$reactV" + "TS$tsV" + "strictMode$strictMode")
-      params {
-          param("env.REACT_VERSION", reactV)
-          param("env.TYPESCRIPT_VERSION", tsV)
-          param("env.STRICT_MODE", strictMode)
-      }
-      dependencies {
-          snapshot(RunAll) {
-          }
-      }
-    })
+    for (strictMode in strictModeVariants) {
+      for (tsV in typescriptVersions) {
+        for (reactV in reactVersions) {
+          buildType({
+            name = "Run All React$reactV TS$tsV strictMode$strictMode"
+            id("react$reactV" + "TS$tsV" + "strictMode$strictMode")
+            params {
+              param("env.REACT_VERSION", reactV)
+              param("env.TYPESCRIPT_VERSION", tsV)
+              param("env.STRICT_MODE", strictMode)
+            }
+            dependencies {
+              snapshot(RunAll) {
+              }
+            }
+          })
+        }
+     }
+  }
 })
 
 object RunAll : BuildType({


### PR DESCRIPTION
Добавление конфиги прогонов на 16, 17, 18 react и strictMode=true в teamcity kotlin dsl

## Ссылки

[IF-2228](https://yt.skbkontur.ru/issue/IF-2228) Подготовка CI к тестированию на различных версиях пакетов

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
