### PR TITLE
ci: add subproject to set env params in version testing config

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -104,18 +104,24 @@ object DiffVersionBuild: Project({
     for (strictMode in strictModeVariants) {
       for (tsV in typescriptVersions) {
         for (reactV in reactVersions) {
-          buildType({
+          subProject({
             name = "Run All React$reactV TS$tsV strictMode$strictMode"
             id("react$reactV" + "TS$tsV" + "strictMode$strictMode")
+
             params {
-              param("env.REACT_VERSION", reactV)
-              param("env.TYPESCRIPT_VERSION", tsV)
-              param("env.STRICT_MODE", strictMode)
-            }
-            dependencies {
-              snapshot(RunAll) {
-              }
-            }
+               param("env.REACT_VERSION", reactV)
+               param("env.TYPESCRIPT_VERSION", tsV)
+               param("env.STRICT_MODE", strictMode)
+             }
+
+             buildType({
+               name = "Run All"
+               id("runall" + "_react$reactV" + "_TS$tsV" + "_strictMode$strictMode")
+               dependencies {
+                 snapshot(RunAll) {
+                 }
+               }
+             })
           })
         }
      }


### PR DESCRIPTION
Добавление subproject с env параметрами react/ts/stricMode для прогонов на разных версиях

## Ссылки

[IF-2228](https://yt.skbkontur.ru/issue/IF-2228) Подготовка CI к тестированию на различных версиях пакетов

## Чек-лист перед запросом ревью

<!-- Перед запросом ревью, пожалуйста, убедись, что все релевантные пункты из чек-листа ниже выполнены. Отметь их символами ✅ / ⬜. Если с каким-то из них возникли сложности — укажи это. -->

1. Добавлены тесты на все изменения
  ⬜ unit-тесты для логики
  ⬜ скриншоты для верстки и кросс-браузерности
  ✅ нерелевантно

2. Добавлена (обновлена) документация
  ⬜ styleguidist для пропов и примеров использования компонентов
  ⬜ jsdoc для утилит и хелперов
  ⬜ комментарии для неочевидных мест в коде
  ⬜ прочие инструкции (`README.md`, `contributing.md` и др.)
  ✅ нерелевантно

3. Изменения корректно типизированы
  ⬜ без использования `any` (см. PR `2856`)
  ✅ нерелевантно

4. Прочее
  ⬜ все тесты и линтеры на CI проходят
  ⬜ в коде нет лишних изменений
  ⬜ заголовок PR кратко и доступно отражает суть изменений (он попадет в changelog)
